### PR TITLE
chore: repair /session-end command and refresh DEVELOPMENT_STATUS

### DIFF
--- a/.claude/commands/session-end.md
+++ b/.claude/commands/session-end.md
@@ -1,90 +1,46 @@
 ---
 description: Complete session documentation update with current status and changes
-allowed-tools: Read, Edit, MultiEdit, Bash(git status), Bash(date), Bash(npm run check:*)
-argument-hint: [session summary/changes made]
+allowed-tools: Read, Edit, MultiEdit, Bash(git status:*), Bash(git log:*), Bash(date:*), Bash(npm run check:*)
+argument-hint: [short summary of what was done this session]
 ---
 
-# 🎯 Session End - Documentation Update
+# 🎯 Session End — Documentation Sync
 
-Performing comprehensive documentation update for session end...
+Capturing this session's work so the next session can resume cleanly.
 
-## Current Status Check
+## 1. Snapshot current state
 !Bash date "+Session End: %Y-%m-%d %H:%M"
 !Bash git status
+!Bash git log --oneline -8
 
-## Session Summary
-**Changes This Session**: $ARGUMENTS
+## 2. Session summary (from the user)
+**Changes this session**: $ARGUMENTS
 
-## Updating Documentation Files
+## 3. Update the running log — `DEVELOPMENT_STATUS.md`
+This is the project's single source of truth for current progress. Read it, then update it:
+!Read DEVELOPMENT_STATUS.md
 
-I'll now update the key documentation files with current status and session information:
+Do the following edits:
+- Update the `*Updated: <date>*` line near the top to **today's date** (from step 1).
+- Add a new dated entry at the top of the status body (just under the header/`---`) titled `## 📅 Session Log — <today's date>` summarizing `$ARGUMENTS`: what changed, any branches/PRs opened, decisions made, and **explicit next steps / open threads** so the next session knows where to pick up.
+- If a priority or phase changed, reflect it in the relevant existing section.
 
-### 1. Update Development Status Report
-!Read /home/runner/workspace/DEVELOPMENT_STATUS.md
+## 4. Update AI onboarding context — `ai_instructions.md`
+!Read ai_instructions.md
 
-I'm updating the development status report with today's date and current post-MVP phase information...
+If it has a "Current State" (or similar) section, refresh its date and any status that changed this session. If nothing material changed, leave it.
 
-!Edit /home/runner/workspace/DEVELOPMENT_STATUS.md "*Updated: August 18, 2025*" "*Updated: August 18, 2025 - Session End Documentation Sync*"
+## 5. Reconcile feature tasks — `tasks/`
+!Bash git status
+If this session advanced a feature tracked in `tasks/`, check off completed sub-tasks in the relevant `tasks-*.md`, and move any finished PRD + task list into `tasks/completed/`. Skip if no tracked feature progressed.
 
-### 2. Update AI Instructions Current State
-!Read /home/runner/workspace/ai_instructions.md
+## 6. Optional: validate before handoff
+Offer to run `npm run check` so the next session doesn't start on a red build. Only run if the user agrees.
 
