### PR TITLE
fix: apply difficulty starting_money_multiplier at game creation

### DIFF
--- a/server/data/gameData.ts
+++ b/server/data/gameData.ts
@@ -1,4 +1,5 @@
 import { gameDataLoader } from '../../shared/utils/dataLoader';
+import { applyStartingMoneyMultiplier, type DifficultyLevel } from '../../shared/utils/startingValues';
 import type { 
   GameDataFiles, 
   GameArtist, 
@@ -209,10 +210,14 @@ export class ServerGameData {
     return this.dataLoader.getWorldConfig();
   }
 
-  async getStartingValues(): Promise<{ money: number; reputation: number; creativeCapital: number }> {
+  async getStartingValues(difficulty: DifficultyLevel = 'normal'): Promise<{ money: number; reputation: number; creativeCapital: number }> {
     const balance = await this.getBalanceConfig();
     return {
-      money: balance.economy.starting_money,
+      money: applyStartingMoneyMultiplier(
+        balance.economy.starting_money,
+        balance.difficulty_modifiers,
+        difficulty
+      ),
       reputation: balance.reputation_system.starting_reputation,
       creativeCapital: balance.reputation_system.starting_creative_capital ?? 0
     };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import {
   getBugReportStats
 } from './utils/bugReportArchival';
 import { seededRandomPick, generateMeetingSeed } from '@shared/utils/seededRandom';
+import { normalizeDifficulty } from '@shared/utils/startingValues';
 
 const EMAIL_CATEGORY_VALUES = [
   "chart",
@@ -512,8 +513,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/game", requireClerkUser, async (req, res) => {
     console.log('🚀 [GAME CREATION] Starting new game creation...');
     try {
-      const { labelData, ...gameStateData } = req.body;
+      const { labelData, difficulty, ...gameStateData } = req.body;
       const validatedData = insertGameStateSchema.parse(gameStateData);
+
+      // MISSING: no UI exposes difficulty selection yet — every game defaults to
+      // 'normal' (1.0x). Passing 'easy'/'hard' applies progression.json's
+      // difficulty_modifiers.starting_money_multiplier (1.5x / 0.7x).
+      const gameDifficulty = normalizeDifficulty(difficulty);
       console.log('📝 [GAME CREATION] Validated data reputation:', validatedData.reputation);
 
       // Validate label data if provided
@@ -525,8 +531,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Ensure serverGameData is initialized before accessing balance config
       await serverGameData.initialize();
 
-      // Set starting values from balance.json configuration
-      const startingValues = await serverGameData.getStartingValues();
+      // Set starting values from balance.json configuration (money scaled by difficulty)
+      const startingValues = await serverGameData.getStartingValues(gameDifficulty);
       // Make these logs more visible
       console.error('🎮🎮🎮 REPUTATION FROM BALANCE:', startingValues.reputation);
       console.error('💰💰💰 MONEY FROM BALANCE:', startingValues.money);
@@ -553,6 +559,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         money: startingValues.money,
         reputation: startingValues.reputation,
         creativeCapital: startingValues.creativeCapital, // FIXED: Use balance.json configuration like money and reputation
+        // Persist difficulty so future systems (reputation_decay, market_variance,
+        // goal_time_extension modifiers) can read it without a schema migration
+        flags: { ...((validatedData.flags as Record<string, unknown>) ?? {}), difficulty: gameDifficulty },
         userId: req.userId  // CRITICAL: Associate game with user
       };
       console.error('✅✅✅ FINAL GAME DATA - Money:', gameDataWithBalance.money, 'Reputation:', gameDataWithBalance.reputation, 'VenueAccess:', gameDataWithBalance.venueAccess);

--- a/shared/utils/startingValues.ts
+++ b/shared/utils/startingValues.ts
@@ -1,0 +1,39 @@
+/**
+ * Starting-value helpers for game creation.
+ *
+ * `difficulty_modifiers` lives in data/balance/progression.json keyed by
+ * easy/normal/hard. Only `starting_money_multiplier` is applied today;
+ * the other modifiers (reputation_decay, market_variance,
+ * goal_time_extension) are still unused.
+ * TODO: apply the remaining difficulty modifiers when a difficulty feature ships.
+ */
+
+export const DIFFICULTY_LEVELS = ['easy', 'normal', 'hard'] as const;
+export type DifficultyLevel = (typeof DIFFICULTY_LEVELS)[number];
+
+/**
+ * Coerces an untrusted value (e.g. from a request body) to a valid
+ * difficulty level, defaulting to 'normal'.
+ */
+export function normalizeDifficulty(value: unknown): DifficultyLevel {
+  if (typeof value === 'string') {
+    const lowered = value.toLowerCase();
+    if ((DIFFICULTY_LEVELS as readonly string[]).includes(lowered)) {
+      return lowered as DifficultyLevel;
+    }
+  }
+  return 'normal';
+}
+
+/**
+ * Applies the difficulty's starting_money_multiplier to the base starting
+ * money. Missing modifiers or an unknown difficulty fall back to 1.0x.
+ */
+export function applyStartingMoneyMultiplier(
+  baseMoney: number,
+  difficultyModifiers: Record<string, Record<string, number>> | undefined | null,
+  difficulty: string
+): number {
+  const multiplier = difficultyModifiers?.[difficulty]?.starting_money_multiplier ?? 1.0;
+  return Math.round(baseMoney * multiplier);
+}

--- a/tests/unit/starting-values-difficulty.test.ts
+++ b/tests/unit/starting-values-difficulty.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyStartingMoneyMultiplier,
+  normalizeDifficulty,
+  DIFFICULTY_LEVELS
+} from '../../shared/utils/startingValues';
+import progression from '../../data/balance/progression.json';
+import economy from '../../data/balance/economy.json';
+
+const modifiers = progression.difficulty_modifiers as Record<string, Record<string, number>>;
+const baseMoney = economy.starting_money as number;
+
+describe('applyStartingMoneyMultiplier', () => {
+  it('applies the real progression.json multipliers to the real economy.json base', () => {
+    expect(applyStartingMoneyMultiplier(baseMoney, modifiers, 'normal')).toBe(baseMoney);
+    expect(applyStartingMoneyMultiplier(baseMoney, modifiers, 'easy')).toBe(
+      Math.round(baseMoney * modifiers.easy.starting_money_multiplier)
+    );
+    expect(applyStartingMoneyMultiplier(baseMoney, modifiers, 'hard')).toBe(
+      Math.round(baseMoney * modifiers.hard.starting_money_multiplier)
+    );
+  });
+
+  it('matches the documented balance values (easy 1.5x, normal 1.0x, hard 0.7x of $500k)', () => {
+    expect(applyStartingMoneyMultiplier(500000, modifiers, 'easy')).toBe(750000);
+    expect(applyStartingMoneyMultiplier(500000, modifiers, 'normal')).toBe(500000);
+    expect(applyStartingMoneyMultiplier(500000, modifiers, 'hard')).toBe(350000);
+  });
+
+  it('falls back to 1.0x for an unknown difficulty key', () => {
+    expect(applyStartingMoneyMultiplier(baseMoney, modifiers, 'brutal')).toBe(baseMoney);
+  });
+
+  it('falls back to 1.0x when modifiers are missing entirely', () => {
+    expect(applyStartingMoneyMultiplier(baseMoney, undefined, 'easy')).toBe(baseMoney);
+    expect(applyStartingMoneyMultiplier(baseMoney, null, 'hard')).toBe(baseMoney);
+  });
+
+  it('falls back to 1.0x when the difficulty entry lacks starting_money_multiplier', () => {
+    expect(applyStartingMoneyMultiplier(1000, { easy: {} }, 'easy')).toBe(1000);
+  });
+
+  it('rounds to a whole dollar amount', () => {
+    expect(applyStartingMoneyMultiplier(1001, { hard: { starting_money_multiplier: 0.7 } }, 'hard')).toBe(701);
+  });
+});
+
+describe('normalizeDifficulty', () => {
+  it('accepts each valid difficulty level', () => {
+    for (const level of DIFFICULTY_LEVELS) {
+      expect(normalizeDifficulty(level)).toBe(level);
+    }
+  });
+
+  it('is case-insensitive', () => {
+    expect(normalizeDifficulty('HARD')).toBe('hard');
+    expect(normalizeDifficulty('Easy')).toBe('easy');
+  });
+
+  it('defaults to normal for unknown or non-string input', () => {
+    expect(normalizeDifficulty('brutal')).toBe('normal');
+    expect(normalizeDifficulty(undefined)).toBe('normal');
+    expect(normalizeDifficulty(null)).toBe('normal');
+    expect(normalizeDifficulty(42)).toBe('normal');
+    expect(normalizeDifficulty({})).toBe('normal');
+  });
+});


### PR DESCRIPTION
## Summary
`data/balance/progression.json` has defined `difficulty_modifiers` (easy 1.5x / normal 1.0x / hard 0.7x `starting_money_multiplier`) since the config was written, and the values are loaded into the balance object and typed — but nothing ever read them. `getStartingValues()` returned `economy.starting_money` unmodified, so the config was dead. (Found during the architecture-docs verification pass.)

This wires the multiplier through with **zero behavior change** for existing flows:

- **`shared/utils/startingValues.ts`** (new): pure helpers `normalizeDifficulty()` and `applyStartingMoneyMultiplier()` — kept out of `server/` so they are unit-testable without importing `server/db`
- **`serverGameData.getStartingValues(difficulty = ''normal'')`**: applies the multiplier; unknown difficulty or missing modifiers fall back to 1.0x
- **`POST /api/game`**: accepts an optional `difficulty` field (coerced to `easy|normal|hard`, defaults to `normal`) and persists it in `game_states.flags.difficulty` so the still-unused modifiers (`reputation_decay`, `market_variance`, `goal_time_extension`) can be implemented later without a schema migration
- **MISSING annotation** in routes.ts: no UI exposes difficulty selection yet, so every game today still starts at the normal 1.0x values ($500k / 5 rep / 10 creative capital)

## Testing
- `npm run check` green
- Full vitest suite **541/541** passing locally against the Docker test DB (CI runs Playwright only)
- 9 new unit tests: real progression.json/economy.json values (easy $750k, normal $500k, hard $350k), unknown-difficulty and missing-modifier fallbacks, rounding, and request-input coercion

🤖 Generated with [Claude Code](https://claude.com/claude-code)