### PR TITLE
chore: add missing drizzle-kit scripts; fix stale commands in CLAUDE.md (C39)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ TypeScript monorepo with Express backend and React frontend for a music industry
 **Emergency Recovery**:
 ```bash
 # If migrations are stuck:
-psql $DATABASE_URL < drizzle/migrations/XXXX.sql
+psql $DATABASE_URL < migrations/XXXX.sql
 npm run check          # Validate TypeScript
 npm run db:studio     # Verify in database
 ```
@@ -80,10 +80,10 @@ npm run db:studio     # Verify in database
 
 ## ✅ Validation Commands
 - `npm run check` - Run TypeScript compilation check
-- `npm run dev` - Starts both client and server with hot reload
-- `npm test` - Run tests in watch mode
+- `npm run dev` - Starts the dev server (single Express process on port 5000 with Vite as middleware — no separate client dev server)
+- `npm test` - Run tests once (alias of `test:run`; for watch mode use `npx vitest`)
 - `npm run test:run` - Run tests once (CI mode)
-- `pkill -f "tsx server"` - Clean up any lingering server processes
+- `npx kill-port 5000` - Clean up a lingering dev server (Windows-friendly; `pkill -f "tsx server"` on POSIX)
 
 ## 🧪 Testing Framework
 - **Framework**: Vitest (native Vite integration, Jest-compatible API)
@@ -91,7 +91,7 @@ npm run db:studio     # Verify in database
 - **Test Files**: Use `*.test.ts` or `*.spec.ts` naming convention
 - **Setup**: Global test configuration in `tests/setup.ts`
 - **Structure**: Wrap tests in `describe()` blocks, use `it()` or `test()` for assertions
-- **Commands**: `npm test` (watch), `npm run test:ui` (interactive UI), `npm run test:coverage` (coverage report)
+- **Commands**: `npm test` (single run), `npx vitest` (watch), `npm run test:ui` (interactive UI), `npm run test:coverage` (coverage report)
 - **Database**: **NEVER** import `server/db` in tests - always use `createTestDatabase()` from `tests/helpers/test-db` to avoid polluting production database
 - **Integration DB setup**: integration tests hit a real Postgres on `localhost:5433` (Docker container `music-label-test`, db `music_label_test`, user/pass `postgres`). Start it, then provision schema — but ⚠️ `drizzle-kit push` does **NOT** create the raw-SQL `CHECK` constraints (e.g. `artists_mood_check`), so apply the SQL migrations (`migrations/*.sql`, at least `0020`) or `artist-mood-constraints.test.ts` fails on a fresh DB.
 - **CI coverage gap**: CI (`.github/workflows/playwright.yml`) runs **Playwright only** — the vitest suite is **NOT** in CI. Run `npm run test:run` **locally** before trusting vitest results.

--- a/docs/09-troubleshooting/technical-debt-backlog.md
+++ b/docs/09-troubleshooting/technical-debt-backlog.md
@@ -10,9 +10,9 @@
 - **Created**: September 2025 (Artist Mood System Implementation - commit `4991ab3`)
 - **Last Updated**: July 1, 2026
 - **Total Items**: 39
-- **Completed**: 36
+- **Completed**: 37
 - **In Progress**: 0
-- **Pending**: 3
+- **Pending**: 2
 
 ---
 
@@ -579,20 +579,18 @@ ArtistPage is very large and monolithic; split into subcomponents and memoize he
 
 ---
 
-### [ ] Comment 39: CLAUDE.md references npm scripts that don't exist in package.json
-**Priority**: 🔵 Low
-**Impact**: Developer/AI-session guidance accuracy (misleading instructions every session)
-**Effort**: Low
+### ~~Comment 39: CLAUDE.md references npm scripts that don't exist in package.json~~ ✅
+**Status**: ✅ **COMPLETED** (July 1, 2026)
 
