### PR TITLE
feat: track executive ids in executive meetings

### DIFF
--- a/client/src/components/SelectionSummary.tsx
+++ b/client/src/components/SelectionSummary.tsx
@@ -27,7 +27,7 @@ interface SelectionSummaryProps {
 
 // Helper function to parse selected actions (both JSON and legacy formats)
 function parseSelectedAction(id: string):
-  | { format: 'json'; roleId: string; actionId: string; choiceId: string }
+  | { format: 'json'; roleId: string; actionId: string; choiceId: string; executiveId?: string }
   | { format: 'legacy'; parts: string[] } {
   try {
     const parsed = JSON.parse(id);
@@ -42,7 +42,8 @@ function parseSelectedAction(id: string):
         format: 'json',
         roleId: parsed.roleId,
         actionId: parsed.actionId,
-        choiceId: parsed.choiceId
+        choiceId: parsed.choiceId,
+        executiveId: typeof parsed.executiveId === 'string' ? parsed.executiveId : undefined
       };
     }
   } catch {
@@ -81,7 +82,10 @@ export function SelectionSummary({
     'Legacy format should be detected correctly'
   );
   console.assert(
-    parseSelectedAction('{"roleId":"head_ar","actionId":"ar_single_choice","choiceId":"accept_terms"}').roleId === 'head_ar',
+    (() => {
+      const parsed = parseSelectedAction('{"roleId":"head_ar","actionId":"ar_single_choice","choiceId":"accept_terms"}');
+      return parsed.format === 'json' && parsed.roleId === 'head_ar';
+    })(),
     'JSON format should parse roleId correctly'
   );
   
@@ -102,7 +106,7 @@ export function SelectionSummary({
 
     if (parsed.format === 'json') {
       // Handle new JSON format: { roleId, actionId, choiceId }
-      const { roleId, actionId, choiceId } = parsed;
+      const { roleId, actionId, choiceId, executiveId } = parsed;
       const executive = executives[roleId] || executives['ceo'];
 
       // Convert actionId to readable meeting name
@@ -110,7 +114,7 @@ export function SelectionSummary({
 
       return {
         id,
-        executiveId: roleId,
+        executiveId: executiveId || roleId,
         executiveName: executive.name,
         meetingId: actionId,
         meetingName: meetingName,

--- a/client/src/machines/executiveMeetingMachine.ts
+++ b/client/src/machines/executiveMeetingMachine.ts
@@ -193,11 +193,20 @@ export const executiveMeetingMachine = createMachine({
       const { selectedExecutive, selectedMeeting, onActionSelected } = context;
       if (!selectedExecutive || !selectedMeeting) return;
 
-      const actionData = {
+      const actionData: {
+        roleId: string;
+        actionId: string;
+        choiceId: string;
+        executiveId?: string;
+      } = {
         roleId: selectedExecutive.role,
         actionId: selectedMeeting.id,
         choiceId: event.choice.id,
       };
+
+      if (selectedExecutive.role !== 'ceo') {
+        actionData.executiveId = selectedExecutive.id;
+      }
 
       if (onActionSelected) {
         onActionSelected(JSON.stringify(actionData));

--- a/client/src/services/executiveService.ts
+++ b/client/src/services/executiveService.ts
@@ -20,18 +20,24 @@ export async function fetchAllRoles(): Promise<GameRole[]> {
 export async function fetchExecutives(gameId: string): Promise<Executive[]> {
   try {
     const response = await apiRequest('GET', `/api/game/${gameId}/executives`);
-    const dbExecutives = await response.json();
+    const dbExecutives = (await response.json()) as Array<Executive & Record<string, unknown>>;
 
     // Add CEO executive since player is the CEO but CEO has meetings/decisions
     // CEO is not stored in database but should be available for meetings
     const ceoExecutive: Executive = {
+      id: 'ceo',
       role: 'ceo',
       level: 0, // CEO has no level - they are the player
       mood: 0, // CEO has no mood - they are the player
       loyalty: 0 // CEO has no loyalty - they are the player
     };
 
-    return [ceoExecutive, ...dbExecutives];
+    const executives = dbExecutives.map(exec => ({
+      ...exec,
+      id: exec.id,
+    })) as Executive[];
+
+    return [ceoExecutive, ...executives];
   } catch (error) {
     console.error('Failed to fetch executives:', error);
     throw error;

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -367,14 +367,18 @@ export const useGameStore = create<GameStore>()(
                 };
               }
               
-              const { roleId, actionId, choiceId } = actionData;
-              
+              const { roleId, actionId, choiceId, executiveId } = actionData;
+
               // Build complete metadata
               const metadata: any = {
                 roleId,
                 actionId,
                 choiceId
               };
+
+              if (executiveId) {
+                metadata.executiveId = executiveId;
+              }
 
               const result = {
                 actionType: 'role_meeting' as const,

--- a/shared/types/gameTypes.ts
+++ b/shared/types/gameTypes.ts
@@ -51,6 +51,7 @@ export interface GameRole {
 }
 
 export interface Executive {
+  id: string;
   role: string;
   level: number;
   mood: number;


### PR DESCRIPTION
## Summary
- expose the executive `id` in the shared type definition and keep the value when loading executives
- include `executiveId` in serialized meeting selections so month advancement metadata carries the acting executive
- surface the id in selection parsing so queued actions retain executive context for downstream processing

## Testing
- `npm run check` *(fails: existing TypeScript errors throughout client/server codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf3169338832eb38ba81874123054