### PR TITLE
docs: release-experience trace plan + backlog C42-C45

### DIFF
--- a/docs/01-planning/implementation-specs/[FUTURE] release-experience-improvement-plan.md
+++ b/docs/01-planning/implementation-specs/[FUTURE] release-experience-improvement-plan.md
@@ -1,0 +1,73 @@
+# [FUTURE] Release Experience Improvement Plan
+
+**Status**: Deferred — sequenced behind Phase 1 service extractions (PR-16..18; PR-17 releasePlanningService touches this exact domain). Companion to `[FUTURE] tour-experience-improvement-plan.md` — the two systems have complementary halves of the same fix.
+*Created: July 2, 2026 (from a two-agent read-only code trace of the full release system, same method as the tour trace)*
+
+---
+
+## Problem Statement
+
+Plan Release shares the tour pathology — decisions front-loaded, feedback back-loaded, dead weeks between — but with a different disease underneath. Tours fake their weekly simulation (all results pre-rolled, cosmetically revealed); releases have an **honest weekly simulation** (streaming revenue rolled fresh each week with real decay) but **bury it in context-free output** and offer **zero mid-flight agency** — a planned release cannot be cancelled, edited, or rescheduled, and its marketing budget is charged at plan time and never refunded.
+
+---
+
+## How a Release Plays Today (verified against code, July 2, 2026)
+
+1. **Planning** (`client/src/pages/PlanReleasePage.tsx`) — the strongest planning UX in the game: song selection, auto-detected type (single/EP/album), week picker with seasonal multipliers, per-channel marketing sliders (radio/digital/PR/influencer), optional lead single with its own week + budget, and a live preview (`POST /api/game/:gameId/releases/preview`, `server/routes/releases.ts:314`) showing estimated streams/revenue, ROI, and every multiplier (release bonus, seasonal, marketing synergy, channel diversity, lead-single boost). On commit (`POST .../releases/plan`, `server/routes/releases.ts:435`): full marketing budget + 1 creative capital deducted immediately; songs lock to the release.
+2. **Waiting weeks** — a timeline card (`client/src/components/ReleaseWorkflowCard.tsx`) with progress bar and phase badges ("Campaign Planned" → "Lead Single Live"). Static: no weekly updates, no anticipation mechanics, silent in WeekSummary.
+3. **Lead single week** (`shared/engine/game-engine.ts:1860-1973`, `processLeadSingles`) — releases separately with real revenue; after week 1 it dissolves into generic "ongoing streams" lines. No hot/cold signal during the exact 1–3 week window where that information should matter.
+4. **Release week** (`game-engine.ts:1979-2165`, `processPlannedReleases`) — good one-time payoff: WeekSummary lines ("🎉 Released: …"), artist mood boost (+5 single / +20 EP-album), distribution email, chart tab, detailed post-release card (campaign tier, ROI, cost-per-stream, track breakdown with lead-single contribution).
+5. **Weeks after** (`game-engine.ts:1572-1854`, `processReleasedProjects`) — revenue **rolled fresh weekly** with decay (weekly_decay_rate 0.85, reputation/access-tier bonuses; `FinancialSystem.calculateOngoingSongRevenue`). Surfaced only as undifferentiated "🎵 \"song\" ongoing streams" lines — no trend, no rise-vs-fade signal.
+
+### Tour vs. Release comparison
+
+| | Tours | Releases |
+|---|---|---|
+| Simulation honesty | Fake — pre-rolled, drip-revealed | Real — weekly decay, rolled fresh |
+| Weekly feedback | One flat line | Many noisy lines, no context/trend |
+| Mid-flight agency | Cancel (60% refund) | **None** — no cancel/edit/reschedule |
+| Planning UX | Good | Excellent |
+
+### Distinctive problems
+
+1. **The awareness system is elaborate dead bookkeeping** (`game-engine.ts:1617-1750`): weekly awareness gain from marketing (weeks 1–4), breakthrough checks (weeks 3–6, 2.5× awareness explosion, slower decay), decay (weeks 5+) — computed, persisted per song, announced in WeekSummary ("🔥 BREAKTHROUGH ACHIEVED!") — and **feeds into nothing**: not streams, not charts, not revenue. The game celebrates a stat with zero mechanical existence. Config in `data/balance/markets.json` (awareness_system); design doc exists (`[FUTURE] awareness-system-design.md`); the "Awareness System Backend Integration" item in DEVELOPMENT_STATUS was never finished.
+2. **Committed money is a black hole**: marketing charged at plan time, no cancel/edit/reschedule endpoint anywhere — a week-30 release planned on week 8 locks that cash for 22 weeks regardless of circumstances.
+3. **Preview and execution are separate code paths** (`calculateReleasePreview`, `game-engine.ts:4692-4941` vs `calculateSophisticatedReleaseOutcome`) — same divergence pathology as the snapshot-built-in-two-places bug (backlog C35) that already shipped a real defect once.
+4. **Rich analytics computed once, shown once**: campaign effectiveness, cost-per-stream, stream distribution, lead-single contribution (`releaseAnalytics.ts`) appear only on the post-release card; nothing evolves weekly. Chart entries update weekly via ChartService but movements aren't called out.
+
+---
+
+## Proposed Solutions (tiered)
+
+### Tier 1 — Surfacing (no engine math changes)
+- **Contextualize ongoing-revenue lines**: trend arrow vs. last week, "week 3 since release", grouped per release instead of a flat list.
+- **Lead-single spotlight** during the pre-release gap: "First week: 41k streams — above projection" on the release card and WeekSummary.
+- **Dashboard countdown / anticipation**: "*Neon Nights* drops in 2 weeks".
+- **Chart movement callouts**: "debuted at #23", "climbed 8 spots" (data already computed by ChartService weekly).
+
+### Tier 2 — Make the systems honest
+- **Awareness: wire it or retire it.** Preferred: feed awareness into the ongoing streaming multiplier per the existing design doc — instantly makes weeks 1–6 matter and gives breakthroughs a real payoff. Alternative: stop announcing a stat with no effect.
+- **Unify preview/execution** into one shared calculation path (prevents C35-style drift).
+- **Weekly campaign-digest email** while a release is live (template exists; only fires once at release).
+
+### Tier 3 — Agency
+- **Cancel/reschedule a planned release** with partial refund — mirror the tour rule but compute it server-side from day one (avoid repeating C40).
+- **One mid-campaign decision** keyed to lead-single performance: double the launch marketing / push the release back / swap the lead single. Meaningful precisely because release outcomes are *not* pre-rolled.
+
+---
+
+## Debt found in passing (tracked in technical-debt-backlog.md)
+
+- **C42 (Medium)**: awareness system computed + announced but mechanically dead — product decision to wire or remove.
+- **C43 (Medium)**: no cancel/edit endpoint for planned releases; funds locked with no recovery path.
+- **C44 (High)**: preview vs execution dual code path.
+- **C45 (Low)**: `star_power_amplification` config enabled but unconsumed; `pressMentions` TODO (press pickups computed, only reputation used).
+
+---
+
+## Sequencing
+
+1. **After PR-17 (releasePlanningService)** lands: this domain's code will have its final Phase 1 shape — implement against that.
+2. **Tier 1** is one focused PR (pure surfacing; data already exists).
+3. **Tier 2 awareness decision** is the highest-leverage item — pairs with the Phase 4 game-feel track, and the tour plan's Tier 2 (per-week rolls + momentum) so both systems converge on "honest weekly simulation, visibly surfaced".
+4. **Tier 3** needs a short PRD (refund %, what's editable, decision-point design).

--- a/docs/09-troubleshooting/technical-debt-backlog.md
+++ b/docs/09-troubleshooting/technical-debt-backlog.md
@@ -9,10 +9,10 @@
 
 - **Created**: September 2025 (Artist Mood System Implementation - commit `4991ab3`)
 - **Last Updated**: July 2, 2026
-- **Total Items**: 41
+- **Total Items**: 45
 - **Completed**: 37
 - **In Progress**: 0
-- **Pending**: 4
+- **Pending**: 8
 
 ---
 
@@ -645,13 +645,13 @@ The `"{label} - Week {n}"` format is constructed independently in `client/src/st
 ### Comment 40: Tour cancellation trusts client-supplied refundAmount 🟡
 **Status**: 📋 **PENDING**
 
-The 60% tour-cancellation refund is computed entirely client-side (`client/src/components/ActiveTours.tsx`, `refundPercentage = 0.6`) and sent in the request body of `POST /api/projects/:id/cancel`. The server (currently `server/routes.ts:1934`; will move with the Phase 1 tour-domain route PR) applies the client's `refundAmount` to the player's money without recomputing or capping it — any refund amount can be submitted.
+The 60% tour-cancellation refund is computed entirely client-side (`client/src/components/ActiveTours.tsx`, `refundPercentage = 0.6`) and sent in the request body of `DELETE /api/projects/:id/cancel`. The server (`server/routes/projects.ts:205` since the Phase 1 route moves) applies the client's `refundAmount` to the player's money without recomputing or capping it — any refund amount can be submitted.
 
-**Action**: Recompute the refund server-side (`(totalCost / plannedCities) * remainingCities * 0.6`) and ignore or validate the client value; move the 60% constant to balance config while at it. **Do as a standalone PR after the Phase 1 tour-domain route move lands** — don't touch `routes.ts` mid-decomposition.
+**Action**: Recompute the refund server-side (`(totalCost / plannedCities) * remainingCities * 0.6`) and ignore or validate the client value; move the 60% constant to balance config while at it. **Unblocked as of July 2, 2026** — the Phase 1 route moves are done; do as a standalone PR.
 
 **Relevant Files**:
 - [client/src/components/ActiveTours.tsx](client/src/components/ActiveTours.tsx)
-- [server/routes.ts](server/routes.ts)
+- [server/routes/projects.ts](server/routes/projects.ts)
 
 *Identified July 2, 2026 during the tour-experience code trace (see `docs/01-planning/implementation-specs/[FUTURE] tour-experience-improvement-plan.md`).*
 
@@ -671,18 +671,78 @@ The 60% tour-cancellation refund is computed entirely client-side (`client/src/c
 
 ---
 
+### Comment 42: Awareness system is fully implemented dead bookkeeping 🟢
+**Status**: 📋 **PENDING**
+
+The song awareness system (`shared/engine/game-engine.ts:1617-1750`) runs every week: awareness gain from marketing channels (weeks 1–4), breakthrough checks with 2.5× awareness explosions (weeks 3–6), and decay (weeks 5+). Values are persisted per song and announced in WeekSummary ("🔥 BREAKTHROUGH ACHIEVED!") — but awareness feeds into **nothing**: not streaming revenue, not charts, not any financial metric. The game celebrates a stat with zero mechanical existence. Config lives in `data/balance/markets.json` (awareness_system); the integration design exists in `docs/01-planning/implementation-specs/[FUTURE] awareness-system-design.md` but the "Awareness System Backend Integration" work was never finished.
+
+**Action**: Product decision — either wire awareness into the ongoing streaming multiplier (preferred; see the release-experience plan Tier 2) or stop surfacing it in WeekSummary until it does something.
+
+**Relevant Files**:
+- [shared/engine/game-engine.ts](shared/engine/game-engine.ts)
+- [data/balance/markets.json](data/balance/markets.json)
+
+*Identified July 2, 2026 during the release-experience code trace (see `docs/01-planning/implementation-specs/[FUTURE] release-experience-improvement-plan.md`).*
+
+---
+
+### Comment 43: Planned releases cannot be cancelled, edited, or rescheduled 🟢
+**Status**: 📋 **PENDING**
+
+`POST /api/game/:gameId/releases/plan` (`server/routes/releases.ts:435`) deducts the full marketing budget plus 1 creative capital at plan time and locks songs to the release — and there is no endpoint (or UI) to cancel, edit, or reschedule a planned release afterward. Money committed to a distant release week is unrecoverable regardless of changed circumstances. Tours, by contrast, support cancellation with a 60% refund.
+
+**Action**: Add a cancel (and optionally reschedule) endpoint with a partial refund, computed server-side from day one (don't repeat C40's client-trust mistake). Land after PR-17 (releasePlanningService) settles this domain.
+
+**Relevant Files**:
+- [server/routes/releases.ts](server/routes/releases.ts)
+- [client/src/components/ReleaseWorkflowCard.tsx](client/src/components/ReleaseWorkflowCard.tsx)
+
+*Identified July 2, 2026 during the release-experience code trace.*
+
+---
+
+### Comment 44: Release preview and execution are separate calculation code paths 🟡
+**Status**: 📋 **PENDING**
+
+The planning preview uses `GameEngine.calculateReleasePreview()` (`shared/engine/game-engine.ts:4692-4941`) while release-week execution uses `calculateSophisticatedReleaseOutcome()` — two independent implementations of the same multiplier chain (release type, seasonal, marketing synergy/diversity, lead-single boost). Any change to one that misses the other silently makes the preview lie to the player. Same divergence pathology as C35 (snapshot built in two places), which already shipped a real bug once.
+
+**Action**: Extract one shared calculation used by both the preview endpoint and week-advance execution. Natural fit for the PR-17 releasePlanningService extraction or immediately after it.
+
+**Relevant Files**:
+- [shared/engine/game-engine.ts](shared/engine/game-engine.ts)
+- [server/routes/releases.ts](server/routes/releases.ts)
+
+*Identified July 2, 2026 during the release-experience code trace.*
+
+---
+
+### Comment 45: Dead release config and unsurfaced press data 🔵
+**Status**: 📋 **PENDING**
+
+Two small leftovers from the release trace: (1) `data/balance/markets.json` `streaming_calculation.star_power_amplification` is `enabled: true` but nothing in the engine consumes it — dead config that reads as a live mechanic; (2) `calculatePressOutcome()` computes a detailed result (pickups count, structure) but only `reputationGain` is used, and `summary.pressMentions` is a standing `TODO` (`shared/engine/game-engine.ts:319`).
+
+**Action**: Either implement star-power amplification and press-mention surfacing or delete the dead config/fields so balance files reflect reality.
+
+**Relevant Files**:
+- [data/balance/markets.json](data/balance/markets.json)
+- [shared/engine/game-engine.ts](shared/engine/game-engine.ts)
+
+*Identified July 2, 2026 during the release-experience code trace.*
+
+---
+
 ## 📊 **Summary Statistics**
 
 ### By Priority
 - 🔴 Critical: 0 items (all completed! 🎉)
-- 🟡 High: 1 item (C40)
-- 🟢 Medium: 1 item (C41)
-- 🔵 Low: 2 items (C26, C32)
+- 🟡 High: 2 items (C40, C44)
+- 🟢 Medium: 3 items (C41, C42, C43)
+- 🔵 Low: 3 items (C26, C32, C45)
 
 ### By Status
-- ✅ Completed: 37 items (90.2%)
+- ✅ Completed: 37 items (82.2%)
 - 🚧 In Progress: 0 items (0%)
-- 📋 Pending: 4 items (9.8%)
+- 📋 Pending: 8 items (17.8%)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `[FUTURE] release-experience-improvement-plan.md` — companion to the tour-experience plan, from a two-agent read-only trace of the Plan Release system (player-facing flow + engine mechanics)
- Adds backlog items **C42–C45**:
  - C42 🟢 awareness system is fully implemented dead bookkeeping (computed + announced weekly, feeds into nothing)
  - C43 🟢 planned releases cannot be cancelled/edited/rescheduled (funds locked at plan time)
  - C44 🟡 preview vs execution are separate calculation code paths (C35-style drift risk)
  - C45 🔵 dead `star_power_amplification` config + unsurfaced press data
- Updates **C40** (tour refund exploit) to unblocked, with the post-Phase-1 route path (`server/routes/projects.ts:205`)

Docs only — no code changes. Sequencing in the plan doc gates implementation behind PR-17 (releasePlanningService).

🤖 Generated with [Claude Code](https://claude.com/claude-code)