### PR TITLE
fix: reconcile focus-slot unlock to a single config source of truth

### DIFF
--- a/DEVELOPMENT_STATUS.md
+++ b/DEVELOPMENT_STATUS.md
@@ -14,9 +14,11 @@
 - **Reviewed all of `docs/`** (6-agent fan-out). Headline: well-organized but two-tier currency; two core flow docs still described the obsolete monthly loop.
 - **Converted the two stale flow docs to the weekly (52-week) system** — `docs/03-workflows/game-system-workflows.md` + `user-interaction-flows.md`, with code-verified corrections (decay is ~15%/week not /month; weekly burn $3–6k base + ~$1,200/artist/wk; song gen Single 2/wk, EP 3/wk; starting money $500k; campaign ends week 52). → branch `docs/weekly-workflow-conversion`.
 - **Fixed the `/session-end` command** (was broken: hardcoded Linux paths, frozen dates, missing files) and added this session-log convention. → branch `chore/session-workflow`.
+- **Reconciled the focus-slot unlock discrepancy (quick win #1)** — collapsed the 3 conflicting values to one source of truth. Canonical = `data/balance/progression.json → progression_thresholds.fourth_focus_slot_reputation`, set to **50** (preserves the previously shipped behavior). The engine now **reads** the threshold + base + max from config instead of hardcoding (`shared/engine/game-engine.ts:349`). Deleted the misnamed week-26 `focus_slots_unlock_threshold` from `projects.json` and its loaders/type (`data/balance.ts`, `shared/utils/dataLoader.ts`, `shared/types/gameTypes.ts`, `scripts/archive/compile-balance.ts`); set the rep value to 50 in `world.json` + the `gameData.ts` sync fallback; fixed `database-design.md` (`focus_slots DEFAULT 2 → 3`). `npm run check` passes. → branch TBD.
 
 **Open threads / next steps:**
-- **Focus-slot unlock has 3 conflicting config values** — engine hardcodes `reputation ≥ 50` (`shared/engine/game-engine.ts:350`), but `data/balance/projects.json` says week 26 and `data/balance/progression.json` says rep 18. Only the hardcoded `≥ 50` runs. Worth reconciling. *(Note: this DEVELOPMENT_STATUS doc's older "Focus Slots unlock at week 26" claim is also wrong vs the engine.)*
+- **(Out of scope, flagged) UI focus-slot cap** — `client/src/components/ActionSelectionPool.tsx:209` hardcodes `selectedActions.length >= 3` with a `// TODO: Use gameState.focusSlots`, so the selection UI may still cap at 3 even after the 4th slot unlocks. Worth a follow-up.
+- **(Historical only)** the Sept-2025 refactoring log below still says "Focus Slots: Unlock at week 26"; left as-is as a point-in-time record, but it does not reflect current behavior (reputation ≥ 50).
 - **Open PRs/branches to merge or close**: PR #24 (queryClient), plus local branches `docs/weekly-workflow-conversion` and `chore/session-workflow` (not yet pushed).
 - **Two open tech-debt items** per `docs/09-troubleshooting/technical-debt-backlog.md`: Comment 25 (`ClerkProvider` `any` cast in `client/src/main.tsx` — quick win) and Comment 26 (`ArtistPage.tsx` is monolithic — larger refactor).
 - **Docs still on the legacy monthly framing** in spots; index files (`docs/README.md`, `docs/claude.md`) don't list `98-research/` or `api-specifications/`.
@@ -29,7 +31,7 @@
 **Quick wins**
 - [ ] **Tech-debt Comment 25** — `ClerkProvider` appearance cast to `any` in `client/src/main.tsx`; tighten typing. Small/isolated. (See `docs/09-troubleshooting/technical-debt-backlog.md`.)
 - [ ] **Patch doc index files** — `docs/README.md` + `docs/claude.md` don't list `98-research/` or `api-specifications/` (invisible to navigation).
-- [ ] **Reconcile focus-slot unlock values** — engine hardcodes `reputation ≥ 50` (`shared/engine/game-engine.ts:~350`), but `data/balance/projects.json` says week 26 and `data/balance/progression.json` says rep 18. Collapse to one source of truth; only the hardcoded value runs.
+- [x] **Reconcile focus-slot unlock values** — ✅ Done June 30, 2026. Canonical source = `progression.json → fourth_focus_slot_reputation` (set to 50); engine reads threshold/base/max from config; deleted the dead week-26 `focus_slots_unlock_threshold`. See session log above.
 
 **Medium**
 - [ ] **Verify the financial bug** — `docs/98-research/FINANCIAL_CALCULATION_BUG_ANALYSIS.md` documents a dual-path revenue/expense bug; confirm whether it was fixed in current code.

--- a/data/balance.ts
+++ b/data/balance.ts
@@ -48,7 +48,6 @@ const balance = {
   time_progression: {
     campaign_length_weeks: projects.time_progression.campaign_length_weeks,
     focus_slots_base: projects.time_progression.focus_slots_base,
-    focus_slots_unlock_threshold: projects.time_progression.focus_slots_unlock_threshold,
     focus_slots_max: projects.time_progression.focus_slots_max,
     project_durations: projects.time_progression.project_durations,
     seasonal_modifiers: markets.seasonal_modifiers

--- a/data/balance/progression.json
+++ b/data/balance/progression.json
@@ -91,7 +91,7 @@
   
   "progression_thresholds": {
     "second_artist_reputation": 10,
-    "fourth_focus_slot_reputation": 18,
+    "fourth_focus_slot_reputation": 50,
     "playlist_niche_streams": 100000,
     "press_blogs_pickups": 2,
     "venue_clubs_sellouts": 2,

--- a/data/balance/projects.json
+++ b/data/balance/projects.json
@@ -4,11 +4,10 @@
     "_dev_note_campaign_length": "UPDATED: Campaign now runs for full calendar year (52 weeks)",
     "_dev_note_locations": [
       "COMPLETED: client/src/components/GameSidebar.tsx - Updated to Week XX/52 display",
-      "COMPLETED: client/src/pages/PlanReleasePage.tsx - Updated to week <= 52 check",
-      "COMPLETED: Adjusted focus_slots_unlock_threshold to week 26 (halfway through 52-week campaign)"
+      "COMPLETED: client/src/pages/PlanReleasePage.tsx - Updated to week <= 52 check"
     ],
+    "_dev_note_focus_slots": "The 4th-slot unlock is REPUTATION-based and lives in progression.json -> progression_thresholds.fourth_focus_slot_reputation (canonical). Only focus_slots_base/max live here.",
     "focus_slots_base": 3,
-    "focus_slots_unlock_threshold": 26,
     "focus_slots_max": 4,
     
     "project_durations": {

--- a/data/world.json
+++ b/data/world.json
@@ -32,7 +32,7 @@
     "press_blogs_pickups": 2,
     "venue_clubs_sellouts": 2,
     "second_artist_reputation": 10,
-    "fourth_focus_slot_reputation": 18
+    "fourth_focus_slot_reputation": 50
   },
   "rng_band": [
     0.9,

--- a/docs/02-architecture/database-design.md
+++ b/docs/02-architecture/database-design.md
@@ -52,7 +52,7 @@ CREATE TABLE game_states (
   money INTEGER DEFAULT 500000,
   reputation INTEGER DEFAULT 10,
   creative_capital INTEGER DEFAULT 15,
-  focus_slots INTEGER DEFAULT 2,
+  focus_slots INTEGER DEFAULT 3,
   used_focus_slots INTEGER DEFAULT 0,
   
   -- Access Tiers

--- a/docs/09-troubleshooting/technical-debt-backlog.md
+++ b/docs/09-troubleshooting/technical-debt-backlog.md
@@ -8,11 +8,11 @@
 ## 📋 **Document Information**
 
 - **Created**: September 2025 (Artist Mood System Implementation - commit `4991ab3`)
-- **Last Updated**: October 19, 2025
-- **Total Items**: 28
+- **Last Updated**: June 30, 2026
+- **Total Items**: 29
 - **Completed**: 26
 - **In Progress**: 0
-- **Pending**: 2
+- **Pending**: 3
 
 ---
 
@@ -339,6 +339,22 @@ Some interactive elements lack clear focus management and aria attributes (Inbox
 
 ## 🟡 **High Priority Items**
 
+### [ ] Comment 29: ActionSelectionPool hardcodes 3-slot selection cap
+**Priority**: 🟡 High
+**Impact**: Gameplay correctness — defeats the 4th focus slot
+**Effort**: Low
+
+`ActionSelectionPool.tsx:209` computes `isDisabled = !isSelected && selectedActions.length >= 3` with a `// TODO: Use gameState.focusSlots from props`. The literal `3` means that even after a player unlocks the 4th focus slot (reputation ≥ 50, see `shared/engine/game-engine.ts:349` and `data/balance/progression.json → progression_thresholds.fourth_focus_slot_reputation`), this selection UI still caps them at 3 actions per week — so the unlocked slot may be unusable from this component.
+
+**Action**: Replace the literal `3` with the player's actual slot count from `gameState.focusSlots` (threaded through props), so the cap tracks the unlocked value.
+
+**Relevant Files**:
+- [client/src/components/ActionSelectionPool.tsx](client/src/components/ActionSelectionPool.tsx)
+
+*Identified June 30, 2026 during the focus-slot unlock reconciliation.*
+
+---
+
 ### ~~Comment 27: Components bypass apiRequest~~ 🟠.
 **Status**: 🟠. **COMPLETED** (October 19, 2025)
 
@@ -463,14 +479,14 @@ ArtistPage is very large and monolithic; split into subcomponents and memoize he
 
 ### By Priority
 - 🔴 Critical: 0 items (all completed! 🎉)
-- 🟡 High: 0 items (down from 3)
-- 🟢 Medium: 1 item (down from 17)
-- ?? Low: 1 item (down from 1)
+- 🟡 High: 1 item (Comment 29)
+- 🟢 Medium: 1 item (Comment 25)
+- 🔵 Low: 1 item (Comment 26)
 
 ### By Status
-- ✅ Completed: 26 items (92.9%)
+- ✅ Completed: 26 items (89.7%)
 - 🚧 In Progress: 0 items (0%)
-- 📋 Pending: 2 items (7.1%)
+- 📋 Pending: 3 items (10.3%)
 
 ---
 

--- a/scripts/archive/compile-balance.ts
+++ b/scripts/archive/compile-balance.ts
@@ -98,7 +98,6 @@ async function compileBalance() {
     time_progression: {
       campaign_length_weeks: projects.time_progression.campaign_length_weeks,
       focus_slots_base: projects.time_progression.focus_slots_base,
-      focus_slots_unlock_threshold: projects.time_progression.focus_slots_unlock_threshold,
       focus_slots_max: projects.time_progression.focus_slots_max,
       project_durations: projects.time_progression.project_durations,
       seasonal_modifiers: markets.seasonal_modifiers  // THIS WAS MISSING! From balance.ts line 54

--- a/server/data/gameData.ts
+++ b/server/data/gameData.ts
@@ -636,7 +636,7 @@ export class ServerGameData {
     if (!this.balanceData) {
       return {
         second_artist_reputation: 10,
-        fourth_focus_slot_reputation: 18,
+        fourth_focus_slot_reputation: 50,
         label_size_thresholds: {
           local: 0,
           regional: 25,

--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -346,14 +346,20 @@ export class GameEngine {
     
     console.log(`[MONEY UPDATE] Starting: $${weekStartMoney}, Revenue: $${summary.revenue}, Expenses: $${summary.expenses}, Final: $${finalMoney}`);
     
-    // Check for focus slot unlock at 50+ reputation
-    if (this.gameState.reputation && this.gameState.reputation >= 50) {
-      const currentSlots = this.gameState.focusSlots || 3;
-      if (currentSlots < 4) {
-        this.gameState.focusSlots = 4;
+    // Check for focus slot unlock — config-driven (single source of truth):
+    //   threshold: data/balance/progression.json -> progression_thresholds.fourth_focus_slot_reputation
+    //   base/max:  data/balance/projects.json     -> time_progression.focus_slots_base / focus_slots_max
+    const focusBalance = this.gameData.getBalanceConfigSync();
+    const focusSlotUnlockReputation = focusBalance?.progression_thresholds?.fourth_focus_slot_reputation ?? 50;
+    const focusSlotsBase = focusBalance?.time_progression?.focus_slots_base ?? 3;
+    const focusSlotsMax = focusBalance?.time_progression?.focus_slots_max ?? 4;
+    if (this.gameState.reputation && this.gameState.reputation >= focusSlotUnlockReputation) {
+      const currentSlots = this.gameState.focusSlots || focusSlotsBase;
+      if (currentSlots < focusSlotsMax) {
+        this.gameState.focusSlots = focusSlotsMax;
         summary.changes.push({
           type: 'unlock',
-          description: 'Fourth focus slot unlocked! You can now select 4 actions per week.'
+          description: `Fourth focus slot unlocked! You can now select ${focusSlotsMax} actions per week.`
         });
         console.log('[UNLOCK] Fourth focus slot unlocked at reputation', this.gameState.reputation);
       }

--- a/shared/types/gameTypes.ts
+++ b/shared/types/gameTypes.ts
@@ -204,7 +204,6 @@ export interface BalanceConfig {
   time_progression: {
     campaign_length_weeks: number;
     focus_slots_base: number;
-    focus_slots_unlock_threshold: number;
     focus_slots_max: number;
     project_durations: Record<string, number[]>;
     seasonal_modifiers: Record<string, number>;

--- a/shared/utils/dataLoader.ts
+++ b/shared/utils/dataLoader.ts
@@ -265,7 +265,6 @@ export class GameDataLoader {
       time_progression: {
         campaign_length_weeks: projects.time_progression.campaign_length_weeks,
         focus_slots_base: projects.time_progression.focus_slots_base,
-        focus_slots_unlock_threshold: projects.time_progression.focus_slots_unlock_threshold,
         focus_slots_max: projects.time_progression.focus_slots_max,
         project_durations: projects.time_progression.project_durations,
         seasonal_modifiers: markets.seasonal_modifiers // CORRECTLY ASSEMBLED HERE


### PR DESCRIPTION
## Summary

The 4th focus slot had **three conflicting config values** — the engine hardcoded `reputation >= 50`, `projects.json` said week 26, and `progression.json` said reputation 18 — of which **only the hardcoded 50 actually ran**. This collapses them to one reputation-based source of truth and makes the engine config-driven, **preserving the previously shipped behavior** (`rep >= 50`).

## Changes

- **Canonical key:** `data/balance/progression.json -> progression_thresholds.fourth_focus_slot_reputation`, set to `50` (mirrored in `world.json` and the `gameData.ts` sync fallback).
- **Engine is config-driven:** `shared/engine/game-engine.ts` now reads threshold/base/max from `getBalanceConfigSync()` (fallbacks `50/3/4`) instead of hardcoding.
- **Removed the red herring:** deleted the misnamed week-26 `focus_slots_unlock_threshold` from `projects.json` and its loaders/type (`data/balance.ts`, `shared/utils/dataLoader.ts`, `shared/types/gameTypes.ts`, `scripts/archive/compile-balance.ts`).
- **Doc fix:** `docs/02-architecture/database-design.md` corrected `focus_slots DEFAULT 2 -> 3` to match `shared/schema.ts`.
- **Tracking:** logged in `DEVELOPMENT_STATUS.md`; filed the related UI bug (`ActionSelectionPool.tsx:209` hardcodes a 3-action cap that defeats the 4th slot) as tech-debt **Comment 29**.

## Validation

- `npm run check` (full `tsc`) passes.
- No behavior change: the unlock still fires at `reputation >= 50`.
- Engine integration test requires a live Postgres test DB (not configured in this environment), so it was skipped — not affected by this change.

## Follow-up (not in this PR)

Tech-debt **Comment 29**: `ActionSelectionPool.tsx:209` hardcodes `selectedActions.length >= 3`, so the selection UI may still cap players at 3 actions even after the 4th slot unlocks. Low-effort fix tracked in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)