### PR TITLE
refactor: extract content router (Phase 1 PR-6)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -29,6 +29,7 @@ import bugReportsRouter from './routes/bugReports';
 import adminRouter from './routes/admin';
 import emailsRouter from './routes/emails';
 import devToolsRouter from './routes/devTools';
+import contentRouter from './routes/content';
 import { ClerkExpressWithAuth, clerkClient } from '@clerk/clerk-sdk-node';
 import { seededRandomPick, generateMeetingSeed } from '@shared/utils/seededRandom';
 import { normalizeDifficulty } from '@shared/utils/startingValues';
@@ -471,17 +472,7 @@ const musicLabelData = {
     }
   });
 
-  // Get available artists for discovery
-  app.get("/api/artists/available", async (req, res) => {
-    try {
-      await serverGameData.initialize();
-      const allArtists = await serverGameData.getAllArtists();
-      res.json({ artists: allArtists || [] });
-    } catch (error) {
-      console.error('Failed to load available artists:', error);
-      res.status(500).json({ error: 'Failed to load available artists' });
-    }
-  });
+  app.use(contentRouter);
 
   // ========================= A&R OFFICE ENDPOINTS =========================
   // Start an A&R sourcing operation
@@ -888,38 +879,6 @@ const musicLabelData = {
     }
   });
 
-  // Get available weekly actions with enriched role data and categories
-  app.get("/api/actions/weekly", requireClerkUser, async (req, res) => {
-    try {
-      await serverGameData.initialize();
-      const actionsData = await serverGameData.getWeeklyActionsWithCategories();
-      const roles = await serverGameData.getAllRoles();
-      
-      // Enrich actions with role meeting data
-      const enrichedActions = actionsData.actions.map((action: any) => {
-        if (action.type === 'role_meeting' && action.role_id) {
-          const role = roles.find(r => r.id === action.role_id);
-          if (role && role.meetings && role.meetings.length > 0) {
-            return {
-              ...action,
-              firstMeetingId: role.meetings[0].id,
-              availableMeetings: role.meetings.length
-            };
-          }
-        }
-        return action;
-      });
-      
-      res.json({ 
-        actions: enrichedActions || [],
-        categories: actionsData.categories || []
-      });
-    } catch (error) {
-      console.error('Failed to load weekly actions:', error);
-      res.status(500).json({ error: 'Failed to load weekly actions' });
-    }
-  });
-
   // Get role/executive data with all their meetings
   // Following the rule: JSON = Content & Config, Database = State & Saves
   // Query params: gameId, week (optional) - for weekly meeting randomization
@@ -1246,18 +1205,6 @@ const musicLabelData = {
         success: false,
         message: error instanceof Error ? error.message : "Failed to process artist dialogue"
       });
-    }
-  });
-
-  // Get project types and configuration
-  app.get("/api/project-types", requireClerkUser, async (req, res) => {
-    try {
-      await serverGameData.initialize();
-      const projectTypes = await serverGameData.getProjectTypes();
-      res.json({ projectTypes: projectTypes || {} });
-    } catch (error) {
-      console.error('Failed to load project types:', error);
-      res.status(500).json({ error: 'Failed to load project types' });
     }
   });
 
@@ -2291,16 +2238,6 @@ const musicLabelData = {
 
   // REMOVED: Duplicate role endpoints - using the implementation at lines 307-362 instead
 
-  // Artist dialogue endpoints
-  app.get("/api/artists/:archetype/dialogue", async (req, res) => {
-    try {
-      const dialogues = await serverGameData.getArtistDialogue(req.params.archetype);
-      res.json(dialogues);
-    } catch (error) {
-      res.status(500).json({ message: "Failed to fetch artist dialogue" });
-    }
-  });
-
   // Dialogue choices (legacy endpoint - kept for backwards compatibility)
   app.get("/api/dialogue/:roleType", async (req, res) => {
     try {
@@ -2329,16 +2266,6 @@ const musicLabelData = {
         message: "Failed to load dialogue data",
         error: error instanceof Error ? error.message : 'Unknown error'
       });
-    }
-  });
-
-  // Game events
-  app.get("/api/events", async (req, res) => {
-    try {
-      const events = await storage.getGameEvents();
-      res.json(events);
-    } catch (error) {
-      res.status(500).json({ message: "Failed to fetch game events" });
     }
   });
 
@@ -4053,20 +3980,6 @@ const musicLabelData = {
   });
 
   app.use(bugReportsRouter);
-
-  // Balance data endpoint
-  app.get('/api/game/:gameId/balance', requireClerkUser, async (req, res) => {
-    try {
-      const balance = await serverGameData.getBalanceConfig();
-      res.json({ balance });
-    } catch (error: any) {
-      console.error('[BALANCE] Failed to load balance data:', error);
-      res.status(500).json({
-        error: 'BALANCE_LOAD_FAILED',
-        message: error.message || 'Failed to load balance configuration'
-      });
-    }
-  });
 
   // Register analytics routes
   app.use('/api/analytics', requireClerkUser, analyticsRouter);

