### PR TITLE
docs: CLAUDE.md guidance from PR #29 session (testing/CI, snapshots, cache, git hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ nul
 # Claude Code local (per-user) settings
 .claude/settings.local.json
 
+# Merge/patch artifacts (never commit these)
+*.orig
+*.rej
+
 # Playwright
 /test-results/
 /playwright-report/

--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -46,7 +46,7 @@
 
 **Cache Management:**
 - Use TanStack Query for server data
-- After week advancement: invalidate `['artist-roi']`, `['executives']`, `['emails']`
+- After week advancement, invalidate server-data queries so new state shows immediately. ⚠️ TanStack matches query keys **element-by-element**, not by string prefix: invalidating `['emails']` does NOT match the scoped email keys `['emails:list', gameId]` / `['emails:unread-count', gameId]`. Use a predicate (`invalidateQueries({ predicate: q => q.queryKey[0] === EMAIL_LIST_SCOPE || q.queryKey[0] === EMAIL_UNREAD_SCOPE })`) or the exact scoped keys. Also invalidate `['artist-roi']`, `['executives']`.
 
 ## XState Machines
 - `machines/executiveMeetingMachine.ts` - Multi-step executive meeting flows


### PR DESCRIPTION
Captures workflow learnings from the email-snapshot/save-load session so they don't have to be rediscovered:

- **Testing/CI reality** — vitest needs a Docker Postgres on :5433; `drizzle-kit push` skips raw-SQL CHECK constraints; CI runs Playwright only (vitest is local-only). Tests must mirror production data shapes.
- **Save/Load Snapshots** (new section) — `musicLabel` is a sibling of `gameState`, not nested; snapshot is built in two places; `SNAPSHOT_VERSION` rules. (This was the #1 review bug.)
- **Cache guidance fix** — `['emails']` never matched the scoped `emails:list`/`emails:unread-count` keys (TanStack matches element-wise); use a predicate. (Root cause of review bug #3.)
- **Git & Branch Workflow** (new section) — selective `git add`, merge main into stale branches before building, keep session docs off feature PRs.
- **.gitignore** `*.orig`/`*.rej`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)