### PR TITLE
docs: Phase 1 pure-move completion (feature routers)

### DIFF
--- a/ai_instructions.md
+++ b/ai_instructions.md
@@ -8,7 +8,7 @@ You're working on **Top Roles: Music Label Manager**, a browser-based music indu
 ## Current State (Updated: July 1, 2026 — scaling arc underway)
 **Latest Session**: Decided against a game-engine rewrite; adopted a 4-phase scaling arc (CI safety net → server seams → engine seams → client state → game feel)
 - **Tech Stack**: React 18 + Vite, Express, PostgreSQL (Railway), Clerk auth, TypeScript, Zustand, React Query, XState
-- **Architecture**: GameEngine (`shared/engine/`) is the single source of truth for game logic; `server/routes.ts` decomposition into feature routers + services is in progress — see `docs/01-planning/implementation-specs/[READY] phase-1-server-routes-refactor-plan.md`
+- **Architecture**: GameEngine (`shared/engine/`) is the single source of truth for game logic; the `server/routes.ts` decomposition into feature routers is **done for all pure moves** — `routes.ts` is now a thin ~121-line registry mounting 16 feature routers from `server/routes/`. The follow-on **service extraction (PR-15..18) is still pending** — see `docs/01-planning/implementation-specs/[READY] phase-1-server-routes-refactor-plan.md`
 - **CI**: vitest suite (545 tests) + Playwright both run in `.github/workflows/playwright.yml`
 - **Current Phase**: Phase 1 of the scaling arc (route extraction, PR-2..18 of the plan)
 
@@ -41,7 +41,8 @@ You're working on **Top Roles: Music Label Manager**, a browser-based music indu
 - `client/src/components/ProjectCreationModal.tsx` - Project creation interface
 
 ### Backend
-- `server/routes.ts` - Express HTTP handling ONLY (delegates ALL business logic to GameEngine)
+- `server/routes.ts` - Thin route registry (~121 lines): mounts feature routers, exports `createServer`
+- `server/routes/` - Per-feature Express routers (emails, games, saves, releases, artists, projects, executives, arOffice, charts, tour, gameLoop, admin, content, devTools, bugReports, analytics); HTTP handling ONLY (delegates ALL business logic to GameEngine)
 - `server/storage.ts` - Pure database operations ONLY
 - `server/data/gameData.ts` - Pure JSON data access ONLY (NO calculations or business logic)
 
@@ -79,7 +80,7 @@ You're working on **Top Roles: Music Label Manager**, a browser-based music indu
 ### Adding a New Feature
 1. Define types in `shared/types/gameTypes.ts`
 2. Add API contract in `shared/api/contracts.ts`
-3. Implement server endpoint in `server/routes.ts`
+3. Implement server endpoint in the relevant `server/routes/<feature>.ts` router (register the full path; add auth middleware per-route)
 4. Create React Query hook in `client/src/features/[feature]/hooks/`
 5. Build UI component
 6. Update this document

--- a/docs/01-planning/implementation-specs/[READY] phase-1-server-routes-refactor-plan.md
+++ b/docs/01-planning/implementation-specs/[READY] phase-1-server-routes-refactor-plan.md
@@ -4,6 +4,29 @@
 *Status: READY — execution gated on merge order: PR #38 (vitest CI) → #36 → #37 → start Phase 1.*
 *Part of the four-phase scaling arc (Phase 0: CI safety net · Phase 1: server seams · Phase 2: engine seams · Phase 3: client state ownership · Phase 4: game feel).*
 