--- a/server/routes/content.ts
+++ b/server/routes/content.ts
@@ -1,0 +1,98 @@
+import { Router } from 'express';
+import { serverGameData } from '../data/gameData';
+import { storage } from '../storage';
+import { requireClerkUser } from '../auth';
+
+const router = Router();
+
+// Get available artists for discovery
+router.get("/api/artists/available", async (req, res) => {
+    try {
+      await serverGameData.initialize();
+      const allArtists = await serverGameData.getAllArtists();
+      res.json({ artists: allArtists || [] });
+    } catch (error) {
+      console.error('Failed to load available artists:', error);
+      res.status(500).json({ error: 'Failed to load available artists' });
+    }
+  });
+
+  // Get available weekly actions with enriched role data and categories
+  router.get("/api/actions/weekly", requireClerkUser, async (req, res) => {
+    try {
+      await serverGameData.initialize();
+      const actionsData = await serverGameData.getWeeklyActionsWithCategories();
+      const roles = await serverGameData.getAllRoles();
+
+      // Enrich actions with role meeting data
+      const enrichedActions = actionsData.actions.map((action: any) => {
+        if (action.type === 'role_meeting' && action.role_id) {
+          const role = roles.find(r => r.id === action.role_id);
+          if (role && role.meetings && role.meetings.length > 0) {
+            return {
+              ...action,
+              firstMeetingId: role.meetings[0].id,
+              availableMeetings: role.meetings.length
+            };
+          }
+        }
+        return action;
+      });
+
+      res.json({
+        actions: enrichedActions || [],
+        categories: actionsData.categories || []
+      });
+    } catch (error) {
+      console.error('Failed to load weekly actions:', error);
+      res.status(500).json({ error: 'Failed to load weekly actions' });
+    }
+  });
+
+  // Get project types and configuration
+  router.get("/api/project-types", requireClerkUser, async (req, res) => {
+    try {
+      await serverGameData.initialize();
+      const projectTypes = await serverGameData.getProjectTypes();
+      res.json({ projectTypes: projectTypes || {} });
+    } catch (error) {
+      console.error('Failed to load project types:', error);
+      res.status(500).json({ error: 'Failed to load project types' });
+    }
+  });
+
+  // Artist dialogue endpoints
+  router.get("/api/artists/:archetype/dialogue", async (req, res) => {
+    try {
+      const dialogues = await serverGameData.getArtistDialogue(req.params.archetype);
+      res.json(dialogues);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch artist dialogue" });
+    }
+  });
+
+  // Game events
+  router.get("/api/events", async (req, res) => {
+    try {
+      const events = await storage.getGameEvents();
+      res.json(events);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch game events" });
+    }
+  });
+
+  // Balance data endpoint
+  router.get('/api/game/:gameId/balance', requireClerkUser, async (req, res) => {
+    try {
+      const balance = await serverGameData.getBalanceConfig();
+      res.json({ balance });
+    } catch (error: any) {
+      console.error('[BALANCE] Failed to load balance data:', error);
+      res.status(500).json({
+        error: 'BALANCE_LOAD_FAILED',
+        message: error.message || 'Failed to load balance configuration'
+      });
+    }
+  });
+
+export default router;


### PR DESCRIPTION
## Summary
Pure move of the 6 static content/config endpoints from `server/routes.ts` into a new `server/routes/content.ts`, following the PR-2..5 router convention (full-path routes, mounted bare, per-route middleware).

Handlers moved verbatim — log lines, status codes, response shapes, and auth status all preserved.

### Endpoints moved (3 public / no-auth preserved)
| Method & Path | Auth |
|---|---|
| GET `/api/artists/available` | none (public) |
| GET `/api/actions/weekly` | requireClerkUser |
| GET `/api/project-types` | requireClerkUser |
| GET `/api/artists/:archetype/dialogue` | none (public) |
| GET `/api/events` | none (public) |
| GET `/api/game/:gameId/balance` | requireClerkUser (`gameId` unused — preserved as-is) |

`app.use(contentRouter)` is mounted at the exact prior position of the first endpoint (`GET /api/artists/available`) to preserve global registration order.

## Verification
- `npm run check` — clean (tsc)
- `npm run test:run` — 545 passing (38 files)
- Route-manifest snapshot **byte-identical** (no update needed; CRLF rewrite noise reverted)
- `storage` import retained in routes.ts (still used 68×); no imports became unused
- No behavior/auth/path/client changes

routes.ts: 4076 → 3989 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
