### PR TITLE
Refactor chart displays to use reusable data table

### DIFF
--- a/client/src/components/Top100ChartDisplay.tsx
+++ b/client/src/components/Top100ChartDisplay.tsx
@@ -2,37 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { RefreshCw, Trophy, TrendingUp, Clock, BarChart3 } from 'lucide-react';
+import { RefreshCw, Trophy, BarChart3 } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
-import {
-  formatChartPosition,
-  formatChartMovement,
-  getChartPositionColor,
-  getMovementColor,
-  getChartPositionBadgeVariant,
-  formatWeeksOnChart,
-  getChartPositionOrdinal,
-  isPlayerSongHighlight,
-  getChartExitRisk,
-  getChartExitRiskColor,
-  getChartExitRiskBgColor
-} from '../../../shared/utils/chartUtils';
+import { ChartDataTable } from '@/components/chart/ChartDataTable';
+import { ChartEntry, chartColumns } from '@/components/chart/chartColumns';
+import { isPlayerSongHighlight } from '../../../shared/utils/chartUtils';
 import { apiRequest } from '@/lib/queryClient';
 
-interface Top100Entry {
-  position: number;
-  songId: string | null;
-  songTitle: string;
-  artistName: string;
-  movement: number;
-  weeksOnChart: number;
-  peakPosition: number | null;
-  isPlayerSong: boolean;
-  isCompetitorSong: boolean;
-  competitorTitle?: string;
-  competitorArtist?: string;
-  isDebut: boolean;
-}
+type Top100Entry = ChartEntry;
 
 interface Top100ChartData {
   chartWeek: string;
@@ -174,218 +151,134 @@ export function Top100ChartDisplay() {
 
   return (
     <Card className="shadow-sm max-w-6xl mx-auto">
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2">
-              <Trophy className="w-5 h-5 text-yellow-600" />
-              <CardTitle>Top 100 Chart</CardTitle>
-              <Badge variant="outline" className="text-xs">
-                Month {chartData.currentMonth}
-              </Badge>
-            </div>
-
-            <div className="flex items-center space-x-4">
-              {playerSongs.length > 0 && (
-                <div className="flex items-center space-x-2">
-                  <div className="w-2 h-2 bg-[#A75A5B] rounded-full"></div>
-                  <span className="text-xs text-white/70">
-                    {playerSongs.length} Your Song{playerSongs.length !== 1 ? 's' : ''}
-                  </span>
-                </div>
-              )}
-
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleRefresh}
-                disabled={refreshing}
-                className="text-white/70 hover:text-white"
-              >
-                <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
-              </Button>
-            </div>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <Trophy className="w-5 h-5 text-yellow-600" />
+            <CardTitle>Top 100 Chart</CardTitle>
+            <Badge variant="outline" className="text-xs">
+              Month {chartData.currentMonth}
+            </Badge>
           </div>
 
-          {debuts.length > 0 && (
-            <div className="mt-2">
-              <Badge variant="secondary" className="text-xs bg-green-100 text-green-700">
-                {debuts.length} New Debut{debuts.length !== 1 ? 's' : ''}
-              </Badge>
-            </div>
-          )}
-
-          {/* Chart Controls */}
-          <div className="mt-4 flex items-center justify-between">
-            <div className="text-sm text-white/70">
-              Showing {displayEntries.length} of {chartData.top100.length} songs
-            </div>
-            {chartData.top100.length > 25 && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShowAll(!showAll)}
-                className="text-white/70 hover:text-white"
-              >
-                {showAll ? 'Show Top 25' : `Show All ${chartData.top100.length}`}
-              </Button>
+          <div className="flex items-center space-x-4">
+            {playerSongs.length > 0 && (
+              <div className="flex items-center space-x-2">
+                <div className="w-2 h-2 bg-[#A75A5B] rounded-full"></div>
+                <span className="text-xs text-white/70">
+                  {playerSongs.length} Your Song{playerSongs.length !== 1 ? 's' : ''}
+                </span>
+              </div>
             )}
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={refreshing}
+              className="text-white/70 hover:text-white"
+            >
+              <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+            </Button>
           </div>
-        </CardHeader>
+        </div>
 
-        <CardContent className="space-y-3">
-          {displayEntries.map((entry, index) => {
-            const isHighlighted = isPlayerSongHighlight(entry.isPlayerSong, entry.position);
-            const exitRisk = getChartExitRisk(entry.movement, entry.weeksOnChart);
+        {debuts.length > 0 && (
+          <div className="mt-2">
+            <Badge variant="secondary" className="text-xs bg-green-100 text-green-700">
+              {debuts.length} New Debut{debuts.length !== 1 ? 's' : ''}
+            </Badge>
+          </div>
+        )}
 
-            return (
-              <div
-                key={entry.songId}
-                className={`flex items-center justify-between p-3 rounded-lg border transition-colors ${
-                  isHighlighted
-                    ? 'bg-[#A75A5B]/10 border-[#A75A5B]/20 ring-1 ring-[#A75A5B]/30'
-                    : 'bg-[#3c252d]/20 border-[#4e324c]/50 hover:bg-[#3c252d]/30'
-                }`}
-              >
-                {/* Left side - Position and Song info */}
-                <div className="flex items-center space-x-4 flex-1">
-                  {/* Chart Position */}
-                  <div className="flex-shrink-0">
-                    {entry.position === 1 ? (
-                      <div className="w-8 h-8 bg-gradient-to-br from-yellow-400 to-yellow-600 rounded-full flex items-center justify-center shadow-lg">
-                        <span className="text-sm font-bold text-yellow-900">1</span>
-                      </div>
-                    ) : entry.position <= 10 ? (
-                      <div className="w-8 h-8 bg-gradient-to-br from-gray-300 to-gray-400 rounded-full flex items-center justify-center shadow-md">
-                        <span className="text-sm font-bold text-gray-900">{entry.position}</span>
-                      </div>
-                    ) : (
-                      <div className={`w-8 h-8 rounded-full flex items-center justify-center font-semibold text-sm ${getChartPositionColor(entry.position)}`}>
-                        {entry.position}
-                      </div>
-                    )}
-                  </div>
+        <div className="mt-4 flex items-center justify-between">
+          <div className="text-sm text-white/70">
+            Showing {displayEntries.length} of {chartData.top100.length} songs
+          </div>
+          {chartData.top100.length > 25 && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowAll(!showAll)}
+              className="text-white/70 hover:text-white"
+            >
+              {showAll ? 'Show Top 25' : `Show All ${chartData.top100.length}`}
+            </Button>
+          )}
+        </div>
+      </CardHeader>
 
-                  {/* Song Details */}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center space-x-2">
-                      <h4 className={`font-medium text-sm truncate ${isHighlighted ? 'text-white' : 'text-white/90'}`}>
-                        {entry.songTitle}
-                      </h4>
-                      {entry.isDebut && (
-                        <Badge variant="secondary" className="text-xs bg-green-100 text-green-700 px-1">
-                          NEW
-                        </Badge>
-                      )}
-                      {isHighlighted && (
-                        <Badge variant="secondary" className="text-xs bg-[#A75A5B] text-white px-1">
-                          YOURS
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="flex items-center space-x-3 text-xs text-white/50 mt-1">
-                      <span>{entry.artistName}</span>
-                      {entry.weeksOnChart > 0 && (
-                        <span>• {formatWeeksOnChart(entry.weeksOnChart)}</span>
-                      )}
-                      {entry.peakPosition && entry.peakPosition !== entry.position && (
-                        <span>• Peak {formatChartPosition(entry.peakPosition)}</span>
-                      )}
-                    </div>
-                  </div>
+      <CardContent className="space-y-6">
+        <ChartDataTable<Top100Entry>
+          columns={chartColumns}
+          data={displayEntries}
+          rowHighlight={entry => isPlayerSongHighlight(entry.isPlayerSong, entry.position)}
+          initialSort={{ columnId: 'position', direction: 'asc' }}
+          getRowKey={entry => entry.songId ?? `${entry.position}-${entry.songTitle}`}
+        />
+
+        {chartData.top100.length > 0 && (
+          <div className="pt-4 border-t border-[#4e324c]">
+            <div className="grid grid-cols-4 gap-4 text-center text-xs">
+              <div>
+                <div className="font-semibold text-white/90">{playerSongs.length}</div>
+                <div className="text-white/50">Your Songs</div>
+              </div>
+              <div>
+                <div className="font-semibold text-white/90">{debuts.length}</div>
+                <div className="text-white/50">New This Week</div>
+              </div>
+              <div>
+                <div className="font-semibold text-white/90">
+                  {chartData.top100.filter(e => e.movement > 0).length}
                 </div>
+                <div className="text-white/50">Climbing</div>
+              </div>
+              <div>
+                <div className="font-semibold text-white/90">
+                  {chartData.top100.filter(e => e.position <= 10).length}
+                </div>
+                <div className="text-white/50">Top 10</div>
+              </div>
+            </div>
+          </div>
+        )}
 
-                {/* Right side - Movement and stats */}
-                <div className="flex items-center space-x-3 flex-shrink-0">
-                  {/* Movement indicator - always shown */}
-                  <div className="flex items-center space-x-1">
-                    <span className={`text-xs font-medium ${getMovementColor(entry.movement)}`}>
-                      {formatChartMovement(entry.movement)}
-                    </span>
+        {chartData.top100.length >= 10 && (
+          <div className="p-4 bg-[#3c252d]/30 rounded-lg border border-[#A75A5B]/20">
+            <h4 className="text-sm font-semibold text-white mb-3 flex items-center space-x-2">
+              <Trophy className="w-4 h-4 text-yellow-600" />
+              <span>Top 10 Highlights</span>
+            </h4>
+            <div className="grid grid-cols-2 gap-2">
+              {chartData.top100.slice(0, 10).map(entry => (
+                <div
+                  key={entry.songId}
+                  className={`flex items-center justify-between p-2 rounded text-xs ${
+                    entry.isPlayerSong
+                      ? 'bg-[#A75A5B]/20 border border-[#A75A5B]/30'
+                      : 'bg-black/20'
+                  }`}
+                >
+                  <div className="flex items-center space-x-2">
+                    <span className="font-mono font-bold w-6">#{entry.position}</span>
+                    <div className="truncate">
+                      <div className="font-medium truncate">{entry.songTitle}</div>
+                      <div className="text-white/50 truncate">{entry.artistName}</div>
+                    </div>
                   </div>
-
-                  {/* Chart exit risk indicator */}
-                  {exitRisk !== 'low' && (
-                    <div
-                      className={`w-2 h-2 rounded-full ${getChartExitRiskBgColor(exitRisk)}`}
-                      title={`${exitRisk === 'high' ? 'High' : 'Medium'} chart exit risk`}
-                    />
+                  {entry.isPlayerSong && (
+                    <Badge variant="secondary" className="text-xs bg-[#A75A5B] text-white px-1 ml-2">
+                      YOURS
+                    </Badge>
                   )}
-
-                  {/* Ordinal position */}
-                  <div className="text-right">
-                    <div className="text-xs text-white/50 font-mono">
-                      {getChartPositionOrdinal(entry.position)}
-                    </div>
-                  </div>
                 </div>
-              </div>
-            );
-          })}
-
-          {/* Chart summary */}
-          {chartData.top100.length > 0 && (
-            <div className="mt-6 pt-4 border-t border-[#4e324c]">
-              <div className="grid grid-cols-4 gap-4 text-center text-xs">
-                <div>
-                  <div className="font-semibold text-white/90">{playerSongs.length}</div>
-                  <div className="text-white/50">Your Songs</div>
-                </div>
-                <div>
-                  <div className="font-semibold text-white/90">{debuts.length}</div>
-                  <div className="text-white/50">New This Week</div>
-                </div>
-                <div>
-                  <div className="font-semibold text-white/90">
-                    {chartData.top100.filter(e => e.movement > 0).length}
-                  </div>
-                  <div className="text-white/50">Climbing</div>
-                </div>
-                <div>
-                  <div className="font-semibold text-white/90">
-                    {chartData.top100.filter(e => e.position <= 10).length}
-                  </div>
-                  <div className="text-white/50">Top 10</div>
-                </div>
-              </div>
+              ))}
             </div>
-          )}
-
-          {/* Quick Top 10 Summary */}
-          {chartData.top100.length >= 10 && (
-            <div className="mt-6 p-4 bg-[#3c252d]/30 rounded-lg border border-[#A75A5B]/20">
-              <h4 className="text-sm font-semibold text-white mb-3 flex items-center space-x-2">
-                <Trophy className="w-4 h-4 text-yellow-600" />
-                <span>Top 10 Highlights</span>
-              </h4>
-              <div className="grid grid-cols-2 gap-2">
-                {chartData.top100.slice(0, 10).map((entry, index) => (
-                  <div
-                    key={entry.songId}
-                    className={`flex items-center justify-between p-2 rounded text-xs ${
-                      entry.isPlayerSong
-                        ? 'bg-[#A75A5B]/20 border border-[#A75A5B]/30'
-                        : 'bg-black/20'
-                    }`}
-                  >
-                    <div className="flex items-center space-x-2">
-                      <span className="font-mono font-bold w-6">#{entry.position}</span>
-                      <div className="truncate">
-                        <div className="font-medium truncate">{entry.songTitle}</div>
-                        <div className="text-white/50 truncate">{entry.artistName}</div>
-                      </div>
-                    </div>
-                    {entry.isPlayerSong && (
-                      <Badge variant="secondary" className="text-xs bg-[#A75A5B] text-white px-1 ml-2">
-                        YOURS
-                      </Badge>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/client/src/components/Top10ChartDisplay.tsx
+++ b/client/src/components/Top10ChartDisplay.tsx
@@ -2,37 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { RefreshCw, Trophy, TrendingUp, Clock, BarChart3 } from 'lucide-react';
+import { RefreshCw, Trophy, BarChart3 } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
 import { apiRequest } from '@/lib/queryClient';
-import {
-  formatChartPosition,
-  formatChartMovement,
-  getChartPositionColor,
-  getMovementColor,
-  getChartPositionBadgeVariant,
-  formatWeeksOnChart,
-  getChartPositionOrdinal,
-  isPlayerSongHighlight,
-  getChartExitRisk,
-  getChartExitRiskColor,
-  getChartExitRiskBgColor
-} from '../../../shared/utils/chartUtils';
+import { ChartDataTable } from '@/components/chart/ChartDataTable';
+import { ChartEntry, chartColumns } from '@/components/chart/chartColumns';
+import { isPlayerSongHighlight } from '../../../shared/utils/chartUtils';
 
-interface Top10Entry {
-  position: number;
-  songId: string | null;
-  songTitle: string;
-  artistName: string;
-  movement: number;
-  weeksOnChart: number;
-  peakPosition: number | null;
-  isPlayerSong: boolean;
-  isCompetitorSong: boolean;
-  competitorTitle?: string;
-  competitorArtist?: string;
-  isDebut: boolean;
-}
+type Top10Entry = ChartEntry;
 
 interface Top10ChartData {
   chartWeek: string;
@@ -213,95 +190,17 @@ export function Top10ChartDisplay() {
         )}
       </CardHeader>
 
-      <CardContent className="space-y-3">
-        {chartData.top10.map((entry, index) => {
-          const isHighlighted = isPlayerSongHighlight(entry.isPlayerSong, entry.position);
-          const exitRisk = getChartExitRisk(entry.movement, entry.weeksOnChart);
+      <CardContent className="space-y-6">
+        <ChartDataTable<Top10Entry>
+          columns={chartColumns}
+          data={chartData.top10}
+          rowHighlight={entry => isPlayerSongHighlight(entry.isPlayerSong, entry.position)}
+          initialSort={{ columnId: 'position', direction: 'asc' }}
+          getRowKey={entry => entry.songId ?? `${entry.position}-${entry.songTitle}`}
+        />
 
-          return (
-            <div
-              key={entry.songId}
-              className={`flex items-center justify-between p-3 rounded-lg border transition-colors ${
-                isHighlighted
-                  ? 'bg-[#A75A5B]/10 border-[#A75A5B]/20 ring-1 ring-[#A75A5B]/30'
-                  : 'bg-[#3c252d]/20 border-[#4e324c]/50 hover:bg-[#3c252d]/30'
-              }`}
-            >
-              {/* Left side - Position and Song info */}
-              <div className="flex items-center space-x-4 flex-1">
-                {/* Chart Position */}
-                <div className="flex-shrink-0">
-                  {entry.position === 1 ? (
-                    <div className="w-8 h-8 bg-gradient-to-br from-yellow-400 to-yellow-600 rounded-full flex items-center justify-center shadow-lg">
-                      <span className="text-sm font-bold text-yellow-900">1</span>
-                    </div>
-                  ) : (
-                    <div className={`w-8 h-8 rounded-full flex items-center justify-center font-semibold text-sm ${getChartPositionColor(entry.position)}`}>
-                      {entry.position}
-                    </div>
-                  )}
-                </div>
-
-                {/* Song Details */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center space-x-2">
-                    <h4 className={`font-medium text-sm truncate ${isHighlighted ? 'text-white' : 'text-white/90'}`}>
-                      {entry.songTitle}
-                    </h4>
-                    {entry.isDebut && (
-                      <Badge variant="secondary" className="text-xs bg-green-100 text-green-700 px-1">
-                        NEW
-                      </Badge>
-                    )}
-                    {isHighlighted && (
-                      <Badge variant="secondary" className="text-xs bg-[#A75A5B] text-white px-1">
-                        YOURS
-                      </Badge>
-                    )}
-                  </div>
-                  <div className="flex items-center space-x-3 text-xs text-white/50 mt-1">
-                    <span>{entry.artistName}</span>
-                    {entry.weeksOnChart > 0 && (
-                      <span>• {formatWeeksOnChart(entry.weeksOnChart)}</span>
-                    )}
-                    {entry.peakPosition && entry.peakPosition !== entry.position && (
-                      <span>• Peak {formatChartPosition(entry.peakPosition)}</span>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* Right side - Movement and stats */}
-              <div className="flex items-center space-x-3 flex-shrink-0">
-                {/* Movement indicator - always shown */}
-                <div className="flex items-center space-x-1">
-                  <span className={`text-xs font-medium ${getMovementColor(entry.movement)}`}>
-                    {formatChartMovement(entry.movement)}
-                  </span>
-                </div>
-
-                {/* Chart exit risk indicator */}
-                {exitRisk !== 'low' && (
-                  <div
-                    className={`w-2 h-2 rounded-full ${getChartExitRiskBgColor(exitRisk)}`}
-                    title={`${exitRisk === 'high' ? 'High' : 'Medium'} chart exit risk`}
-                  />
-                )}
-
-                {/* Ordinal position */}
-                <div className="text-right">
-                  <div className="text-xs text-white/50 font-mono">
-                    {getChartPositionOrdinal(entry.position)}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-
-        {/* Chart summary */}
         {chartData.top10.length > 0 && (
-          <div className="mt-4 pt-3 border-t border-[#4e324c]">
+          <div className="pt-3 border-t border-[#4e324c]">
             <div className="grid grid-cols-3 gap-4 text-center text-xs">
               <div>
                 <div className="font-semibold text-white/90">{playerSongs.length}</div>

--- a/client/src/components/chart/ChartDataTable.tsx
+++ b/client/src/components/chart/ChartDataTable.tsx
@@ -1,0 +1,151 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface ChartColumn<TEntry> {
+  id: string;
+  header: (props: { direction: SortDirection | null; toggleSort: () => void }) => React.ReactNode;
+  cell: (entry: TEntry) => React.ReactNode;
+  sortable?: boolean;
+  sortAccessor?: (entry: TEntry) => string | number | null | undefined;
+  headerClassName?: string;
+  cellClassName?: string;
+}
+
+interface SortState {
+  columnId: string;
+  direction: SortDirection;
+}
+
+interface ChartDataTableProps<TData> {
+  columns: ChartColumn<TData>[];
+  data: TData[];
+  rowHighlight?: (row: TData) => boolean;
+  emptyMessage?: string;
+  className?: string;
+  initialSort?: SortState;
+  getRowKey?: (row: TData, index: number) => React.Key;
+}
+
+export function ChartDataTable<TData>({
+  columns,
+  data,
+  rowHighlight,
+  emptyMessage = 'No chart entries available.',
+  className,
+  initialSort,
+  getRowKey
+}: ChartDataTableProps<TData>) {
+  const [sortState, setSortState] = React.useState<SortState | null>(initialSort ?? null);
+
+  const sortedData = React.useMemo(() => {
+    if (!sortState) {
+      return data;
+    }
+
+    const column = columns.find(col => col.id === sortState.columnId);
+
+    if (!column || !column.sortable || !column.sortAccessor) {
+      return data;
+    }
+
+    const directionMultiplier = sortState.direction === 'asc' ? 1 : -1;
+
+    return [...data].sort((a, b) => {
+      const aValue = column.sortAccessor?.(a);
+      const bValue = column.sortAccessor?.(b);
+
+      if (typeof aValue === 'number' && typeof bValue === 'number') {
+        return (aValue - bValue) * directionMultiplier;
+      }
+
+      const aString = (aValue ?? '').toString().toLowerCase();
+      const bString = (bValue ?? '').toString().toLowerCase();
+
+      return aString.localeCompare(bString) * directionMultiplier;
+    });
+  }, [columns, data, sortState]);
+
+  const handleToggleSort = React.useCallback(
+    (columnId: string) => {
+      const column = columns.find(col => col.id === columnId);
+      if (!column || !column.sortable) {
+        return;
+      }
+
+      setSortState(prev => {
+        if (!prev || prev.columnId !== columnId) {
+          return { columnId, direction: 'asc' };
+        }
+
+        return {
+          columnId,
+          direction: prev.direction === 'asc' ? 'desc' : 'asc'
+        };
+      });
+    },
+    [columns]
+  );
+
+  return (
+    <div className={cn('rounded-md border border-[#4e324c] bg-[#1f1720]/60', className)}>
+      <Table>
+        <TableHeader className="bg-black/20">
+          <TableRow className="border-[#4e324c]">
+            {columns.map(column => {
+              const direction = sortState?.columnId === column.id ? sortState.direction : null;
+
+              return (
+                <TableHead
+                  key={column.id}
+                  className={cn(
+                    'px-4 py-3 text-xs font-semibold uppercase tracking-wide text-white/60',
+                    column.headerClassName
+                  )}
+                >
+                  {column.header({
+                    direction,
+                    toggleSort: () => handleToggleSort(column.id)
+                  })}
+                </TableHead>
+              );
+            })}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sortedData.length ? (
+            sortedData.map((row, index) => (
+              <TableRow
+                key={getRowKey ? getRowKey(row, index) : index}
+                className={cn(
+                  'border-[#4e324c] transition-colors',
+                  rowHighlight?.(row)
+                    ? 'bg-[#A75A5B]/10 hover:bg-[#A75A5B]/20'
+                    : 'hover:bg-[#3c252d]/30'
+                )}
+              >
+                {columns.map(column => (
+                  <TableCell
+                    key={column.id}
+                    className={cn('px-4 py-3 text-sm text-white/80', column.cellClassName)}
+                  >
+                    {column.cell(row)}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center text-sm text-white/60">
+                {emptyMessage}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/client/src/components/chart/chartColumns.tsx
+++ b/client/src/components/chart/chartColumns.tsx
@@ -1,0 +1,220 @@
+import * as React from 'react';
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  formatChartMovement,
+  formatChartPosition,
+  formatWeeksOnChart,
+  getChartExitRisk,
+  getChartExitRiskBgColor,
+  getChartPositionColor,
+  getChartPositionOrdinal,
+  getMovementColor,
+  isPlayerSongHighlight
+} from '@shared/utils/chartUtils';
+import { cn } from '@/lib/utils';
+
+import { ChartColumn, SortDirection } from './ChartDataTable';
+
+export interface ChartEntry {
+  position: number;
+  songId: string | null;
+  songTitle: string;
+  artistName: string;
+  movement: number;
+  weeksOnChart: number;
+  peakPosition: number | null;
+  isPlayerSong: boolean;
+  isCompetitorSong: boolean;
+  competitorTitle?: string;
+  competitorArtist?: string;
+  isDebut: boolean;
+}
+
+const headerButtonClasses =
+  'flex w-full items-center gap-1 text-xs font-semibold uppercase tracking-wide text-white/60';
+
+function SortIndicator({ direction }: { direction: SortDirection | null }) {
+  if (direction === 'asc') {
+    return <ArrowUp className="h-3 w-3 text-white/90" />;
+  }
+
+  if (direction === 'desc') {
+    return <ArrowDown className="h-3 w-3 text-white/90" />;
+  }
+
+  return <ArrowUpDown className="h-3 w-3 text-white/30" />;
+}
+
+export const chartColumns: ChartColumn<ChartEntry>[] = [
+  {
+    id: 'position',
+    sortable: true,
+    sortAccessor: entry => entry.position,
+    header: ({ direction, toggleSort }) => (
+      <button
+        type="button"
+        className={cn(headerButtonClasses, 'justify-start')}
+        onClick={toggleSort}
+      >
+        Pos
+        <SortIndicator direction={direction} />
+      </button>
+    ),
+    cell: entry => (
+      <div className="flex items-center gap-3">
+        {entry.position === 1 ? (
+          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-yellow-400 to-yellow-600 text-sm font-bold text-yellow-900 shadow-lg">
+            1
+          </div>
+        ) : (
+          <div
+            className={cn(
+              'flex h-8 w-8 items-center justify-center rounded-full text-sm font-semibold',
+              getChartPositionColor(entry.position)
+            )}
+          >
+            {entry.position}
+          </div>
+        )}
+        <span className="hidden text-[11px] font-mono uppercase tracking-wide text-white/40 xl:inline">
+          {getChartPositionOrdinal(entry.position)}
+        </span>
+      </div>
+    )
+  },
+  {
+    id: 'songTitle',
+    sortable: true,
+    sortAccessor: entry => entry.songTitle.toLowerCase(),
+    header: ({ direction, toggleSort }) => (
+      <button
+        type="button"
+        className={cn(headerButtonClasses, 'justify-start')}
+        onClick={toggleSort}
+      >
+        Song
+        <SortIndicator direction={direction} />
+      </button>
+    ),
+    cell: entry => {
+      const isHighlighted = isPlayerSongHighlight(entry.isPlayerSong, entry.position);
+
+      return (
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                'truncate text-sm font-medium',
+                isHighlighted ? 'text-white' : 'text-white/90'
+              )}
+            >
+              {entry.songTitle}
+            </span>
+            {entry.isDebut && (
+              <Badge variant="secondary" className="bg-green-100 px-1 text-xs text-green-700">
+                NEW
+              </Badge>
+            )}
+            {isHighlighted && (
+              <Badge variant="secondary" className="bg-[#A75A5B] px-1 text-xs text-white">
+                YOURS
+              </Badge>
+            )}
+          </div>
+          <div className="text-xs text-white/60">{entry.artistName}</div>
+        </div>
+      )
+    }
+  },
+  {
+    id: 'weeksOnChart',
+    sortable: true,
+    sortAccessor: entry => (entry.weeksOnChart > 0 ? entry.weeksOnChart : entry.isDebut ? -1 : 0),
+    header: ({ direction, toggleSort }) => (
+      <button
+        type="button"
+        className={cn(headerButtonClasses, 'justify-end')}
+        onClick={toggleSort}
+      >
+        Weeks
+        <SortIndicator direction={direction} />
+      </button>
+    ),
+    cell: entry => {
+      const weeksText =
+        entry.weeksOnChart > 0 ? formatWeeksOnChart(entry.weeksOnChart) : entry.isDebut ? 'Debut' : '—';
+
+      return <div className="text-right text-xs font-mono text-white/70">{weeksText}</div>;
+    }
+  },
+  {
+    id: 'peakPosition',
+    sortable: true,
+    sortAccessor: entry => entry.peakPosition ?? 9999,
+    header: ({ direction, toggleSort }) => (
+      <button
+        type="button"
+        className={cn(headerButtonClasses, 'justify-end')}
+        onClick={toggleSort}
+      >
+        Peak
+        <SortIndicator direction={direction} />
+      </button>
+    ),
+    cell: entry => (
+      <div className="text-right text-xs font-mono text-white/70">
+        {entry.peakPosition ? formatChartPosition(entry.peakPosition) : '—'}
+      </div>
+    )
+  },
+  {
+    id: 'movement',
+    sortable: true,
+    sortAccessor: entry => entry.movement,
+    header: ({ direction, toggleSort }) => (
+      <button
+        type="button"
+        className={cn(headerButtonClasses, 'justify-end')}
+        onClick={toggleSort}
+      >
+        Move
+        <SortIndicator direction={direction} />
+      </button>
+    ),
+    cell: entry => (
+      <div
+        className={cn(
+          'text-right text-xs font-semibold',
+          getMovementColor(entry.movement)
+        )}
+      >
+        {formatChartMovement(entry.movement)}
+      </div>
+    )
+  },
+  {
+    id: 'exitRisk',
+    headerClassName: 'text-right',
+    cellClassName: 'text-right',
+    header: () => (
+      <div className="flex w-full justify-end text-xs font-semibold uppercase tracking-wide text-white/60">
+        Risk
+      </div>
+    ),
+    cell: entry => {
+      const exitRisk = getChartExitRisk(entry.movement, entry.weeksOnChart);
+      const riskLabel = exitRisk === 'high' ? 'High' : exitRisk === 'medium' ? 'Watch' : 'Stable';
+      const riskTextClass =
+        exitRisk === 'high' ? 'text-red-400' : exitRisk === 'medium' ? 'text-amber-300' : 'text-green-400';
+
+      return (
+        <div className="flex items-center justify-end gap-2">
+          <span className={cn('h-2.5 w-2.5 rounded-full', getChartExitRiskBgColor(exitRisk))} />
+          <span className={cn('text-[11px] font-semibold uppercase', riskTextClass)}>{riskLabel}</span>
+        </div>
+      );
+    }
+  }
+];


### PR DESCRIPTION
## Summary
- replace the bespoke list rendering in the Top 10 and Top 100 chart views with the shared `ChartDataTable`
- add the reusable `ChartDataTable` component and chart column helpers to encapsulate sorting, highlighting, and table styling
- keep the existing chart metrics/summary blocks intact while delegating song rows to the shadcn-style data table

## Testing
- `npm run check` *(fails: pre-existing type errors in unrelated areas of the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1c3d6024832e8d388d5f157d89fc