### PR TITLE
Add email inbox UI and hooks

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import { SaveGameModal } from './SaveGameModal';
 import { ToastNotification } from './ToastNotification';
 import { WeekSummary } from './WeekSummary';
 import { MusicCalendar } from './MusicCalendar';
+import { InboxWidget } from './InboxWidget';
 import { useGameStore } from '@/store/gameStore';
 import { useState, useEffect } from 'react';
 import { useLocation } from 'wouter';
@@ -71,9 +72,10 @@ export function Dashboard({
             <ArtistRoster />
           </div>
 
-          {/* Music Calendar */}
-          <div className="lg:col-span-1">
+          {/* Music Calendar & Inbox */}
+          <div className="lg:col-span-1 space-y-4">
             <MusicCalendar />
+            <InboxWidget />
           </div>
         </div>
 

--- a/client/src/components/InboxModal.tsx
+++ b/client/src/components/InboxModal.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+import { useEmails, useMarkEmailRead, useUnreadEmailCount } from '@/hooks/useEmails';
+import type { EmailCategory } from '@shared/types/emailTypes';
+import type { EmailTemplateData, EmailTemplateProps } from './email-templates';
+import {
+  ArtistDiscoveryEmail,
+  FinancialReportEmail,
+  NumberOneDebutEmail,
+  ReleaseEmail,
+  TierUnlockEmail,
+  Top10DebutEmail,
+  TourCompletionEmail,
+} from './email-templates';
+
+const CATEGORY_LABELS: Record<EmailCategory, string> = {
+  tour_completion: 'Tour Completion',
+  top_10_debut: 'Top 10 Debut',
+  release: 'Release',
+  number_one_debut: '#1 Debut',
+  tier_unlock: 'Tier Unlock',
+  artist_discovery: 'Artist Discovery',
+  financial_report: 'Financial Report',
+};
+
+const CATEGORY_OPTIONS: { value: 'all' | EmailCategory; label: string }[] = [
+  { value: 'all', label: 'All categories' },
+  { value: 'tour_completion', label: 'Tour Completion' },
+  { value: 'top_10_debut', label: 'Top 10 Debut' },
+  { value: 'number_one_debut', label: '#1 Debut' },
+  { value: 'release', label: 'Releases' },
+  { value: 'tier_unlock', label: 'Tier Unlocks' },
+  { value: 'artist_discovery', label: 'Artist Discovery' },
+  { value: 'financial_report', label: 'Financial Reports' },
+];
+
+const TEMPLATE_MAP: Record<EmailCategory, React.ComponentType<EmailTemplateProps>> = {
+  tour_completion: TourCompletionEmail,
+  top_10_debut: Top10DebutEmail,
+  release: ReleaseEmail,
+  number_one_debut: NumberOneDebutEmail,
+  tier_unlock: TierUnlockEmail,
+  artist_discovery: ArtistDiscoveryEmail,
+  financial_report: FinancialReportEmail,
+};
+
+interface InboxModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialEmailId?: string | null;
+}
+
+export function InboxModal({ open, onOpenChange, initialEmailId }: InboxModalProps) {
+  const [category, setCategory] = useState<'all' | EmailCategory>('all');
+  const [showUnreadOnly, setShowUnreadOnly] = useState(false);
+  const [selectedEmailId, setSelectedEmailId] = useState<string | null>(null);
+
+  const queryParams = useMemo(
+    () => ({
+      limit: 50,
+      category: category === 'all' ? undefined : category,
+      isRead: showUnreadOnly ? false : undefined,
+    }),
+    [category, showUnreadOnly]
+  );
+
+  const { data, isLoading, isFetching, refetch } = useEmails(queryParams);
+  const { data: unreadData } = useUnreadEmailCount();
+  const markEmailRead = useMarkEmailRead();
+
+  const emails = data?.emails ?? [];
+  const unreadCount = unreadData?.count ?? data?.unreadCount ?? 0;
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedEmailId(null);
+      setCategory('all');
+      setShowUnreadOnly(false);
+      return;
+    }
+
+    if (emails.length === 0) {
+      setSelectedEmailId(null);
+      return;
+    }
+
+    setSelectedEmailId((current) => {
+      if (current && emails.some((email) => email.id === current)) {
+        return current;
+      }
+
+      if (initialEmailId && emails.some((email) => email.id === initialEmailId)) {
+        return initialEmailId;
+      }
+
+      return emails[0]?.id ?? null;
+    });
+  }, [open, emails, initialEmailId]);
+
+  const selectedEmail = emails.find((email) => email.id === selectedEmailId) ?? null;
+
+  const TemplateComponent = selectedEmail
+    ? TEMPLATE_MAP[selectedEmail.category] ?? DefaultEmailTemplate
+    : null;
+
+  const handleToggleRead = () => {
+    if (!selectedEmail) return;
+    markEmailRead.mutate({ emailId: selectedEmail.id, isRead: !selectedEmail.isRead });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl border border-[#4e324c] bg-[#160c12] text-white">
+        <DialogHeader className="border-b border-[#4e324c] pb-4">
+          <DialogTitle className="flex items-center justify-between text-lg font-semibold text-white">
+            <span>Inbox</span>
+            <Badge variant="secondary" className="bg-[#A75A5B] text-white">
+              {unreadCount} unread
+            </Badge>
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-4 flex h-[70vh] flex-col gap-4 lg:flex-row">
+          <aside className="w-full flex-shrink-0 lg:w-72">
+            <div className="flex h-full flex-col rounded-xl border border-[#4e324c] bg-[#1b1016]">
+              <div className="space-y-4 border-b border-[#4e324c] p-4">
+                <div className="space-y-2">
+                  <Label className="text-xs uppercase tracking-wide text-white/60">Category</Label>
+                  <Select value={category} onValueChange={(value) => setCategory(value as 'all' | EmailCategory)}>
+                    <SelectTrigger className="h-9 border-[#4e324c] bg-black/40 text-white">
+                      <SelectValue placeholder="All categories" />
+                    </SelectTrigger>
+                    <SelectContent className="border-[#4e324c] bg-[#160c12] text-white">
+                      {CATEGORY_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value} className="text-sm">
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="unread-only"
+                      checked={showUnreadOnly}
+                      onCheckedChange={(checked) => setShowUnreadOnly(checked)}
+                    />
+                    <Label htmlFor="unread-only" className="text-xs text-white/70">
+                      Unread only
+                    </Label>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs text-white/70 hover:text-white"
+                    onClick={() => refetch()}
+                    disabled={isFetching}
+                  >
+                    {isFetching ? 'Refreshing…' : 'Refresh'}
+                  </Button>
+                </div>
+              </div>
+
+              <ScrollArea className="flex-1">
+                <div className="space-y-2 p-3">
+                  {isLoading ? (
+                    <LoadingList />
+                  ) : emails.length === 0 ? (
+                    <div className="rounded-lg border border-dashed border-white/20 bg-black/20 p-6 text-center text-sm text-white/60">
+                      No emails yet. Advance the week to generate updates.
+                    </div>
+                  ) : (
+                    emails.map((email) => (
+                      <button
+                        key={email.id}
+                        type="button"
+                        className={cn(
+                          'w-full rounded-lg border px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-[#A75A5B]',
+                          selectedEmailId === email.id
+                            ? 'border-[#A75A5B] bg-[#A75A5B]/20'
+                            : 'border-transparent bg-black/20 hover:border-[#4e324c] hover:bg-black/30'
+                        )}
+                        onClick={() => setSelectedEmailId(email.id)}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2">
+                            {!email.isRead && <span className="h-2 w-2 rounded-full bg-emerald-400" />}
+                            <span className="text-sm font-semibold text-white">{email.subject}</span>
+                          </div>
+                          <span className="text-xs text-white/50">{formatTimestamp(email.createdAt)}</span>
+                        </div>
+                        <div className="mt-1 flex items-center justify-between">
+                          <span className="text-xs text-white/60">{email.sender}</span>
+                          <Badge variant="outline" className="text-xs text-white/70">
+                            {CATEGORY_LABELS[email.category]}
+                          </Badge>
+                        </div>
+                        {email.preview && (
+                          <p className="mt-2 text-xs text-white/55">
+                            {email.preview}
+                          </p>
+                        )}
+                      </button>
+                    ))
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
+          </aside>
+
+          <section className="flex-1 rounded-xl border border-[#4e324c] bg-[#1b1016]">
+            {selectedEmail && TemplateComponent ? (
+              <div className="flex h-full flex-col">
+                <div className="space-y-3 border-b border-[#4e324c] p-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary" className="bg-white/10 text-white/80">
+                      Week {selectedEmail.week}
+                    </Badge>
+                    <Badge variant="outline" className="border-[#A75A5B] text-[#F6B5B6]">
+                      {CATEGORY_LABELS[selectedEmail.category]}
+                    </Badge>
+                    {!selectedEmail.isRead && (
+                      <Badge variant="secondary" className="bg-emerald-500/20 text-emerald-200">
+                        Unread
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div>
+                    <h3 className="text-xl font-semibold text-white">{selectedEmail.subject}</h3>
+                    <p className="text-xs text-white/60">
+                      {selectedEmail.sender} • {formatTimestamp(selectedEmail.createdAt)}
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleToggleRead}
+                      disabled={markEmailRead.isPending}
+                      className="border-[#4e324c] text-xs text-white hover:border-[#A75A5B] hover:text-white"
+                    >
+                      {selectedEmail.isRead ? 'Mark unread' : 'Mark as read'}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-xs text-white/70 hover:text-white"
+                      onClick={() => {
+                        setShowUnreadOnly(false);
+                        setCategory('all');
+                      }}
+                    >
+                      Show all
+                    </Button>
+                  </div>
+                </div>
+
+                <ScrollArea className="flex-1">
+                  <div className="space-y-4 p-4">
+                    <Separator className="border-[#4e324c]" />
+                    <TemplateComponent email={selectedEmail as EmailTemplateData} />
+                  </div>
+                </ScrollArea>
+              </div>
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm text-white/60">
+                Select an email to read the details.
+              </div>
+            )}
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function LoadingList() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <Skeleton key={index} className="h-16 w-full rounded-lg bg-white/5" />
+      ))}
+    </div>
+  );
+}
+
+function DefaultEmailTemplate({ email }: EmailTemplateProps) {
+  return (
+    <pre className="overflow-x-auto rounded-lg border border-white/10 bg-black/30 p-4 text-xs text-white/70">
+      {JSON.stringify(email.body, null, 2)}
+    </pre>
+  );
+}
+
+function formatTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}

