### PR TITLE
fix(ui): overflow and layout fixes (save modal, avatars, dashboard)

### DIFF
--- a/client/src/components/MetricsDashboard.tsx
+++ b/client/src/components/MetricsDashboard.tsx
@@ -201,6 +201,12 @@ export function MetricsDashboard() {
   const netProfitLoss = stats.revenue - stats.expenses;
   const reputationChange = getReputationChange();
 
+  // Whole-dollar display with the sign before the $ ("-$16,688", not "$-16,687.5")
+  const formatMoney = (amount: number) =>
+    `${amount < 0 ? '-' : ''}$${Math.abs(Math.round(amount)).toLocaleString()}`;
+  const formatSignedMoney = (amount: number) =>
+    amount >= 0 ? `+${formatMoney(amount)}` : formatMoney(amount);
+
   const renderExpenseBreakdown = () => {
     if (!stats.expenseBreakdown) {
       return <div className="text-xs text-black/50">No expense breakdown available</div>;
@@ -354,10 +360,12 @@ export function MetricsDashboard() {
         
         {/* Desktop Layout */}
         <div className="hidden lg:block">
-          <div className="grid grid-cols-11 gap-6">
-            
+          {/* Sections sit side-by-side only at xl+; below that they stack so the
+              money figures don't overflow their ~70px grid cells */}
+          <div className="grid grid-cols-1 xl:grid-cols-11 gap-4 xl:gap-6">
+
             {/* Core Status Section */}
-            <div className="col-span-3 bg-brand-dark-card/[0.66] rounded-[8px] p-4 border border-brand-purple-light">
+            <div className="xl:col-span-3 min-w-0 bg-brand-dark-card/[0.66] rounded-[8px] p-4 border border-brand-purple-light">
               <h3 className="text-xs font-semibold text-white/50 uppercase tracking-wider mb-3 flex items-center">
                 <i className="fas fa-tachometer-alt mr-2 text-brand-burgundy"></i>
                 Core Status
@@ -387,7 +395,7 @@ export function MetricsDashboard() {
             </div>
 
             {/* Weekly Performance Section */}
-            <div className="col-span-5 bg-brand-dark-card/[0.66] rounded-[8px] p-4 border border-brand-purple-light">
+            <div className="xl:col-span-5 min-w-0 bg-brand-dark-card/[0.66] rounded-[8px] p-4 border border-brand-purple-light">
               <h3 className="text-xs font-semibold text-white/50 uppercase tracking-wider mb-3 flex items-center">
                 <i className="fas fa-chart-line mr-2 text-green-600"></i>
                 Weekly Performance
@@ -405,7 +413,7 @@ export function MetricsDashboard() {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div className="cursor-help">
-                        <div className="text-lg font-bold text-emerald-600">${stats.revenue.toLocaleString()}</div>
+                        <div className="text-lg font-bold text-emerald-600">{formatMoney(stats.revenue)}</div>
                         <div className="text-xs text-white/50">earned</div>
                       </div>
                     </TooltipTrigger>
@@ -418,7 +426,7 @@ export function MetricsDashboard() {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div className="cursor-help">
-                        <div className="text-lg font-bold text-red-600">${stats.expenses.toLocaleString()}</div>
+                        <div className="text-lg font-bold text-red-600">{formatMoney(stats.expenses)}</div>
                         <div className="text-xs text-white/50">spent</div>
                       </div>
                     </TooltipTrigger>
@@ -429,7 +437,7 @@ export function MetricsDashboard() {
                 </div>
                 <div className="text-center">
                   <div className={`text-lg font-bold ${netProfitLoss >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
-                    {netProfitLoss >= 0 ? '+' : ''}${netProfitLoss.toLocaleString()}
+                    {formatSignedMoney(netProfitLoss)}
                   </div>
                   <div className="text-xs text-white/50">{netProfitLoss >= 0 ? 'profit' : 'loss'}</div>
                 </div>
@@ -437,7 +445,7 @@ export function MetricsDashboard() {
             </div>
 
             {/* Access Tiers Section */}
-            <div className="col-span-3 bg-brand-dark-card/[0.66] rounded-[8px] p-4 border border-brand-purple-light">
+            <div className="xl:col-span-3 min-w-0 bg-brand-dark-card/[0.66] rounded-[8px] p-4 border border-brand-purple-light">
               <h3 className="text-xs font-semibold text-white/50 uppercase tracking-wider mb-3 flex items-center">
                 <i className="fas fa-trophy mr-2 text-brand-burgundy-dark"></i>
                 Access Tiers
@@ -518,7 +526,7 @@ export function MetricsDashboard() {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div className="cursor-help">
-                        <div className="text-base font-bold text-emerald-600">${stats.revenue.toLocaleString()}</div>
+                        <div className="text-base font-bold text-emerald-600">{formatMoney(stats.revenue)}</div>
                         <div className="text-xs text-white/50">earned</div>
                       </div>
                     </TooltipTrigger>
@@ -531,7 +539,7 @@ export function MetricsDashboard() {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div className="cursor-help">
-                        <div className="text-base font-bold text-red-600">${stats.expenses.toLocaleString()}</div>
+                        <div className="text-base font-bold text-red-600">{formatMoney(stats.expenses)}</div>
                         <div className="text-xs text-white/50">spent</div>
                       </div>
                     </TooltipTrigger>
@@ -542,7 +550,7 @@ export function MetricsDashboard() {
                 </div>
                 <div className="text-center p-2 bg-brand-purple/20 rounded">
                   <div className={`text-base font-bold ${netProfitLoss >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
-                    {netProfitLoss >= 0 ? '+' : ''}${netProfitLoss.toLocaleString()}
+                    {formatSignedMoney(netProfitLoss)}
                   </div>
                   <div className="text-xs text-white/50">net</div>
                 </div>
@@ -644,7 +652,7 @@ export function MetricsDashboard() {
                 </div>
                 <div className="text-center p-2 bg-brand-purple/20 rounded-lg">
                   <div className={`text-base font-bold ${netProfitLoss >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>
-                    {netProfitLoss >= 0 ? '+' : ''}${netProfitLoss.toLocaleString()}
+                    {formatSignedMoney(netProfitLoss)}
                   </div>
                   <div className="text-xs text-white/50">net {netProfitLoss >= 0 ? 'profit' : 'loss'}</div>
                 </div>
@@ -655,7 +663,7 @@ export function MetricsDashboard() {
                 <div>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="text-emerald-600 font-medium cursor-help">${stats.revenue.toLocaleString()}</span>
+                      <span className="text-emerald-600 font-medium cursor-help">{formatMoney(stats.revenue)}</span>
                     </TooltipTrigger>
                     <TooltipContent className="max-w-xs">
                       {renderRevenueBreakdown()}
@@ -666,7 +674,7 @@ export function MetricsDashboard() {
                 <div>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="text-red-600 font-medium cursor-help">${stats.expenses.toLocaleString()}</span>
+                      <span className="text-red-600 font-medium cursor-help">{formatMoney(stats.expenses)}</span>
                     </TooltipTrigger>
                     <TooltipContent className="max-w-xs">
                       {renderExpenseBreakdown()}

--- a/client/src/components/MusicCalendar.tsx
+++ b/client/src/components/MusicCalendar.tsx
@@ -453,11 +453,11 @@ export function MusicCalendar({
               key={event.id}
               className="bg-brand-purple/30 after:bg-brand-burgundy relative rounded-md p-2 pl-6 text-sm after:absolute after:inset-y-2 after:left-2 after:w-1 after:rounded-full"
             >
-              <div className="font-medium text-white flex items-center gap-2">
-                {getEventIcon(event.type)}
-                {event.title}
+              <div className="font-medium text-white flex items-start gap-2">
+                <span className="shrink-0 mt-0.5">{getEventIcon(event.type)}</span>
+                <span className="min-w-0 break-words">{event.title}</span>
               </div>
-              <div className="text-white/50 text-xs">
+              <div className="text-white/50 text-xs break-words">
                 {formatDateRange(event.from, event.to)}
                 {event.artistName && ` • ${event.artistName}`}
               </div>
@@ -479,7 +479,7 @@ export function MusicCalendar({
       <TooltipProvider>
         <Card className={cn("py-4 bg-brand-dark-card border-brand-purple h-full", className)}>
           <CardContent className="px-4 h-full flex flex-col">
-            <div className="flex gap-4 flex-1">
+            <div className="flex flex-wrap gap-4 flex-1">
               {/* Week picker grid on the left */}
               <div className="flex-shrink-0">
                 <div className="border border-brand-burgundy/30 rounded-lg p-4 bg-brand-dark-card/40">
@@ -555,7 +555,7 @@ export function MusicCalendar({
               </div>
 
               {/* Events on the right */}
-              <div className="flex-1 border-l border-brand-purple pl-4 flex flex-col">
+              <div className="flex-1 basis-44 min-w-0 border-l border-brand-purple pl-4 flex flex-col">
                 <div className="flex items-center justify-between mb-3">
                   <WeekHeader week={activeSelectedWeek} dates={selectedWeekDates} />
                 </div>
@@ -572,7 +572,7 @@ export function MusicCalendar({
   return (
     <Card className={cn("py-4 bg-brand-dark-card border-brand-purple h-full", className)}>
       <CardContent className="px-4 h-full flex flex-col">
-        <div className="flex gap-4 flex-1">
+        <div className="flex flex-wrap gap-4 flex-1">
           {/* Calendar on the left */}
           <div className="flex-shrink-0">
             <Calendar
@@ -615,7 +615,7 @@ export function MusicCalendar({
           </div>
 
           {/* Events on the right (display mode) or Week info (selection mode) */}
-          <div className="flex-1 border-l border-brand-purple pl-4 flex flex-col">
+          <div className="flex-1 basis-44 min-w-0 border-l border-brand-purple pl-4 flex flex-col">
             <div className="flex items-center justify-between mb-3">
               <WeekHeader week={activeSelectedWeek} dates={selectedWeekDates} />
               {!selectionMode && (

--- a/client/src/components/SaveGameModal.tsx
+++ b/client/src/components/SaveGameModal.tsx
@@ -404,12 +404,12 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="w-full max-w-2xl">
+        <DialogContent className="w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden">
           <DialogHeader className="border-b border-brand-purple pb-4">
             <DialogTitle className="text-lg font-semibold text-white">Save & Load Game</DialogTitle>
           </DialogHeader>
 
-          <div className="p-6 space-y-4">
+          <div className="flex-1 min-h-0 overflow-y-auto p-6 space-y-4">
             {/* Manual saves */}
             {manualSaves.length > 0 && (
               <div className="space-y-3">
@@ -529,23 +529,23 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
                 <p className="text-sm text-white/50">Empty Slot</p>
               </div>
             ))}
+          </div>
 
-            {/* New save input */}
-            <div className="space-y-2">
-              <Input
-                placeholder="Enter save name..."
-                value={newSaveName}
-                onChange={(e) => setNewSaveName(e.target.value)}
-                className="w-full"
-              />
-              <Button
-                onClick={handleSave}
-                disabled={!newSaveName.trim() || saving}
-                className="w-full bg-brand-burgundy text-white hover:bg-brand-burgundy"
-              >
-                {saving ? 'Saving...' : 'Save Game'}
-              </Button>
-            </div>
+          {/* New save input — pinned below the scrolling list */}
+          <div className="px-6 pt-4 space-y-2 border-t border-brand-purple">
+            <Input
+              placeholder="Enter save name..."
+              value={newSaveName}
+              onChange={(e) => setNewSaveName(e.target.value)}
+              className="w-full"
+            />
+            <Button
+              onClick={handleSave}
+              disabled={!newSaveName.trim() || saving}
+              className="w-full bg-brand-burgundy text-white hover:bg-brand-burgundy"
+            >
+              {saving ? 'Saving...' : 'Save Game'}
+            </Button>
           </div>
 
           <div className="p-6 border-t border-brand-purple flex justify-between">

--- a/client/src/layouts/GameLayout.tsx
+++ b/client/src/layouts/GameLayout.tsx
@@ -20,8 +20,11 @@ export default function GameLayout({
       <GameSidebar
         onShowSaveModal={onShowSaveModal}
       />
-      <SidebarInset className="bg-transparent">
-        <div className="flex-1 p-0 min-h-screen bg-transparent">
+      {/* min-w-0 lets the content pane shrink below its content's intrinsic width —
+          without it, wide tables push the whole page past the viewport instead of
+          scrolling inside their overflow-auto wrappers */}
+      <SidebarInset className="bg-transparent min-w-0">
+        <div className="flex-1 p-0 min-h-screen min-w-0 bg-transparent">
           <div className="flex items-center gap-2 p-4 border-b border-brand-rose/30">
             <SidebarTrigger className="h-4 w-4 text-white hover:bg-white/10" />
           </div>

--- a/client/src/pages/AROffice.tsx
+++ b/client/src/pages/AROffice.tsx
@@ -41,8 +41,10 @@ export default function AROffice() {
         </div>
 
         <div className="relative">
-          {/* Marcus Rodriguez Executive Office Avatar */}
-          <div className="absolute -top-72 -right-20 z-10">
+          {/* Marcus Rodriguez Executive Office Avatar — wrapper height matches the
+              -top offset so the image is cropped exactly at the card's top edge
+              (the card background is translucent, so it can't hide the overlap) */}
+          <div className="absolute -top-72 -right-20 z-10 h-72 overflow-hidden">
             <img
               src="/avatars/marcus_rodriguez_exec_office.png"
               alt="Marcus Rodriguez in executive office"

--- a/client/src/pages/ArtistPage.tsx
+++ b/client/src/pages/ArtistPage.tsx
@@ -419,8 +419,10 @@ export default function ArtistPage() {
         <Tabs defaultValue="overview" className="space-y-6">
           <div className="relative">
             <TabsList className="grid grid-cols-5 w-full max-w-2xl">
-              {/* Nova Sterling positioned relative to tab menu */}
-              <div className="absolute -top-40 -right-20 z-10">
+              {/* Artist avatar positioned relative to tab menu — wrapper height =
+                  top offset (160px) + tab bar (40px) + space-y-6 gap (24px) so the
+                  image crops exactly at the translucent card's top edge below */}
+              <div className="absolute -top-40 -right-20 z-10 h-56 overflow-hidden">
                 <img
                   src={getAvatarUrl(artist.name)}
                   alt={`${artist.name} avatar`}


### PR DESCRIPTION
## What changed

Five UI overflow/layout fixes found while playing at non-wide window sizes, all verified live in the browser at 1100px and 1440px viewports:

- **SaveGameModal**: with many saves the dialog grew past the screen. It's now capped at 85vh with the saves list as the only scrollable region; the save-name input and Export/Import/Cancel footer stay pinned and always reachable.
- **A&R Office / Artist pages**: the absolutely-positioned character avatars overlap the cards below, and since card backgrounds are translucent the overlap showed through. The avatar wrappers now have a height matching their negative-top offset plus `overflow-hidden`, cropping the image exactly at the card's top edge (measured pixel-exact in the preview). Note: the clip height mirrors the `-top-*` offset — move both together if repositioning.
- **MetricsDashboard**: the 3/5/3 11-column grid started at `lg`, leaving ~60px cells that money strings overflowed (and forced the grid past the viewport, clipping Access Tiers). Sections now stack below `xl` and have `min-w-0`. Money is also formatted as whole dollars with the sign before the symbol (`-$16,687` instead of `$-16,687.5`) via a shared helper used by all three responsive layouts.
- **MusicCalendar**: the events panel next to the fixed-width calendar couldn't shrink, so event titles and the week header spilled outside the card. Added `min-w-0` + word wrapping, and the panel wraps below the calendar when the card is narrow.
- **GameLayout (root cause)**: the `SidebarInset` flex chain lacked `min-w-0`, so any wide table's intrinsic width propagated up and stretched the whole page sideways instead of scrolling inside its `overflow-auto` wrapper. Fixed at the layout level, which covers every page.

## Why

At window widths below ~1280px the dashboard scrolled horizontally, metric values overlapped, and characters bled through cards.

## Reviewer notes

- `npm run check` green; changes are className/JSX-structure only plus the small `formatMoney`/`formatSignedMoney` helpers (rounding display only — no game-logic change).
- The `xl` breakpoint choice for the metrics grid: at `lg` minus the 256px sidebar, the 11-col layout mathematically cannot fit the money strings; `xl` is the first width where it can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)