+## Execution status
+
+*Updated July 2, 2026. All pure-move PRs merged to `main`; `server/routes.ts` went 5,341 → 121 lines. Every PR was a pure move: byte-identical route-manifest snapshot, tsc clean, 545/545 vitest. (GitHub PR #49 was an unrelated docs PR, not part of this plan.)*
+
+- ✅ PR-1 — route-manifest characterization test (#39, prior session)
+- ✅ PR-2 — `bugReports.ts` router (#42)
+- ✅ PR-3 — `admin.ts` router (#43)
+- ✅ PR-4 — `emails.ts` router + email zod schemas (#44)
+- ✅ PR-5 — `devTools.ts` router (#45)
+- ✅ PR-6 — `content.ts` router (#46)
+- ✅ PR-7 — `arOffice.ts` router (#47)
+- ✅ PR-8 — `executives.ts` router (#48)
+- ✅ PR-9 — `artists.ts` router (#50)
+- ✅ PR-10 — `projects.ts` router (#51)
+- ✅ PR-11 — `charts.ts` + `tour.ts` routers (#52)
+- ✅ PR-12 — `releases.ts` router (#53)
+- ✅ PR-13 — `games.ts` router (#54)
+- ✅ PR-14 — `saves.ts` + `gameLoop.ts` routers (#55)
+- ⏳ PR-15 — `gameCreationService` extraction (pending)
+- ⏳ PR-16 — `saveService` extraction (pending)
+- ⏳ PR-17 — `releasePlanningService` extraction (pending)
+- ⏳ PR-18 — `artistService` extraction (pending)
+
 ## 0. Ground truth (verified against the working tree)
 
 - `server/routes.ts` is **5,341 lines** with **85 route registrations + 1 router mount** (`/api/analytics`).

--- a/docs/02-architecture/system-architecture.md
+++ b/docs/02-architecture/system-architecture.md
@@ -119,8 +119,13 @@ export const musicLabels = pgTable("music_labels", { /* player label identity */
 export const moodEvents = pgTable("mood_events", { /* artist mood history */ });
 ```
 
-### **3. REST API Layer (`/server/routes.ts`)**
+### **3. REST API Layer (`/server/routes.ts` + `/server/routes/`)**
 **Purpose**: HTTP interface for client-server communication
+
+**Structure** (as of Phase 1 route refactor — see `docs/01-planning/implementation-specs/[READY] phase-1-server-routes-refactor-plan.md`):
+- `server/routes.ts` is now a **thin registry (~121 lines)**: it wires the Clerk webhook + health + `/api/me`, then mounts 16 feature routers from `server/routes/` in the original registration order, and exports `createServer`. The prior monolithic 5,341-line file is gone.
+- **Feature routers** (`server/routes/`): `analytics`, `bugReports`, `admin`, `emails`, `devTools`, `content`, `arOffice`, `executives`, `artists`, `projects`, `charts`, `tour`, `releases`, `games`, `saves`, `gameLoop`.
+- **Full-path router convention**: each router registers its routes with the **full API path** (e.g. `/api/game/:gameId/emails`) and is mounted **bare** (`app.use(emailsRouter)`, not under a path prefix), with **auth middleware applied per-route** inside each router. Paths and behavior are unchanged from the monolith.
 
 **API Design Principles**:
 - **RESTful conventions**: Clear resource-based URLs

--- a/docs/05-backend/backend-architecture.md
+++ b/docs/05-backend/backend-architecture.md
@@ -24,8 +24,25 @@ The Music Label Manager backend is a **Node.js** application built with **Expres
 ```
 server/
 ├── index.ts              # Server entry point and configuration
-├── routes.ts             # All API endpoints and route handlers
-├── auth.ts               # Authentication system (Passport.js)
+├── routes.ts             # Thin route registry (~121 lines): webhook/health/me + mounts feature routers, exports createServer
+├── routes/               # Feature routers (one Express Router per domain)
+│   ├── analytics.ts      #   /api/analytics
+│   ├── bugReports.ts     #   bug report endpoints
+│   ├── admin.ts          #   admin-only endpoints
+│   ├── emails.ts         #   in-game inbox
+│   ├── devTools.ts       #   dev/debug tooling
+│   ├── content.ts        #   game content (some public/no-auth)
+│   ├── arOffice.ts       #   A&R Office operations
+│   ├── executives.ts     #   executive team + dialogue
+│   ├── artists.ts        #   artist signing/management
+│   ├── projects.ts       #   project creation/lifecycle
+│   ├── charts.ts         #   weekly charts
+│   ├── tour.ts           #   tour endpoints
+│   ├── releases.ts       #   release planning
+│   ├── games.ts          #   game lifecycle
+│   ├── saves.ts          #   save/load snapshots
+│   └── gameLoop.ts       #   advance-week / select-actions
+├── auth.ts               # Authentication system (Clerk)
 ├── db.ts                 # Database connection and configuration
 ├── storage.ts            # Data access layer abstraction
 ├── vite.ts               # Vite integration for development
@@ -50,7 +67,7 @@ shared/
 ## 🔧 Server Implementation
 
 ### **1. Express.js Route Structure**
-RESTful API implementation with middleware integration:
+RESTful API implementation, decomposed into per-feature routers (Phase 1 route refactor — see `docs/01-planning/implementation-specs/[READY] phase-1-server-routes-refactor-plan.md`). `server/routes.ts` is a thin registry that mounts 16 feature routers from `server/routes/`. Each router registers its **full API path** and is mounted **bare**, with **auth middleware applied per-route** inside the router. Endpoint paths, request/response behavior, and auth requirements are **unchanged** from the previous monolithic `routes.ts` — only the file organization changed.
 
 ```typescript
 // Core game operations


### PR DESCRIPTION
Reflects that all Phase 1 pure-move PRs are merged to `main`: `server/routes.ts` went from 5,341 lines to a thin ~121-line registry mounting 16 feature routers from `server/routes/`. Docs-only, no code changes. Service extractions (PR-15..18) remain pending.

## File updates
- **`docs/01-planning/implementation-specs/[READY] phase-1-server-routes-refactor-plan.md`** — added an "Execution status" section: PR-1..14 ✅ merged (mapped to #39, #42–#48, #50–#55; noted #49 was unrelated), PR-15..18 ⏳ pending. Plan line-number references left intact.
- **`docs/02-architecture/system-architecture.md`** — rewrote the REST API Layer section to describe the thin `routes.ts` + `server/routes/` feature routers, the full-path/bare-mount/per-route-auth convention, and a link to the Phase 1 plan. Endpoint examples kept (paths unchanged).
- **`docs/05-backend/backend-architecture.md`** — updated the server file-structure diagram to show `routes.ts` (thin registry) + the `routes/` subdirectory, and revised the "Express.js Route Structure" section to describe the feature-router decomposition (behavior/paths/auth unchanged).
- **`ai_instructions.md`** — updated only routes-related lines: decomposition no longer "in progress" for pure moves (service extraction still pending); Key Files now lists `server/routes/` routers; feature-add example points to the relevant router. No full rewrite (file is stale overall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
