### PR TITLE
refactor: extract executives/roles router (Phase 1 PR-8)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5,7 +5,6 @@ import { storage } from "./storage";
 import { insertGameStateSchema, insertGameSaveSchema, gameSaveSnapshotSchema, insertArtistSchema, insertProjectSchema, insertWeeklyActionSchema, insertMusicLabelSchema, labelRequestSchema, gameStates, gameSaves, weeklyActions, projects, songs, artists, releases, releaseSongs, roles, executives, musicLabels, moodEvents, emails, type GameSaveSnapshot, SNAPSHOT_VERSION } from "@shared/schema";
 import { z } from "zod";
 import { serverGameData } from "./data/gameData";
-import { gameDataLoader } from "@shared/utils/dataLoader";
 import { GameEngine } from "../shared/engine/game-engine";
 import { FinancialSystem, VenueCapacityManager } from "../shared/engine/FinancialSystem";
 import { ChartService } from "../shared/engine/ChartService";
@@ -31,8 +30,8 @@ import emailsRouter from './routes/emails';
 import devToolsRouter from './routes/devTools';
 import contentRouter from './routes/content';
 import arOfficeRouter from './routes/arOffice';
+import executivesRouter from './routes/executives';
 import { ClerkExpressWithAuth, clerkClient } from '@clerk/clerk-sdk-node';
