### PR TITLE
refactor: extract emails router (Phase 1 PR-4)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,7 +6,6 @@ import path from 'path';
 import { storage } from "./storage";
 import { insertGameStateSchema, insertGameSaveSchema, gameSaveSnapshotSchema, insertArtistSchema, insertProjectSchema, insertWeeklyActionSchema, insertMusicLabelSchema, labelRequestSchema, gameStates, gameSaves, weeklyActions, projects, songs, artists, releases, releaseSongs, roles, executives, musicLabels, moodEvents, emails, type GameSaveSnapshot, SNAPSHOT_VERSION } from "@shared/schema";
 import { z } from "zod";
-import type { EmailCategory } from "@shared/types/emailTypes";
 import { serverGameData } from "./data/gameData";
 import { gameDataLoader } from "@shared/utils/dataLoader";
 import { GameEngine } from "../shared/engine/game-engine";
@@ -30,30 +29,10 @@ import { requireClerkUser, handleClerkWebhook, requireAdmin } from './auth';
 import analyticsRouter from './routes/analytics';
 import bugReportsRouter from './routes/bugReports';
 import adminRouter from './routes/admin';
+import emailsRouter from './routes/emails';
 import { ClerkExpressWithAuth, clerkClient } from '@clerk/clerk-sdk-node';
 import { seededRandomPick, generateMeetingSeed } from '@shared/utils/seededRandom';
 import { normalizeDifficulty } from '@shared/utils/startingValues';