-Updating the current state section in AI instructions...
-
-!Edit /home/runner/workspace/ai_instructions.md "## Current State (Updated: August 18, 2025)" "## Current State (Updated: August 18, 2025 - Session End)"
-
-### 3. Update Claude Session Onboarding Document
-!Read /home/runner/workspace/docs/CLAUDE_SESSION_ONBOARDING.md
-
-Refreshing the onboarding document date...
-
-!Edit /home/runner/workspace/docs/CLAUDE_SESSION_ONBOARDING.md "*Updated: August 18, 2025*" "*Updated: August 18, 2025 - Latest Session Sync*"
-
-### 4. Update Main Documentation Hub
-!Read /home/runner/workspace/docs/README.md
-
-Ensuring the main README reflects current status...
-
-### 5. Update Handoff Summary
-!Read /home/runner/workspace/docs/HANDOFF_SUMMARY.md
-
-## 📋 Documentation Update Summary
-
-✅ **Files Updated:**
-- DEVELOPMENT_STATUS.md - Phase status refreshed and priorities confirmed
-- ai_instructions.md - Current state section updated  
-- docs/CLAUDE_SESSION_ONBOARDING.md - Onboarding document refreshed
-- docs/README.md - Main documentation hub verified
-- docs/HANDOFF_SUMMARY.md - Development handoff info current
-
-✅ **Project Status Confirmed:**
-- **Phase**: Post-MVP Development (MVP completed August 2025)
-- **Playability**: Fully functional strategic simulation game
-- **Architecture**: React 18 + TypeScript + Node.js + PostgreSQL
-- **Documentation**: Comprehensive strategic + technical documentation
-
-✅ **Key Systems Documented:**
-- Complete 52-week campaign with scoring and victory conditions
-- Artist discovery, signing, and management systems  
-- Project creation workflow (Singles, EPs, Mini-Tours)
-- Role-based dialogue system with 72+ dialogue choices
-- Resource management (money, reputation, access tiers)
-- Save/load system with multiple slots and JSON export
-- Campaign completion screen with restart functionality
-
-## 🚀 Session End Complete
-
-**Music Label Manager** documentation has been synchronized for post-MVP development phase and is ready for the next session.
-
-**Session Notes**: $ARGUMENTS
-
-**Next Steps**: 
-- All documentation reflects current 98% MVP completion status
-- Use `/onboard` command at start of next session for full context
-- Consider committing documentation updates to preserve session state
-- Project ready for continued development or team handoff
-
-**Final Status**: Documentation sync complete - project ready for next session or handoff.
+## 7. Wrap up
+- Summarize exactly which files were updated.
+- Remind the user these doc updates should be committed (prefer a branch, e.g. `docs/session-<date>`), and offer to do it.
+- Confirm: next session should start with `/onboard`.
 
 ---
-*Session ended and documented: August 18, 2025*
+*This command keeps `DEVELOPMENT_STATUS.md` current as the cross-session handoff. Paths are repo-relative so it works on any machine.*

--- a/DEVELOPMENT_STATUS.md
+++ b/DEVELOPMENT_STATUS.md
@@ -23,6 +23,28 @@
 
 ---
 
+## 🗂️ Backlog / Candidate Work
+*Compiled June 30, 2026 from the docs review + onboarding. Pick from here next session.*
+
+**Quick wins**
+- [ ] **Tech-debt Comment 25** — `ClerkProvider` appearance cast to `any` in `client/src/main.tsx`; tighten typing. Small/isolated. (See `docs/09-troubleshooting/technical-debt-backlog.md`.)
+- [ ] **Patch doc index files** — `docs/README.md` + `docs/claude.md` don't list `98-research/` or `api-specifications/` (invisible to navigation).
+- [ ] **Reconcile focus-slot unlock values** — engine hardcodes `reputation ≥ 50` (`shared/engine/game-engine.ts:~350`), but `data/balance/projects.json` says week 26 and `data/balance/progression.json` says rep 18. Collapse to one source of truth; only the hardcoded value runs.
+
+**Medium**
+- [ ] **Verify the financial bug** — `docs/98-research/FINANCIAL_CALCULATION_BUG_ANALYSIS.md` documents a dual-path revenue/expense bug; confirm whether it was fixed in current code.
+- [ ] **Tech-debt Comment 26** — `client/src/pages/ArtistPage.tsx` is monolithic; split into memoized subcomponents. Larger refactor.
+- [ ] **Add a GameEngine architecture doc** — `02-architecture/` has no dedicated doc for the core shared `GameEngine`, despite its centrality.
+
+**Feature threads** (from `docs/01-planning/`)
+- [ ] **Artist-mood plan** — paused after Phase 5 (Oct 12, 2025), resumable. (`implementation-specs/[IN-PROGRESS] artist-mood-plan.md`)
+- [ ] **Artist-contract-system refactor** — flagged as next target; dependency map exists (`implementation-specs/artist-contract-system-dependencies.md`).
+
+**Housekeeping**
+- [ ] Merge open PRs **#24** (queryClient fix), **#25** (weekly-workflow docs), **#26** (session workflow), then resync local `main`.
+
+---
+
 ## 🚀 **MAJOR SYSTEM REFACTORING - SEPTEMBER 24, 2025**
 
 ### **MASSIVE MONTH-TO-WEEK CONVERSION COMPLETE**