-import { seededRandomPick, generateMeetingSeed } from '@shared/utils/seededRandom';
 import { normalizeDifficulty } from '@shared/utils/startingValues';
 
 export async function registerRoutes(app: Express): Promise<Server> {
@@ -478,184 +477,9 @@ const musicLabelData = {
   // ========================= A&R OFFICE ENDPOINTS =========================
   app.use(arOfficeRouter);
 
-  // Get role/executive data with all their meetings
-  // Following the rule: JSON = Content & Config, Database = State & Saves
-  // Query params: gameId, week (optional) - for weekly meeting randomization
-  app.get("/api/roles/:roleId", requireClerkUser, async (req, res) => {
-    try {
-      // Use serverGameData to load data properly
-      await serverGameData.initialize();
-      const rolesData = await serverGameData.getAllRoles();
-      const role = rolesData.find((r: any) => r.id === req.params.roleId);
-
-      if (!role) {
-        return res.status(404).json({ error: `Role ${req.params.roleId} not found` });
-      }
-
-      // Load actions using serverGameData
-      const actionsData = await serverGameData.getWeeklyActionsWithCategories();
-      let roleMeetings = actionsData.actions.filter((action: any) =>
-        action.type === 'role_meeting' &&
-        action.role_id === req.params.roleId
-      );
-
-      // Filter out test meetings from production randomization
-      roleMeetings = roleMeetings.filter((meeting: any) =>
-        !meeting.id.startsWith('TEST_')
-      );
-
-      console.log(`Found ${roleMeetings.length} meetings for role ${req.params.roleId}`);
-
-      // Weekly meeting randomization: if gameId and week provided, select one meeting
-      const { gameId, week } = req.query;
-      console.log(`[MEETING API] Request for ${req.params.roleId} - gameId: ${gameId}, week: ${week}`);
-
-      if (gameId && week && roleMeetings.length > 0) {
-        const weekNum = parseInt(week as string);
-        if (!isNaN(weekNum)) {
-          const seed = generateMeetingSeed(gameId as string, weekNum, req.params.roleId);
-          const selectedMeeting = seededRandomPick(roleMeetings, seed);
-          console.log(`[MEETING API] ✅ Randomized to 1 meeting for ${req.params.roleId} week ${weekNum}:`, selectedMeeting?.id);
-          roleMeetings = selectedMeeting ? [selectedMeeting] : roleMeetings;
-        }
-      } else {
-        console.log(`[MEETING API] ❌ NO RANDOMIZATION - returning all ${roleMeetings.length} meetings for ${req.params.roleId}`);
-      }
-
-      res.json({
-        ...role,
-        meetings: roleMeetings
-      });
-    } catch (error: any) {
-      console.error('Failed to load role:', error);
-      res.status(500).json({
-        error: 'Failed to load role data',
-        details: error.message || 'Unknown error',
-        roleId: req.params.roleId
-      });
-    }
-  });
-
-  // Get specific meeting data for a role
-  // Following the rule: JSON = Content & Config, Database = State & Saves
-  app.get("/api/roles/:roleId/meetings/:meetingId", requireClerkUser, async (req, res) => {
-    try {
-      // Use the same serverGameData methods that work elsewhere
-      await serverGameData.initialize();
-      const actionsData = await serverGameData.getWeeklyActionsWithCategories();
-      
-      // Find the meeting in actions (getWeeklyActionsWithCategories returns actions array)
-      const meeting = actionsData.actions.find((action: any) => 
-        action.type === 'role_meeting' && 
-        action.role_id === req.params.roleId && 
-        action.id === req.params.meetingId
-      );
-      
-      console.log('Looking for meeting:', req.params.meetingId, 'for role:', req.params.roleId);
-      console.log('Found meeting:', meeting ? 'Yes' : 'No');
-      if (meeting) {
-        console.log('Meeting data:', JSON.stringify(meeting, null, 2));
-      }
-      
-      if (!meeting) {
-        return res.status(404).json({ error: 'Meeting not found' });
-      }
-      
-      // Return the meeting data in the format DialogueModal expects
-      res.json({
-        id: meeting.id,
-        prompt: meeting.prompt || '',
-        choices: meeting.choices || []
-      });
-    } catch (error) {
-      console.error('Failed to load meeting:', error);
-      res.status(500).json({ error: 'Failed to load meeting data' });
-    }
-  });
-
-  // Get executives for a game
-  app.get("/api/game/:gameId/executives", requireClerkUser, async (req, res) => {
-    try {
-      const { gameId } = req.params;
-      console.log('[ROUTES] Fetching executives for game:', gameId);
-      
-      const executives = await storage.getExecutivesByGame(gameId);
-      console.log('[ROUTES] Found executives:', executives.length);
-      
-      res.json(executives);
-    } catch (error) {
-      console.error('[ROUTES] Error fetching executives:', error);
-      res.status(500).json({ message: "Failed to fetch executives" });
-    }
-  });
-
-  // Process executive action/decision (Week 2 Task)
-  app.post("/api/game/:gameId/executive/:execId/action", requireClerkUser, async (req, res) => {
-    try {
-      const { gameId, execId } = req.params;
-      const { actionId, meetingId, choiceId, metadata } = req.body;
-      
-      // Get the game state
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) {
-        return res.status(404).json({ message: "Game not found" });
-      }
-      
-      // Store the executive action as a selected action for the week
-      const executiveAction = {
-        actionType: 'role_meeting' as const,
-        targetId: execId,
-        metadata: {
-          roleId: metadata?.roleId || 'unknown',
-          actionId: actionId,
-          choiceId: choiceId,
-          executiveId: execId,
-          ...metadata
-        }
-      };
-
-      // Check if focus slots are available
-      const usedSlots = gameState.usedFocusSlots || 0;
-      const totalSlots = gameState.focusSlots || 3;
-
-      if (usedSlots >= totalSlots) {
-        return res.status(400).json({
-          message: "No focus slots available",
-          usedSlots,
-          totalSlots
-        });
-      }
-
-      // NOTE: Executive mood/loyalty processing now handled during week advancement
-      // This ensures single source of truth and prevents duplicate processing
-
-      // Update the used focus slots count
-      gameState.usedFocusSlots = usedSlots + 1;
-
-      // Save the updated game state
-      await storage.updateGameState(gameId, {
-        ...gameState,
-        flags: gameState.flags as any, // Type assertion to handle unknown -> Json conversion
-        weeklyStats: gameState.weeklyStats as any, // Type assertion to handle unknown -> Json conversion
-        tierUnlockHistory: gameState.tierUnlockHistory as any // Type assertion to handle unknown -> Json conversion
-      });
-
-      // Return success response with updated state
-      res.json({
-        success: true,
-        executiveId: execId,
-        actionId: actionId,
-        gameId: gameId,
-        week: gameState.currentWeek,
-        usedSlots: gameState.usedFocusSlots,
-        totalSlots: totalSlots,
-        message: "Executive action processed successfully"
-      });
-    } catch (error) {
-      console.error('Failed to process executive action:', error);
-      res.status(500).json({ message: "Failed to process executive action" });
-    }
-  });
+  // Roles / executives / dialogue endpoints extracted to server/routes/executives.ts (PR-8)
+  // Mounted at the original position of GET /api/roles/:roleId to preserve registration order.
+  app.use(executivesRouter);
 
   // ========================================
   // Artist Dialogue Endpoint
@@ -1837,36 +1661,8 @@ const musicLabelData = {
 
   // REMOVED: Duplicate role endpoints - using the implementation at lines 307-362 instead
 
-  // Dialogue choices (legacy endpoint - kept for backwards compatibility)
-  app.get("/api/dialogue/:roleType", async (req, res) => {
-    try {
-      const { sceneId } = req.query;
-      const choices = await storage.getDialogueChoices(
-        req.params.roleType, 
-        sceneId as string
-      );
-      res.json(choices);
-    } catch (error) {
-      res.status(500).json({ message: "Failed to fetch dialogue choices" });
-    }
-  });
-
-  // Get all dialogue scenes for frontend random selection
-  app.get("/api/dialogue-scenes", async (req, res) => {
-    try {
-      const dialogueData = await gameDataLoader.loadDialogueData();
-      res.json({
-        version: dialogueData.version,
-        scenes: dialogueData.additional_scenes
-      });
-    } catch (error) {
-      console.error('[API] Failed to load dialogue data:', error);
-      res.status(500).json({
-        message: "Failed to load dialogue data",
-        error: error instanceof Error ? error.message : 'Unknown error'
-      });
-    }
-  });
+  // Dialogue endpoints (/api/dialogue/:roleType, /api/dialogue-scenes) extracted to
+  // server/routes/executives.ts (PR-8), mounted via executivesRouter above.
 
   // Phase 1: Song and Release Management API Routes
   

--- a/server/routes/executives.ts
+++ b/server/routes/executives.ts
@@ -1,0 +1,218 @@
+import { Router } from 'express';
+import { serverGameData } from '../data/gameData';
+import { storage } from '../storage';
+import { requireClerkUser } from '../auth';
+import { seededRandomPick, generateMeetingSeed } from '@shared/utils/seededRandom';
+import { gameDataLoader } from '@shared/utils/dataLoader';
+
+const router = Router();
+
+// Query params: gameId, week (optional) - for weekly meeting randomization
+router.get("/api/roles/:roleId", requireClerkUser, async (req, res) => {
+    try {
+      // Use serverGameData to load data properly
+      await serverGameData.initialize();
+      const rolesData = await serverGameData.getAllRoles();
+      const role = rolesData.find((r: any) => r.id === req.params.roleId);
+
+      if (!role) {
+        return res.status(404).json({ error: `Role ${req.params.roleId} not found` });
+      }
+
+      // Load actions using serverGameData
+      const actionsData = await serverGameData.getWeeklyActionsWithCategories();
+      let roleMeetings = actionsData.actions.filter((action: any) =>
+        action.type === 'role_meeting' &&
+        action.role_id === req.params.roleId
+      );
+
+      // Filter out test meetings from production randomization
+      roleMeetings = roleMeetings.filter((meeting: any) =>
+        !meeting.id.startsWith('TEST_')
+      );
+
+      console.log(`Found ${roleMeetings.length} meetings for role ${req.params.roleId}`);
+
+      // Weekly meeting randomization: if gameId and week provided, select one meeting
+      const { gameId, week } = req.query;
+      console.log(`[MEETING API] Request for ${req.params.roleId} - gameId: ${gameId}, week: ${week}`);
+
+      if (gameId && week && roleMeetings.length > 0) {
+        const weekNum = parseInt(week as string);
+        if (!isNaN(weekNum)) {
+          const seed = generateMeetingSeed(gameId as string, weekNum, req.params.roleId);
+          const selectedMeeting = seededRandomPick(roleMeetings, seed);
+          console.log(`[MEETING API] ✅ Randomized to 1 meeting for ${req.params.roleId} week ${weekNum}:`, selectedMeeting?.id);
+          roleMeetings = selectedMeeting ? [selectedMeeting] : roleMeetings;
+        }
+      } else {
+        console.log(`[MEETING API] ❌ NO RANDOMIZATION - returning all ${roleMeetings.length} meetings for ${req.params.roleId}`);
+      }
+
+      res.json({
+        ...role,
+        meetings: roleMeetings
+      });
+    } catch (error: any) {
+      console.error('Failed to load role:', error);
+      res.status(500).json({
+        error: 'Failed to load role data',
+        details: error.message || 'Unknown error',
+        roleId: req.params.roleId
+      });
+    }
+  });
+
+  // Get specific meeting data for a role
+  // Following the rule: JSON = Content & Config, Database = State & Saves
+  router.get("/api/roles/:roleId/meetings/:meetingId", requireClerkUser, async (req, res) => {
+    try {
+      // Use the same serverGameData methods that work elsewhere
+      await serverGameData.initialize();
+      const actionsData = await serverGameData.getWeeklyActionsWithCategories();
+
+      // Find the meeting in actions (getWeeklyActionsWithCategories returns actions array)
+      const meeting = actionsData.actions.find((action: any) =>
+        action.type === 'role_meeting' &&
+        action.role_id === req.params.roleId &&
+        action.id === req.params.meetingId
+      );
+
+      console.log('Looking for meeting:', req.params.meetingId, 'for role:', req.params.roleId);
+      console.log('Found meeting:', meeting ? 'Yes' : 'No');
+      if (meeting) {
+        console.log('Meeting data:', JSON.stringify(meeting, null, 2));
+      }
+
+      if (!meeting) {
+        return res.status(404).json({ error: 'Meeting not found' });
+      }
+
+      // Return the meeting data in the format DialogueModal expects
+      res.json({
+        id: meeting.id,
+        prompt: meeting.prompt || '',
+        choices: meeting.choices || []
+      });
+    } catch (error) {
+      console.error('Failed to load meeting:', error);
+      res.status(500).json({ error: 'Failed to load meeting data' });
+    }
+  });
+
+  // Get executives for a game
+  router.get("/api/game/:gameId/executives", requireClerkUser, async (req, res) => {
+    try {
+      const { gameId } = req.params;
+      console.log('[ROUTES] Fetching executives for game:', gameId);
+
+      const executives = await storage.getExecutivesByGame(gameId);
+      console.log('[ROUTES] Found executives:', executives.length);
+
+      res.json(executives);
+    } catch (error) {
+      console.error('[ROUTES] Error fetching executives:', error);
+      res.status(500).json({ message: "Failed to fetch executives" });
+    }
+  });
+
+  // Process executive action/decision (Week 2 Task)
+  router.post("/api/game/:gameId/executive/:execId/action", requireClerkUser, async (req, res) => {
+    try {
+      const { gameId, execId } = req.params;
+      const { actionId, meetingId, choiceId, metadata } = req.body;
+
+      // Get the game state
+      const gameState = await storage.getGameState(gameId);
+      if (!gameState) {
+        return res.status(404).json({ message: "Game not found" });
+      }
+
+      // Store the executive action as a selected action for the week
+      const executiveAction = {
+        actionType: 'role_meeting' as const,
+        targetId: execId,
+        metadata: {
+          roleId: metadata?.roleId || 'unknown',
+          actionId: actionId,
+          choiceId: choiceId,
+          executiveId: execId,
+          ...metadata
+        }
+      };
+
+      // Check if focus slots are available
+      const usedSlots = gameState.usedFocusSlots || 0;
+      const totalSlots = gameState.focusSlots || 3;
+
+      if (usedSlots >= totalSlots) {
+        return res.status(400).json({
+          message: "No focus slots available",
+          usedSlots,
+          totalSlots
+        });
+      }
+
+      // NOTE: Executive mood/loyalty processing now handled during week advancement
+      // This ensures single source of truth and prevents duplicate processing
+
+      // Update the used focus slots count
+      gameState.usedFocusSlots = usedSlots + 1;
+
+      // Save the updated game state
+      await storage.updateGameState(gameId, {
+        ...gameState,
+        flags: gameState.flags as any, // Type assertion to handle unknown -> Json conversion
+        weeklyStats: gameState.weeklyStats as any, // Type assertion to handle unknown -> Json conversion
+        tierUnlockHistory: gameState.tierUnlockHistory as any // Type assertion to handle unknown -> Json conversion
+      });
+
+      // Return success response with updated state
+      res.json({
+        success: true,
+        executiveId: execId,
+        actionId: actionId,
+        gameId: gameId,
+        week: gameState.currentWeek,
+        usedSlots: gameState.usedFocusSlots,
+        totalSlots: totalSlots,
+        message: "Executive action processed successfully"
+      });
+    } catch (error) {
+      console.error('Failed to process executive action:', error);
+      res.status(500).json({ message: "Failed to process executive action" });
+    }
+  });
+
+  // Dialogue choices (legacy endpoint - kept for backwards compatibility)
+  router.get("/api/dialogue/:roleType", async (req, res) => {
+    try {
+      const { sceneId } = req.query;
+      const choices = await storage.getDialogueChoices(
+        req.params.roleType,
+        sceneId as string
+      );
+      res.json(choices);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch dialogue choices" });
+    }
+  });
+
+  // Get all dialogue scenes for frontend random selection
+  router.get("/api/dialogue-scenes", async (req, res) => {
+    try {
+      const dialogueData = await gameDataLoader.loadDialogueData();
+      res.json({
+        version: dialogueData.version,
+        scenes: dialogueData.additional_scenes
+      });
+    } catch (error) {
+      console.error('[API] Failed to load dialogue data:', error);
+      res.status(500).json({
+        message: "Failed to load dialogue data",
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+
+export default router;


### PR DESCRIPTION
## PR-8: Extract executives/roles router (Phase 1)

Pure move — no behavior, auth, path, or response-shape changes; no client changes.

### Endpoints moved to `server/routes/executives.ts` (6)
- `GET /api/roles/:roleId` (requireClerkUser) — uses `seededRandomPick`/`generateMeetingSeed`
- `GET /api/roles/:roleId/meetings/:meetingId` (requireClerkUser)
- `GET /api/game/:gameId/executives` (requireClerkUser)
- `POST /api/game/:gameId/executive/:execId/action` (requireClerkUser)
- `GET /api/dialogue/:roleType` — **legacy, NO auth (preserved)**
- `GET /api/dialogue-scenes` — **NO auth (preserved)**, uses `gameDataLoader` directly

### Wiring
- Full-path router, per-route middleware (matching PRs 2–7 convention).
- `app.use(executivesRouter)` mounted at the original position of `GET /api/roles/:roleId` (the first of these endpoints) to preserve global registration order.
- Removed now-unused imports from `routes.ts`: `gameDataLoader`, `seededRandomPick`, `generateMeetingSeed` (grep-audited; no remaining references).
- No `clamp` helper was in scope — the `clamp` in `routes.ts` lives inside the artist-dialogue handler (PR-9 territory), not any moved handler. Left untouched.

### Verification
- `npm run check` — passes (tsc clean).
- `npm run test:run` — **545 passing** (38 files), including the route-manifest snapshot test → manifest **byte-identical** (no route/middleware/auth lost).
- Verbatim-check: handler bodies compared against `git show main:server/routes.ts` (normalizing `app.`→`router.`, whitespace) — **match**. The only reported delta was a legacy comment line excluded by the comparison-slice boundary, not a body difference; the comment is present verbatim in the new file.
- `git diff --check` clean — no LF→CRLF noise.
- `routes.ts`: 3588 → 3384 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