-Root `CLAUDE.md` has drifted from `package.json`: the "Database & Migrations" and "Validation Commands" sections reference `npm run db:generate`, `npm run db:studio`, and `npm run db:introspect`, none of which exist as scripts (only `db:push` and `db:cleanup-orphaned` do). `npm test` is described as "watch mode" but is defined as `vitest run` (single run; watch would be bare `vitest`). `pkill -f "tsx server"` is a Linux command documented for a Windows dev environment.
+**Resolution**: Added the missing scripts to `package.json` rather than deleting the documented workflow — `db:generate` (`drizzle-kit generate`), `db:studio` (`drizzle-kit studio`), `db:introspect` (`drizzle-kit introspect`); all three commands are supported by the installed drizzle-kit 0.30.4 and `docs/06-development/database-practices.md` documents them extensively as the intended workflow. Fixed CLAUDE.md: `npm test` now correctly described as a single run (`vitest run`) with `npx vitest` for watch mode; replaced the POSIX-only `pkill` cleanup line with `npx kill-port 5000`; corrected the dev-server description (single Express process with Vite middleware, not two servers); fixed the emergency-recovery migration path (`migrations/`, not `drizzle/migrations/`).
 
-**Action**: Reconcile CLAUDE.md with the actual scripts — either fix the doc text or add the missing drizzle-kit scripts to `package.json` if they're meant to exist (check `drizzle.config.ts` and `docs/06-development/database-practices.md` for intent). Land on a small docs/chore branch off main.
+Root `CLAUDE.md` had drifted from `package.json`: the "Database & Migrations" and "Validation Commands" sections referenced `npm run db:generate`, `npm run db:studio`, and `npm run db:introspect`, none of which existed as scripts. `npm test` was described as "watch mode" but was defined as `vitest run`. `pkill -f "tsx server"` was a Linux command documented for a Windows dev environment.
 
 **Relevant Files**:
 - [CLAUDE.md](CLAUDE.md)
 - [package.json](package.json)
 
-*Identified July 1, 2026 during the architecture-docs cleanup session.*
+*Identified July 1, 2026 during the architecture-docs cleanup session; resolved same day.*
 
 ---
 
@@ -650,12 +648,12 @@ The `"{label} - Week {n}"` format is constructed independently in `client/src/st
 - 🔴 Critical: 0 items (all completed! 🎉)
 - 🟡 High: 0 items (all completed! 🎉)
 - 🟢 Medium: 0 items (all completed! 🎉)
-- 🔵 Low: 3 items (C26, C32, C39)
+- 🔵 Low: 2 items (C26, C32)
 
 ### By Status
-- ✅ Completed: 36 items (92.3%)
+- ✅ Completed: 37 items (94.9%)
 - 🚧 In Progress: 0 items (0%)
-- 📋 Pending: 3 items (7.7%)
+- 📋 Pending: 2 items (5.1%)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "test:db:start": "node tests/start-test-db.js",
     "test:db:stop": "node tests/stop-test-db.js",
     "test:db:reset": "node tests/reset-test-db.js",
+    "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio",
+    "db:introspect": "drizzle-kit introspect",
     "db:cleanup-orphaned": "tsx scripts/cleanup-orphaned-games.ts",
     "compile-balance": "tsx scripts/compile-balance.ts"
   },


### PR DESCRIPTION
## Summary
- CLAUDE.md documented `npm run db:generate` / `db:studio` / `db:introspect` but the scripts never existed in package.json. `docs/06-development/database-practices.md` documents them extensively as the intended workflow and the installed drizzle-kit 0.30.4 supports all three commands, so this adds the scripts rather than deleting the docs.
- CLAUDE.md corrections: `npm test` is a single run (`vitest run`), not watch mode; the dev server is one Express process with Vite middleware (not two servers); the POSIX-only `pkill` cleanup line is replaced with `npx kill-port 5000`; the emergency-recovery migration path is `migrations/`, not `drizzle/migrations/`.
- Marks backlog **Comment 39** completed (37/39 done, 2 pending).

## Testing
- `npx drizzle-kit --help` confirms `generate`, `studio`, `introspect` are all valid commands on 0.30.4
- Tooling/docs only — no runtime code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)