-
-const EMAIL_CATEGORY_VALUES = [
-  "chart",
-  "financial",
-  "artist",
-  "ar"
-] as const satisfies readonly EmailCategory[];
-
-const emailCategoryEnum = z.enum(EMAIL_CATEGORY_VALUES);
-
-const emailQuerySchema = z.object({
-  isRead: z.enum(["true", "false"]).optional(),
-  category: emailCategoryEnum.optional(),
-  week: z.coerce.number().int().min(1).optional(),
-  limit: z.coerce.number().int().min(1).max(100).optional(),
-  offset: z.coerce.number().int().min(0).optional()
-});
-
-const markEmailReadSchema = z.object({
-  isRead: z.boolean()
-});
 
 export async function registerRoutes(app: Express): Promise<Server> {
 
@@ -118,169 +97,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Email endpoints
-  app.get('/api/game/:gameId/emails', requireClerkUser, async (req, res) => {
-    try {
-      const userId = req.userId;
-      if (!userId) {
-        return res.status(401).json({ message: 'Authentication required' });
-      }
-
-      const { gameId } = req.params;
-      const queryParams = emailQuerySchema.parse(req.query);
-
-      console.log('[API] GET /emails - Query params:', queryParams);
-
-      const [gameOwnership] = await db
-        .select({ id: gameStates.id })
-        .from(gameStates)
-        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
-        .limit(1);
-
-      if (!gameOwnership) {
-        return res.status(403).json({
-          error: 'UNAUTHORIZED',
-          message: 'You do not have permission to access this game'
-        });
-      }
-
-      const storageParams = {
-        isRead: typeof queryParams.isRead === 'string' ? queryParams.isRead === 'true' : undefined,
-        category: queryParams.category,
-        week: queryParams.week,
-        limit: queryParams.limit,
-        offset: queryParams.offset
-      };
-
-      console.log('[API] Calling storage.getEmailsByGame with:', storageParams);
-
-      const result = await storage.getEmailsByGame(gameId, storageParams);
-
-      console.log('[API] Storage returned:', { total: result.total, emailCount: result.emails.length });
-
-      res.json(result);
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return res.status(400).json({
-          message: 'Invalid query parameters',
-          errors: error.errors
-        });
-      }
-      console.error('[API] Failed to fetch emails:', error);
-      res.status(500).json({ message: 'Failed to fetch emails' });
-    }
-  });
-
-  app.get('/api/game/:gameId/emails/unread-count', requireClerkUser, async (req, res) => {
-    try {
-      const userId = req.userId;
-      if (!userId) {
-        return res.status(401).json({ message: 'Authentication required' });
-      }
-
-      const { gameId } = req.params;
-
-      const [gameOwnership] = await db
-        .select({ id: gameStates.id })
-        .from(gameStates)
-        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
-        .limit(1);
-
-      if (!gameOwnership) {
-        return res.status(403).json({
-          error: 'UNAUTHORIZED',
-          message: 'You do not have permission to access this game'
-        });
-      }
-
-      const result = await storage.getEmailsByGame(gameId, {
-        isRead: false,
-        limit: 1,
-        offset: 0
-      });
-
-      res.json({ count: result.unreadCount });
-    } catch (error) {
-      console.error('[API] Failed to fetch unread email count:', error);
-      res.status(500).json({ message: 'Failed to fetch unread email count' });
-    }
-  });
-
-  app.patch('/api/game/:gameId/emails/:emailId/read', requireClerkUser, async (req, res) => {
-    try {
-      const userId = req.userId;
-      if (!userId) {
-        return res.status(401).json({ message: 'Authentication required' });
-      }
-
-      const { gameId, emailId } = req.params;
-      const body = markEmailReadSchema.parse(req.body);
-
-      const [gameOwnership] = await db
-        .select({ id: gameStates.id })
-        .from(gameStates)
-        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
-        .limit(1);
-
-      if (!gameOwnership) {
-        return res.status(403).json({
-          error: 'UNAUTHORIZED',
-          message: 'You do not have permission to access this game'
-        });
-      }
-
-      const email = await storage.markEmailRead(gameId, emailId, body.isRead);
-      res.json({ success: true, email });
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return res.status(400).json({
-          message: 'Invalid request body',
-          errors: error.errors
-        });
-      }
-
-      if (error instanceof Error && error.message.includes('not found')) {
-        return res.status(404).json({ message: 'Email not found' });
-      }
-
-      console.error('[API] Failed to update email read status:', error);
-      res.status(500).json({ message: 'Failed to update email read status' });
-    }
-  });
-
-  app.delete('/api/game/:gameId/emails/:emailId', requireClerkUser, async (req, res) => {
-    try {
-      const userId = req.userId;
-      if (!userId) {
-        return res.status(401).json({ message: 'Authentication required' });
-      }
-
-      const { gameId, emailId } = req.params;
-
-      const [gameOwnership] = await db
-        .select({ id: gameStates.id })
-        .from(gameStates)
-        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
-        .limit(1);
-
-      if (!gameOwnership) {
-        return res.status(403).json({
-          error: 'UNAUTHORIZED',
-          message: 'You do not have permission to access this game'
-        });
-      }
-
-      const existingEmail = await storage.getEmailById(gameId, emailId);
-      if (!existingEmail) {
-        return res.status(404).json({ message: 'Email not found' });
-      }
-
-      await storage.deleteEmail(gameId, emailId);
-      res.json({ success: true });
-    } catch (error) {
-      console.error('[API] Failed to delete email:', error);
-      res.status(500).json({ message: 'Failed to delete email' });
-    }
-  });
+  app.use(emailsRouter);
 
   // Current user metadata (minimal): isAdmin flag derived from Clerk privateMetadata
   app.get('/api/me', ClerkExpressWithAuth(), async (req, res) => {

--- a/server/routes/emails.ts
+++ b/server/routes/emails.ts
@@ -1,0 +1,198 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import type { EmailCategory } from "@shared/types/emailTypes";
+import { storage } from '../storage';
+import { gameStates } from '@shared/schema';
+import { db } from '../db';
+import { eq, and } from 'drizzle-orm';
+import { requireClerkUser } from '../auth';
+
+const router = Router();
+
+const EMAIL_CATEGORY_VALUES = [
+  "chart",
+  "financial",
+  "artist",
+  "ar"
+] as const satisfies readonly EmailCategory[];
+
+const emailCategoryEnum = z.enum(EMAIL_CATEGORY_VALUES);
+
+const emailQuerySchema = z.object({
+  isRead: z.enum(["true", "false"]).optional(),
+  category: emailCategoryEnum.optional(),
+  week: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional()
+});
+
+const markEmailReadSchema = z.object({
+  isRead: z.boolean()
+});
+
+// Email endpoints
+router.get('/api/game/:gameId/emails', requireClerkUser, async (req, res) => {
+    try {
+      const userId = req.userId;
+      if (!userId) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      const { gameId } = req.params;
+      const queryParams = emailQuerySchema.parse(req.query);
+
+      console.log('[API] GET /emails - Query params:', queryParams);
+
+      const [gameOwnership] = await db
+        .select({ id: gameStates.id })
+        .from(gameStates)
+        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
+        .limit(1);
+
+      if (!gameOwnership) {
+        return res.status(403).json({
+          error: 'UNAUTHORIZED',
+          message: 'You do not have permission to access this game'
+        });
+      }
+
+      const storageParams = {
+        isRead: typeof queryParams.isRead === 'string' ? queryParams.isRead === 'true' : undefined,
+        category: queryParams.category,
+        week: queryParams.week,
+        limit: queryParams.limit,
+        offset: queryParams.offset
+      };
+
+      console.log('[API] Calling storage.getEmailsByGame with:', storageParams);
+
+      const result = await storage.getEmailsByGame(gameId, storageParams);
+
+      console.log('[API] Storage returned:', { total: result.total, emailCount: result.emails.length });
+
+      res.json(result);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: 'Invalid query parameters',
+          errors: error.errors
+        });
+      }
+      console.error('[API] Failed to fetch emails:', error);
+      res.status(500).json({ message: 'Failed to fetch emails' });
+    }
+  });
+
+router.get('/api/game/:gameId/emails/unread-count', requireClerkUser, async (req, res) => {
+    try {
+      const userId = req.userId;
+      if (!userId) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      const { gameId } = req.params;
+
+      const [gameOwnership] = await db
+        .select({ id: gameStates.id })
+        .from(gameStates)
+        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
+        .limit(1);
+
+      if (!gameOwnership) {
+        return res.status(403).json({
+          error: 'UNAUTHORIZED',
+          message: 'You do not have permission to access this game'
+        });
+      }
+
+      const result = await storage.getEmailsByGame(gameId, {
+        isRead: false,
+        limit: 1,
+        offset: 0
+      });
+
+      res.json({ count: result.unreadCount });
+    } catch (error) {
+      console.error('[API] Failed to fetch unread email count:', error);
+      res.status(500).json({ message: 'Failed to fetch unread email count' });
+    }
+  });
+
+router.patch('/api/game/:gameId/emails/:emailId/read', requireClerkUser, async (req, res) => {
+    try {
+      const userId = req.userId;
+      if (!userId) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      const { gameId, emailId } = req.params;
+      const body = markEmailReadSchema.parse(req.body);
+
+      const [gameOwnership] = await db
+        .select({ id: gameStates.id })
+        .from(gameStates)
+        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
+        .limit(1);
+
+      if (!gameOwnership) {
+        return res.status(403).json({
+          error: 'UNAUTHORIZED',
+          message: 'You do not have permission to access this game'
+        });
+      }
+
+      const email = await storage.markEmailRead(gameId, emailId, body.isRead);
+      res.json({ success: true, email });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          message: 'Invalid request body',
+          errors: error.errors
+        });
+      }
+
+      if (error instanceof Error && error.message.includes('not found')) {
+        return res.status(404).json({ message: 'Email not found' });
+      }
+
+      console.error('[API] Failed to update email read status:', error);
+      res.status(500).json({ message: 'Failed to update email read status' });
+    }
+  });
+
+router.delete('/api/game/:gameId/emails/:emailId', requireClerkUser, async (req, res) => {
+    try {
+      const userId = req.userId;
+      if (!userId) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      const { gameId, emailId } = req.params;
+
+      const [gameOwnership] = await db
+        .select({ id: gameStates.id })
+        .from(gameStates)
+        .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
+        .limit(1);
+
+      if (!gameOwnership) {
+        return res.status(403).json({
+          error: 'UNAUTHORIZED',
+          message: 'You do not have permission to access this game'
+        });
+      }
+
+      const existingEmail = await storage.getEmailById(gameId, emailId);
+      if (!existingEmail) {
+        return res.status(404).json({ message: 'Email not found' });
+      }
+
+      await storage.deleteEmail(gameId, emailId);
+      res.json({ success: true });
+    } catch (error) {
+      console.error('[API] Failed to delete email:', error);
+      res.status(500).json({ message: 'Failed to delete email' });
+    }
+  });
+
+export default router;