--- a/DEVELOPMENT_STATUS.md
+++ b/DEVELOPMENT_STATUS.md
@@ -1,6 +1,25 @@
 # Music Label Manager - Development Status
 **Single Source of Truth for Current Progress**
-*Updated: October 15, 2025*
+*Updated: June 30, 2026*
+
+---
+
+## 📅 Session Log — June 30, 2026
+
+**First session back after ~8 months away.** Focus was re-orientation, repo hygiene, and documentation accuracy. No gameplay/feature changes.
+
+**Done this session:**
+- **Synced local `main`** — it was 2 PRs behind `origin/main`; fast-forwarded 8 commits to `27f4d3d` (also pruned two malformed `ux-prototypes` files).
+- **Fixed a TypeScript build break** — `client/src/lib/queryClient.ts` default `queryFn` was typed over a too-narrow `QueryKeyWithUrl`, unassignable to TanStack's `QueryKey` slot (TS2322). Retyped over `QueryKey`; runtime URL contract still enforced by `extractUrlFromQueryKey`. `npm run check` now passes. → branch `fix/queryclient-querykey-type`, **PR #24**.
+- **Reviewed all of `docs/`** (6-agent fan-out). Headline: well-organized but two-tier currency; two core flow docs still described the obsolete monthly loop.
+- **Converted the two stale flow docs to the weekly (52-week) system** — `docs/03-workflows/game-system-workflows.md` + `user-interaction-flows.md`, with code-verified corrections (decay is ~15%/week not /month; weekly burn $3–6k base + ~$1,200/artist/wk; song gen Single 2/wk, EP 3/wk; starting money $500k; campaign ends week 52). → branch `docs/weekly-workflow-conversion`.
+- **Fixed the `/session-end` command** (was broken: hardcoded Linux paths, frozen dates, missing files) and added this session-log convention. → branch `chore/session-workflow`.
+
+**Open threads / next steps:**
+- **Focus-slot unlock has 3 conflicting config values** — engine hardcodes `reputation ≥ 50` (`shared/engine/game-engine.ts:350`), but `data/balance/projects.json` says week 26 and `data/balance/progression.json` says rep 18. Only the hardcoded `≥ 50` runs. Worth reconciling. *(Note: this DEVELOPMENT_STATUS doc's older "Focus Slots unlock at week 26" claim is also wrong vs the engine.)*
+- **Open PRs/branches to merge or close**: PR #24 (queryClient), plus local branches `docs/weekly-workflow-conversion` and `chore/session-workflow` (not yet pushed).
+- **Two open tech-debt items** per `docs/09-troubleshooting/technical-debt-backlog.md`: Comment 25 (`ClerkProvider` `any` cast in `client/src/main.tsx` — quick win) and Comment 26 (`ArtistPage.tsx` is monolithic — larger refactor).
+- **Docs still on the legacy monthly framing** in spots; index files (`docs/README.md`, `docs/claude.md`) don't list `98-research/` or `api-specifications/`.
 
 ---
 


### PR DESCRIPTION
## Summary

The `/session-end` slash command was non-functional and `DEVELOPMENT_STATUS.md` had drifted ~8 months stale. This repairs the cross-session documentation workflow.

## Changes

**`.claude/commands/session-end.md`** — was broken:
- Hardcoded `/home/runner/workspace/...` Linux paths (don't resolve on Windows)
- Frozen Aug-2025 dates baked into the command
- Referenced files that no longer exist (`docs/CLAUDE_SESSION_ONBOARDING.md`, `docs/HANDOFF_SUMMARY.md`)

Rewritten to be **repo-relative and portable**, pointing only at files that exist (`DEVELOPMENT_STATUS.md`, `ai_instructions.md`, `tasks/`), and establishing a dated **Session Log** convention as the handoff mechanism.

**`DEVELOPMENT_STATUS.md`** — refreshed Oct 2025 → Jun 2026 with a session-log entry capturing recent work and open threads (focus-slot config discrepancy, open branches/PRs, tech-debt items).

## Workflow going forward
`/onboard` at session start → work → `/session-end` at end (updates the log) → commit on a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)