### PR TITLE
fix(client): make default queryFn assignable to TanStack QueryKey

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { QueryClient, QueryFunction, QueryKey } from "@tanstack/react-query";
 import logger, { redactSensitiveHeaders } from "./logger";
 
 async function getClerkToken(): Promise<string | null> {
@@ -308,7 +308,11 @@ function extractUrlFromQueryKey(queryKey: readonly unknown[]): string {
   return url;
 }
 
-export function getQueryFn<T>({ on401: unauthorizedBehavior }: { on401: UnauthorizedBehavior }): QueryFunction<T, QueryKeyWithUrl> {
+export function getQueryFn<T>({ on401: unauthorizedBehavior }: { on401: UnauthorizedBehavior }): QueryFunction<T, QueryKey> {
+  // NOTE: typed over the general `QueryKey` (not `QueryKeyWithUrl`) so this is
+  // assignable to TanStack's default `queryFn` slot, which must accept any key
+  // shape. The string-URL contract is enforced at runtime by
+  // `extractUrlFromQueryKey`, which throws if `queryKey[0]` is not a string.
   return async ({ queryKey }) => {
     const url = extractUrlFromQueryKey(queryKey);
     const shouldReturnNull = unauthorizedBehavior === "returnNull";


### PR DESCRIPTION
## Problem

`npm run check` fails on `main` with a TypeScript error in `client/src/lib/queryClient.ts`:

```
client/src/lib/queryClient.ts(334,7): error TS2322:
  Type 'QueryFunction<unknown, QueryKeyWithUrl>' is not assignable to
  '... QueryFunction<unknown, QueryKey, never> | undefined'.
  Type 'QueryKey' is not assignable to type 'QueryKeyWithUrl'.
    Source provides no match for required element at position 0 in target.
```

`getQueryFn` returned `QueryFunction<T, QueryKeyWithUrl>`, where `QueryKeyWithUrl = readonly [string, ...unknown[]]` requires the first key element to be a string. TanStack Query's default `queryFn` slot expects `QueryFunction<T, QueryKey>` (`QueryKey = readonly unknown[]`). Because the query-key parameter is **contravariant**, a function demanding a *narrower* key shape is not assignable to the default slot — which must accept any key.

## Fix

Type the returned function over the general `QueryKey` instead of `QueryKeyWithUrl`. The string-URL contract is still enforced at runtime by `extractUrlFromQueryKey`, which throws if `queryKey[0]` is not a non-empty string — the correct enforcement point for a default `queryFn`.

## Verification

- `npm run check` now passes clean (no `tsc` errors).
- Single-file change; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)