--- a/client/src/components/InboxWidget.tsx
+++ b/client/src/components/InboxWidget.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Inbox } from 'lucide-react';
+import { useEmails, useUnreadEmailCount } from '@/hooks/useEmails';
+import { InboxModal } from './InboxModal';
+
+export function InboxWidget() {
+  const [open, setOpen] = useState(false);
+  const { data: unreadData, isLoading: unreadLoading } = useUnreadEmailCount();
+  const { data, isLoading } = useEmails({ limit: 1 });
+
+  const latestEmail = data?.emails?.[0] ?? null;
+  const unreadCount = unreadData?.count ?? data?.unreadCount ?? 0;
+
+  return (
+    <>
+      <Card
+        role="button"
+        tabIndex={0}
+        onClick={() => setOpen(true)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setOpen(true);
+          }
+        }}
+        className="group relative cursor-pointer border-[#4e324c]/80 bg-gradient-to-br from-[#28131d] via-[#221018] to-[#1b0e14] transition hover:border-[#A75A5B] focus:outline-none focus:ring-2 focus:ring-[#A75A5B]"
+      >
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+          <CardTitle className="flex items-center gap-2 text-xl">
+            <Inbox className="h-5 w-5 text-[#F6B5B6]" />
+            Inbox
+          </CardTitle>
+          <Badge className="bg-[#A75A5B] text-white">
+            {unreadLoading ? '—' : `${unreadCount} unread`}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLoading ? (
+            <Skeleton className="h-14 w-full rounded-lg bg-white/10" />
+          ) : latestEmail ? (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-sm font-semibold text-white">{latestEmail.subject}</p>
+                <Badge variant="outline" className="text-xs text-white/70">
+                  {formatCategory(latestEmail.category)}
+                </Badge>
+              </div>
+              <p className="text-xs text-white/60">
+                {latestEmail.preview ?? 'Open to read the full briefing.'}
+              </p>
+              <p className="text-[11px] uppercase tracking-wide text-white/40">
+                {formatTimestamp(latestEmail.createdAt)} • Week {latestEmail.week}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2 text-sm text-white/60">
+              <p>No emails yet.</p>
+              <p>Advance the week to receive updates from your team.</p>
+            </div>
+          )}
+
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="bg-[#A75A5B] text-white hover:bg-[#c3747a]"
+            onClick={(event) => {
+              event.stopPropagation();
+              setOpen(true);
+            }}
+          >
+            Open inbox
+          </Button>
+        </CardContent>
+      </Card>
+
+      <InboxModal open={open} onOpenChange={setOpen} initialEmailId={latestEmail?.id ?? null} />
+    </>
+  );
+}
+
+function formatTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function formatCategory(category: string) {
+  switch (category) {
+    case 'tour_completion':
+      return 'Tour';
+    case 'top_10_debut':
+      return 'Top 10 Debut';
+    case 'number_one_debut':
+      return '#1 Debut';
+    case 'release':
+      return 'Release';
+    case 'tier_unlock':
+      return 'Tier Unlock';
+    case 'artist_discovery':
+      return 'Artist Discovery';
+    case 'financial_report':
+      return 'Financial Report';
+    default:
+      return 'Update';
+  }
+}

