### PR TITLE
docs: add Clerk auth instructions to claude guide

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -18,6 +18,11 @@
 - All JSON data must validate with Zod schemas
 - Use small, incremental changes: Plan → Propose → Build → Verify
 
+## 🔐 Authentication & API Integration
+- Authentication is powered by Clerk; rely on Clerk React hooks and components (`useUser()`, `useAuth()`, `<SignedIn>`, `<SignedOut>`, `<UserButton>`)
+- Never roll your own auth helpers—extend behavior by composing Clerk primitives and reference Clerk documentation for additional components
+- When calling backend endpoints, always go through the shared `apiRequest()` helper in `queryClient.ts`; it attaches Clerk JWT tokens automatically and prevents duplicate auth logic
+
 ## ✅ Validation Commands
 - `npm run check` - Run TypeScript compilation check
 - `npm run dev` - Starts both client and server with hot reload


### PR DESCRIPTION
## Summary
- document Clerk-based authentication practices in `claude.md`
- note required Clerk hooks/components for UI authentication flows
- remind developers to call the shared `apiRequest()` helper for backend access

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbb6c01638832eb0032fc9dc6c23c3