### PR DESCRIPTION
Stacked on #43 (PR-3 admin router). Base this PR onto `refactor/pr3-admin-router`; retarget to `main` once PR-3 merges.

## What
Pure move of the 4 email endpoints from `server/routes.ts` into a new `server/routes/emails.ts`, following the full-path bare-mounted router convention from PR-2/PR-3.

Endpoints moved verbatim (handlers, per-route `requireClerkUser`, log lines, status codes, response shapes):
- `GET /api/game/:gameId/emails`
- `GET /api/game/:gameId/emails/unread-count`
- `PATCH /api/game/:gameId/emails/:emailId/read`
- `DELETE /api/game/:gameId/emails/:emailId`

Also moved the module-scope email zod schemas (`emailQuerySchema`, `markEmailReadSchema`) and their supporting `EMAIL_CATEGORY_VALUES` / `emailCategoryEnum` plus the `EmailCategory` type import — verified used only by these handlers. Mounted via `app.use(emailsRouter)` at the exact location where the first email endpoint previously sat, preserving registration order.

The `emails` schema-table import stays in `routes.ts` (still used by the save-restore handler).

## Non-goals
No behavior/auth/path changes, no client changes (per Phase 1 plan §6).

## Verification
- `npm run check` — passes
- `npm run test:run` — 545 passing (38 files), test DB on 5433
- Route-manifest snapshot (`tests/endpoints/route-manifest.test.ts`) stayed byte-identical (the working-copy rewrite was pure LF→CRLF noise and was reverted; the passing test confirms the manifest is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)