--- a/client/src/components/email-templates/ArtistDiscoveryEmail.tsx
+++ b/client/src/components/email-templates/ArtistDiscoveryEmail.tsx
@@ -1,0 +1,46 @@
+import { formatCurrency, formatNumber } from './utils';
+import type { EmailTemplateProps } from './types';
+
+export function ArtistDiscoveryEmail({ email }: EmailTemplateProps) {
+  const body = email.body as Record<string, any>;
+
+  return (
+    <div className="space-y-4 text-sm text-white/85">
+      <div>
+        <p className="text-white font-semibold">Mac has a new talent recommendation.</p>
+        <p>{body?.bio ?? 'This artist fits the A&R brief you set this week.'}</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Info label="Artist" value={body?.name ?? 'New Artist'} />
+        <Info label="Archetype" value={body?.archetype ?? 'Unknown'} />
+        <Info label="Genre" value={body?.genre ?? 'Open Format'} />
+        <Info label="Talent" value={body?.talent ? `${formatNumber(body.talent)} / 100` : 'Scouted'} />
+      </div>
+
+      <div className="rounded-lg border border-white/10 bg-black/30 p-4 space-y-2">
+        <div className="text-xs uppercase tracking-wide text-white/60">Financials</div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-white/60">Signing Bonus</span>
+          <span className="text-white font-semibold">{formatCurrency(body?.signingCost)}</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-white/60">Weekly Cost</span>
+          <span className="text-white font-semibold">{formatCurrency(body?.weeklyCost)}</span>
+        </div>
+        <div className="text-xs text-white/50">
+          Scouted via {body?.sourcingType ?? 'A&R initiative'}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Info({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/40 p-4">
+      <div className="text-xs uppercase tracking-wide text-white/60">{label}</div>
+      <div className="text-white font-semibold">{value}</div>
+    </div>
+  );
+}

--- a/client/src/components/email-templates/FinancialReportEmail.tsx
+++ b/client/src/components/email-templates/FinancialReportEmail.tsx
@@ -1,0 +1,59 @@
+import { formatCurrency } from './utils';
+import type { EmailTemplateProps } from './types';
+
+export function FinancialReportEmail({ email }: EmailTemplateProps) {
+  const body = email.body as Record<string, any>;
+  const expenseBreakdown = (body?.expenseBreakdown ?? {}) as Record<string, number>;
+
+  return (
+    <div className="space-y-4 text-sm text-white/85">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <SummaryCard label="Revenue" value={formatCurrency(body?.revenue)} positive />
+        <SummaryCard label="Expenses" value={formatCurrency(body?.expenses)} negative />
+        <SummaryCard label="Net" value={formatCurrency((body?.revenue ?? 0) - (body?.expenses ?? 0))} />
+        <SummaryCard label="Streams" value={(body?.streams ?? 0).toLocaleString()} />
+      </div>
+
+      {Object.keys(expenseBreakdown).length > 0 && (
+        <div className="rounded-lg border border-white/10 bg-black/30">
+          <div className="border-b border-white/10 px-4 py-2 text-xs uppercase tracking-wide text-white/60">
+            Expense Breakdown
+          </div>
+          <div className="divide-y divide-white/10">
+            {Object.entries(expenseBreakdown).map(([category, value]) => (
+              <div key={category} className="px-4 py-2 flex items-center justify-between text-sm">
+                <span className="capitalize text-white/70">{category.replace(/([A-Z])/g, ' $1')}</span>
+                <span className="text-white font-medium">{formatCurrency(value)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {typeof body?.financialBreakdown === 'string' && (
+        <div className="rounded-lg border border-white/10 bg-black/20 p-4 text-white/70 whitespace-pre-wrap text-xs">
+          {body.financialBreakdown}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  positive,
+  negative,
+}: {
+  label: string;
+  value: string;
+  positive?: boolean;
+  negative?: boolean;
+}) {
+  return (
+    <div className={`rounded-lg border bg-black/40 p-4 ${positive ? 'border-green-500/40' : negative ? 'border-red-500/40' : 'border-white/10'}`}>
+      <div className="text-xs uppercase tracking-wide text-white/60">{label}</div>
+      <div className={`text-lg font-semibold ${positive ? 'text-green-300' : negative ? 'text-red-300' : 'text-white'}`}>{value}</div>
+    </div>
+  );
+}

--- a/client/src/components/email-templates/NumberOneDebutEmail.tsx
+++ b/client/src/components/email-templates/NumberOneDebutEmail.tsx
@@ -1,0 +1,38 @@
+import { formatNumber } from './utils';
+import type { EmailTemplateProps } from './types';
+
+export function NumberOneDebutEmail({ email }: EmailTemplateProps) {
+  const body = email.body as Record<string, any>;
+
+  return (
+    <div className="space-y-4 text-sm text-white/85">
+      <p className="text-white font-semibold text-lg">Historic #1 Debut!</p>
+      <p>
+        {body?.artistName ?? 'Your artist'} stormed the charts with "{body?.songTitle ?? 'the single'}",
+        debuting at #1 this week. The industry will be talking about this for a long time.
+      </p>
+
+      <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/10 p-4 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-xs uppercase tracking-wide text-yellow-200/80">Debut Position</span>
+          <span className="text-2xl font-bold text-yellow-200">#1</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-xs uppercase tracking-wide text-yellow-200/80">Projected Streams</span>
+          <span className="text-xl font-semibold text-yellow-100">
+            {formatNumber(body?.streams ?? body?.projectedStreams)}
+          </span>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-white/10 bg-black/40 p-4 space-y-1">
+        <div className="text-xs uppercase tracking-wide text-white/50">Momentum Signals</div>
+        <ul className="list-disc list-inside space-y-1 text-white/80">
+          <li>Massive social engagement across focus platforms</li>
+          <li>Press already requesting interviews</li>
+          <li>Playlist teams asking for expedited follow-up</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/email-templates/ReleaseEmail.tsx
+++ b/client/src/components/email-templates/ReleaseEmail.tsx
@@ -1,0 +1,44 @@
+import { formatCurrency } from './utils';
+import type { EmailTemplateProps } from './types';
+
+export function ReleaseEmail({ email }: EmailTemplateProps) {
+  const body = email.body as Record<string, any>;
+  const metadata = (body?.metadata ?? {}) as Record<string, any>;
+
+  return (
+    <div className="space-y-4 text-sm text-white/85">
+      <p className="text-white font-semibold">Distribution update for your latest release.</p>
+      <p>{body?.description ?? 'Your new release is live across all platforms.'}</p>
+
+      <div className="rounded-lg border border-white/10 bg-black/30 p-4 space-y-2">
+        <InfoRow label="Release Title" value={metadata?.projectTitle ?? metadata?.projectName ?? 'New Release'} />
+        <InfoRow label="Primary Artist" value={metadata?.artistName ?? metadata?.artist ?? 'Signed Artist'} />
+        <InfoRow label="Project ID" value={body?.projectId ?? metadata?.projectId ?? '—'} />
+      </div>
+
+      {typeof metadata?.initialStreams === 'number' && (
+        <div className="rounded-lg border border-green-500/40 bg-green-500/10 p-4">
+          <div className="text-xs uppercase tracking-wide text-green-200/80">Launch Highlights</div>
+          <div className="text-white text-lg font-semibold">
+            {metadata.initialStreams.toLocaleString()} projected streams in the first 24 hours.
+          </div>
+        </div>
+      )}
+
+      {typeof metadata?.launchSpend === 'number' && (
+        <div className="text-xs text-white/60">
+          Launch marketing spend so far: {formatCurrency(metadata.launchSpend)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-white/60">{label}</span>
+      <span className="text-white font-medium">{value}</span>
+    </div>
+  );
+}

--- a/client/src/components/email-templates/TierUnlockEmail.tsx
+++ b/client/src/components/email-templates/TierUnlockEmail.tsx
@@ -1,0 +1,44 @@
+import { formatCurrency } from './utils';
+import type { EmailTemplateProps } from './types';
+
+export function TierUnlockEmail({ email }: EmailTemplateProps) {
+  const body = email.body as Record<string, any>;
+  const amount = typeof body?.amount === 'number' ? body.amount : null;
+
+  return (
+    <div className="space-y-4 text-sm text-white/85">
+      <p className="text-white font-semibold">New access unlocked for the label.</p>
+      <p>{body?.description ?? 'You have unlocked a new strategic tier.'}</p>
+
+      <div className="rounded-lg border border-purple-500/40 bg-purple-500/10 p-4 space-y-3">
+        <Info label="Unlocked" value={deriveUnlockName(body?.description)} />
+        {amount !== null && (
+          <Info label="Immediate Value" value={formatCurrency(amount)} highlight />
+        )}
+      </div>
+
+      <p className="text-xs text-white/60">
+        Keep momentum going by planning complementary actions while the market is excited.
+      </p>
+    </div>
+  );
+}
+
+function deriveUnlockName(description: string | undefined): string {
+  if (!description) return 'Access Tier';
+  if (description.toLowerCase().includes('playlist')) return 'Playlist Access';
+  if (description.toLowerCase().includes('press')) return 'Press Access';
+  if (description.toLowerCase().includes('venue')) return 'Venue Access';
+  if (description.toLowerCase().includes('producer')) return 'Producer Network';
+  if (description.toLowerCase().includes('focus slot')) return 'Additional Focus Slot';
+  return description;
+}
+
+function Info({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-white/60 text-xs uppercase tracking-wide">{label}</span>
+      <span className={`text-sm font-semibold ${highlight ? 'text-purple-100' : 'text-white'}`}>{value}</span>
+    </div>
+  );
+}

--- a/client/src/components/email-templates/Top10DebutEmail.tsx
+++ b/client/src/components/email-templates/Top10DebutEmail.tsx
@@ -1,0 +1,50 @@
+import { formatNumber } from './utils';
+import type { EmailTemplateProps } from './types';
+
+export function Top10DebutEmail({ email }: EmailTemplateProps) {
+  const body = email.body as Record<string, any>;
+
+  return (
+    <div className="space-y-4 text-sm text-white/80">
+      <div>
+        <p className="text-white font-semibold">Your marketing blitz is paying off.</p>
+        <p>
+          "{body?.songTitle ?? 'The single'}" debuted in the Top 10 with
+          {' '}#{body?.position ?? '?'} on the national charts.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Stat label="Debut Position" value={`#${body?.position ?? '?'}`} />
+        <Stat label="Movement" value={formatMovement(body?.movement)} />
+        <Stat label="Weeks on Chart" value={formatNumber(body?.weeksOnChart)} />
+      </div>
+
+      <div className="rounded-lg border border-white/10 bg-black/30 p-4">
+        <div className="text-xs uppercase tracking-wide text-white/50">Artist</div>
+        <div className="text-white font-medium">{body?.artistName ?? 'Artist'}</div>
+        {body?.peakPosition && (
+          <div className="text-xs text-white/60 mt-1">
+            Peak position to date: #{body.peakPosition}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/40 p-4">
+      <div className="text-white/60 text-xs uppercase tracking-wide">{label}</div>
+      <div className="text-lg font-semibold text-white">{value}</div>
+    </div>
+  );
+}
+
+function formatMovement(movement: number | null | undefined): string {
+  if (typeof movement !== 'number') return '—';
+  if (movement === 0) return 'Flat';
+  const direction = movement > 0 ? '▲' : '▼';
+  return `${direction} ${Math.abs(movement)} spots`;
+}

--- a/client/src/components/email-templates/TourCompletionEmail.tsx
+++ b/client/src/components/email-templates/TourCompletionEmail.tsx
@@ -1,0 +1,48 @@
+import { formatCurrency, formatNumber } from './utils';
+import type { EmailTemplateProps } from './types';
+
+export function TourCompletionEmail({ email }: EmailTemplateProps) {
+  const body = email.body as Record<string, any>;
+  const metadata = (body?.metadata ?? {}) as Record<string, any>;
+
+  return (
+    <div className="space-y-4 text-sm text-white/80">
+      <p className="text-white font-semibold">Tour recap from the road team.</p>
+      <p>
+        {body?.description ?? 'Your tour has wrapped for the week. Here is how the dates performed.'}
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="rounded-lg border border-white/10 bg-black/40 p-4">
+          <div className="text-white/60 text-xs uppercase tracking-wide">Gross Revenue</div>
+          <div className="text-lg font-semibold text-green-300">{formatCurrency(body?.amount ?? metadata?.amount)}</div>
+        </div>
+        <div className="rounded-lg border border-white/10 bg-black/40 p-4">
+          <div className="text-white/60 text-xs uppercase tracking-wide">Project</div>
+          <div className="text-white font-medium">
+            {metadata?.projectName ?? metadata?.projectId ?? body?.projectId ?? 'Tour'}
+          </div>
+        </div>
+      </div>
+
+      {Array.isArray(metadata?.cities) && metadata.cities.length > 0 && (
+        <div className="rounded-lg border border-white/10 bg-black/20">
+          <div className="border-b border-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white/60">
+            City Highlights
+          </div>
+          <div className="divide-y divide-white/10">
+            {metadata.cities.map((city: any, index: number) => (
+              <div key={city?.name ?? index} className="px-4 py-2 flex items-center justify-between">
+                <div>
+                  <div className="text-white font-medium">{city?.name ?? 'Tour Stop'}</div>
+                  <div className="text-white/60 text-xs">{city?.venue ?? 'Venue TBD'}</div>
+                </div>
+                <div className="text-white/80 font-semibold">{formatNumber(city?.attendance)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/email-templates/index.ts
+++ b/client/src/components/email-templates/index.ts
@@ -1,0 +1,8 @@
+export * from './ArtistDiscoveryEmail';
+export * from './FinancialReportEmail';
+export * from './NumberOneDebutEmail';
+export * from './ReleaseEmail';
+export * from './TierUnlockEmail';
+export * from './Top10DebutEmail';
+export * from './TourCompletionEmail';
+export type { EmailTemplateProps, EmailTemplateData } from './types';

--- a/client/src/components/email-templates/types.ts
+++ b/client/src/components/email-templates/types.ts
@@ -1,0 +1,7 @@
+import type { EmailRecord } from '@shared/types/emailTypes';
+
+export type EmailTemplateData = EmailRecord<Record<string, unknown>>;
+
+export interface EmailTemplateProps {
+  email: EmailTemplateData;
+}

--- a/client/src/components/email-templates/utils.ts
+++ b/client/src/components/email-templates/utils.ts
@@ -1,0 +1,18 @@
+export function formatCurrency(value: number | null | undefined): string {
+  const amount = typeof value === 'number' && !Number.isNaN(value) ? value : 0;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function formatNumber(value: number | null | undefined): string {
+  const amount = typeof value === 'number' && !Number.isNaN(value) ? value : 0;
+  return new Intl.NumberFormat('en-US').format(amount);
+}
+
+export function formatPercentage(value: number | null | undefined): string {
+  const amount = typeof value === 'number' && !Number.isNaN(value) ? value : 0;
+  return `${amount.toFixed(1)}%`;
+}

--- a/client/src/hooks/useEmails.ts
+++ b/client/src/hooks/useEmails.ts
@@ -1,0 +1,140 @@
+import { useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { apiRequest } from '@/lib/queryClient';
+import type { EmailRecord, EmailCategory } from '@shared/types/emailTypes';
+
+export interface EmailListQuery {
+  isRead?: boolean;
+  category?: EmailCategory;
+  week?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface EmailListResponse {
+  emails: EmailRecord<Record<string, unknown>>[];
+  total: number;
+  unreadCount: number;
+}
+
+function buildQueryString(params: EmailListQuery): string {
+  const searchParams = new URLSearchParams();
+
+  if (typeof params.limit === 'number') {
+    searchParams.set('limit', String(params.limit));
+  }
+  if (typeof params.offset === 'number') {
+    searchParams.set('offset', String(params.offset));
+  }
+  if (typeof params.week === 'number') {
+    searchParams.set('week', String(params.week));
+  }
+  if (typeof params.isRead === 'boolean') {
+    searchParams.set('isRead', params.isRead ? 'true' : 'false');
+  }
+  if (params.category) {
+    searchParams.set('category', params.category);
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+function normalizeEmail(email: any): EmailRecord<Record<string, unknown>> {
+  const createdAt = email?.createdAt instanceof Date
+    ? email.createdAt.toISOString()
+    : typeof email?.createdAt === 'string'
+      ? email.createdAt
+      : new Date().toISOString();
+
+  const updatedAt = email?.updatedAt instanceof Date
+    ? email.updatedAt.toISOString()
+    : typeof email?.updatedAt === 'string'
+      ? email.updatedAt
+      : createdAt;
+
+  return {
+    id: email?.id ?? '',
+    gameId: email?.gameId ?? '',
+    week: Number(email?.week ?? 0),
+    category: email?.category ?? 'financial_report',
+    sender: email?.sender ?? 'System',
+    senderRoleId: email?.senderRoleId ?? null,
+    subject: email?.subject ?? 'Message',
+    preview: email?.preview ?? null,
+    body: (email?.body ?? {}) as Record<string, unknown>,
+    metadata: (email?.metadata ?? {}) as Record<string, unknown>,
+    isRead: Boolean(email?.isRead),
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function useEmails(params: EmailListQuery = {}) {
+  const gameId = useGameStore((state) => state.gameState?.id);
+  const memoizedParams = useMemo(() => ({ ...params }), [JSON.stringify(params)]);
+
+  return useQuery<EmailListResponse>({
+    queryKey: ['emails', gameId, memoizedParams],
+    enabled: Boolean(gameId),
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) {
+        return { emails: [], total: 0, unreadCount: 0 };
+      }
+
+      const response = await apiRequest('GET', `/api/game/${gameId}/emails${buildQueryString(memoizedParams)}`);
+      const data = await response.json();
+
+      return {
+        emails: Array.isArray(data?.emails) ? data.emails.map(normalizeEmail) : [],
+        total: Number(data?.total ?? 0),
+        unreadCount: Number(data?.unreadCount ?? 0),
+      };
+    },
+  });
+}
+
+export function useUnreadEmailCount() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  return useQuery<{ count: number }>({
+    queryKey: ['emails', gameId, 'unread-count'],
+    enabled: Boolean(gameId),
+    staleTime: 15_000,
+    queryFn: async () => {
+      if (!gameId) {
+        return { count: 0 };
+      }
+
+      const response = await apiRequest('GET', `/api/game/${gameId}/emails/unread-count`);
+      return response.json();
+    },
+  });
+}
+
+export function useMarkEmailRead() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ emailId, isRead }: { emailId: string; isRead: boolean }) => {
+      if (!gameId) {
+        throw new Error('No game selected');
+      }
+
+      const response = await apiRequest('PATCH', `/api/game/${gameId}/emails/${emailId}/read`, {
+        isRead,
+      });
+
+      const data = await response.json();
+      return normalizeEmail(data?.email);
+    },
+    onSuccess: () => {
+      if (!gameId) return;
+      queryClient.invalidateQueries({ queryKey: ['emails', gameId] });
+      queryClient.invalidateQueries({ queryKey: ['emails', gameId, 'unread-count'] });
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add React Query hooks for fetching and updating game emails
- create an inbox widget and modal with filtering, unread controls, and template rendering
- implement email templates for each category used in the weekly generator

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dccfaa899c832eb9e6478cbb5a88ec