### PR TITLE
ci: cache Playwright browsers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,20 @@ jobs:
         node-version: lts/*
     - name: Install dependencies
       run: npm ci
-    - name: Install Playwright Browsers
+    - name: Get installed Playwright version
+      id: playwright-version
+      run: echo "version=$(npm ls @playwright/test --json | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).dependencies['@playwright/test'].version))")" >> "$GITHUB_OUTPUT"
+    - name: Cache Playwright browsers
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+    - name: Install Playwright browser OS dependencies (cache hit)
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps
+    - name: Install Playwright Browsers (cache miss)
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test


### PR DESCRIPTION
## Summary
- Cache the Playwright browser binaries (`~/.cache/ms-playwright`) between CI runs, keyed on the resolved `@playwright/test` version, so we skip the full browser download on cache hits.
- On cache hit, only run `npx playwright install-deps` (OS-level libs, fast). On cache miss, run the existing `npx playwright install --with-deps` to download browsers + libs and seed the cache.
- Kept all three browser projects (chromium, firefox, webkit) since `playwright.config.ts` defines projects for all of them, not just chromium — narrowing to chromium-only would have skipped real cross-browser coverage.
- `vitest` job untouched.

## Details
- Version is read via `npm ls @playwright/test --json` after `npm ci`, so the cache key tracks the actual resolved version rather than the semver range in `package.json`.
- Cache key: `${{ runner.os }}-playwright-<resolved-version>` (e.g. `Linux-playwright-1.56.0`).
- Expected savings: roughly 1-3 minutes per run once the cache is warm (skips downloading Chromium/Firefox/WebKit binaries).
- Caveat: the first run after this merges will still be a cache miss and pay the full download cost — that's expected, it seeds the cache for subsequent runs. Bumping `@playwright/test` will also produce a fresh cache miss until re-seeded.

## Test plan
- [ ] YAML validated (`npx js-yaml .github/workflows/playwright.yml`)
- [ ] Merge and confirm first run does a cache miss + full install and populates the cache
- [ ] Confirm a subsequent run reports a cache hit and skips `playwright install --with-deps`, using `install-deps` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)