### PR TITLE
refactor(saves): extract saveService (PR-16)

### DIFF
--- a/server/routes/saves.ts
+++ b/server/routes/saves.ts
@@ -1,82 +1,11 @@
 import { Router } from 'express';
-import { randomUUID } from 'crypto';
 import { z } from 'zod';
 import { storage } from '../storage';
-import { db } from '../db';
-import { eq, inArray } from 'drizzle-orm';
 import { requireClerkUser } from '../auth';
-import {
-  insertGameSaveSchema,
-  gameSaveSnapshotSchema,
-  gameStates,
-  weeklyActions,
-  projects,
-  songs,
-  artists,
-  releases,
-  releaseSongs,
-  roles,
-  executives,
-  musicLabels,
-  moodEvents,
-  emails,
-  type GameSaveSnapshot,
-  SNAPSHOT_VERSION,
-} from '@shared/schema';
+import { insertGameSaveSchema } from '@shared/schema';
+import { saveService } from '../services/saveService';
 
 const router = Router();
-
-const validateSnapshotCollections = (snapshot: GameSaveSnapshot) => {
-  const errors: string[] = [];
-
-  const ensureArray = (value: unknown, name: string): value is unknown[] => {
-    if (value === undefined || value === null) return false;
-    if (!Array.isArray(value)) {
-      errors.push(`${name} must be an array`);
-      return false;
-    }
-    return true;
-  };
-
-  if (ensureArray(snapshot.releaseSongs, 'releaseSongs')) {
-    snapshot.releaseSongs.forEach((entry, index) => {
-      if (!entry || typeof entry.releaseId !== 'string' || typeof entry.songId !== 'string') {
-        errors.push(`releaseSongs[${index}] is missing required releaseId/songId`);
-      }
-    });
-  }
-
-  if (ensureArray(snapshot.executives, 'executives')) {
-    snapshot.executives.forEach((exec: any, index) => {
-      if (!exec || typeof exec.id !== 'string' || typeof exec.role !== 'string') {
-        errors.push(`executives[${index}] is missing required id/role`);
-      }
-    });
-  }
-
-  if (ensureArray(snapshot.moodEvents, 'moodEvents')) {
-    snapshot.moodEvents.forEach((event: any, index) => {
-      if (!event || typeof event.id !== 'string' || typeof event.artistId !== 'string') {
-        errors.push(`moodEvents[${index}] is missing required id/artistId`);
-      }
-    });
-  }
-
-  if (ensureArray(snapshot.emails, 'emails')) {
-    snapshot.emails.forEach((email: any, index) => {
-      if (!email || typeof (email as any).id !== 'string' || typeof email.subject !== 'string') {
-        errors.push(`emails[${index}] is missing required id/subject`);
-      }
-    });
-  }
-
-  if (errors.length > 0) {
-    const error = new Error('Invalid snapshot collections');
-    (error as any).code = 'INVALID_SNAPSHOT_COLLECTIONS';
-    (error as any).details = errors;
-    throw error;
-  }
-};
 
   // Save game routes
   router.get("/api/saves", requireClerkUser, async (req, res) => {
@@ -110,28 +39,17 @@ const validateSnapshotCollections = (snapshot: GameSaveSnapshot) => {
   router.post("/api/saves", requireClerkUser, async (req, res) => {
     try {
       const validatedData = insertGameSaveSchema.parse(req.body);
-      const snapshot = validatedData.gameState;
-      const snapshotGameId = snapshot?.gameState?.id;
 
-      if (!snapshotGameId) {
+      const save = await saveService.createSave(req.userId!, validatedData);
+
+      res.json(save);
+    } catch (error) {
+      if ((error as any)?.code === 'INVALID_SNAPSHOT') {
         return res.status(400).json({
           error: 'INVALID_SNAPSHOT',
           message: 'Save snapshot is missing game identifier'
         });
       }
-
-      const save = await storage.createGameSave({
-        ...validatedData,
-        week: snapshot.gameState.currentWeek,
-        userId: req.userId!,
-      });
-
-      if (validatedData.isAutosave) {
-        await storage.purgeOldAutosaves(req.userId!, snapshotGameId, 3);
-      }
-
-      res.json(save);
-    } catch (error) {
       if (error instanceof z.ZodError) {
         res.status(400).json({ message: "Invalid save data", errors: error.errors });
       } else {
@@ -146,522 +64,39 @@ const validateSnapshotCollections = (snapshot: GameSaveSnapshot) => {
       mode: z.enum(['overwrite', 'fork']).default('overwrite'),
     });
 
-    // Helper function to convert timestamp strings to Date objects
-    const convertTimestamps = (obj: any): any => {
-      if (!obj || typeof obj !== 'object') return obj;
-
-      if (Array.isArray(obj)) {
-        return obj.map(item => convertTimestamps(item));
-      }
-
-      const converted: any = {};
-      for (const [key, value] of Object.entries(obj)) {
-        // Convert fields that end with 'At' or are known timestamp fields
-        if ((key.endsWith('At') || key === 'createdAt' || key === 'updatedAt') &&
-            typeof value === 'string' && value) {
-          converted[key] = new Date(value);
-        } else if (value && typeof value === 'object') {
-          converted[key] = convertTimestamps(value);
-        } else {
-          converted[key] = value;
-        }
-      }
-      return converted;
-    };
-
     try {
       const { mode } = restoreRequestSchema.parse(req.body ?? {});
 
-      const save = await storage.getGameSaveForUser(req.params.saveId, req.userId!);
-      if (!save) {
+      const result = mode === 'overwrite'
+        ? await saveService.restoreOverwrite(req.params.saveId, req.userId!)
+        : await saveService.restoreFork(req.params.saveId, req.userId!);
+
+      return res.json(result);
+    } catch (error) {
+      if ((error as any)?.code === 'SAVE_NOT_FOUND') {
         return res.status(404).json({
           error: 'SAVE_NOT_FOUND',
           message: 'Save file not found or does not belong to this user',
         });
       }
-
-      const snapshot = gameSaveSnapshotSchema.parse(save.gameState) as GameSaveSnapshot;
-      if ((snapshot.snapshotVersion ?? 1) !== SNAPSHOT_VERSION) {
+      if ((error as any)?.code === 'UNSUPPORTED_SNAPSHOT_VERSION') {
         return res.status(400).json({
           error: 'UNSUPPORTED_SNAPSHOT_VERSION',
-          message: `Snapshot version ${snapshot.snapshotVersion ?? 1} is not supported. Expected version ${SNAPSHOT_VERSION}.`,
+          message: (error as Error).message,
         });
       }
-      const targetGameState = snapshot.gameState;
-      const sourceGameId = targetGameState?.id;
-
-      validateSnapshotCollections(snapshot);
-
-      if (!sourceGameId) {
+      if ((error as any)?.code === 'INVALID_SNAPSHOT') {
         return res.status(400).json({
           error: 'INVALID_SNAPSHOT',
           message: 'Save snapshot is missing game identifier',
         });
       }
-
-      if (mode === 'overwrite') {
-        console.log('[RESTORE] Starting overwrite mode for game:', sourceGameId);
-        const existingGame = await storage.getGameState(sourceGameId);
-        if (!existingGame || existingGame.userId !== req.userId) {
-          return res.status(403).json({
-            error: 'UNAUTHORIZED',
-            message: 'You do not have permission to restore this game',
-          });
-        }
-
-        console.log('[RESTORE] Beginning transaction...');
-        await db.transaction(async (tx) => {
-          console.log('[RESTORE] Step 1: Updating game_states...');
-          await tx.update(gameStates)
-            .set({
-              currentWeek: targetGameState.currentWeek,
-              money: targetGameState.money,
-              reputation: targetGameState.reputation,
-              creativeCapital: targetGameState.creativeCapital,
-              focusSlots: targetGameState.focusSlots ?? existingGame.focusSlots,
-              usedFocusSlots: targetGameState.usedFocusSlots ?? 0,
-              arOfficeSlotUsed: targetGameState.arOfficeSlotUsed ?? false,
-              arOfficeSourcingType: targetGameState.arOfficeSourcingType ?? null,
-              arOfficePrimaryGenre: targetGameState.arOfficePrimaryGenre ?? null,
-              arOfficeSecondaryGenre: targetGameState.arOfficeSecondaryGenre ?? null,
-              arOfficeOperationStart: targetGameState.arOfficeOperationStart ?? null,
-              playlistAccess: targetGameState.playlistAccess ?? existingGame.playlistAccess,
-              pressAccess: targetGameState.pressAccess ?? existingGame.pressAccess,
-              venueAccess: targetGameState.venueAccess ?? existingGame.venueAccess,
-              campaignType: targetGameState.campaignType ?? existingGame.campaignType,
-              campaignCompleted: targetGameState.campaignCompleted ?? existingGame.campaignCompleted,
-              rngSeed: targetGameState.rngSeed ?? existingGame.rngSeed,
-              flags: targetGameState.flags ?? existingGame.flags ?? {},
-              weeklyStats: targetGameState.weeklyStats ?? existingGame.weeklyStats ?? {},
-              tierUnlockHistory: targetGameState.tierUnlockHistory ?? existingGame.tierUnlockHistory ?? {},
-              userId: req.userId!,
-              updatedAt: new Date(),
-            })
-            .where(eq(gameStates.id, sourceGameId));
-
-          // IMPORTANT: Delete in order of foreign key dependencies (children first, parents last)
-          // Deletion ordering summary:
-          // 1. release_songs → depends on releases & songs (junction table must be cleared first)
-          // 2. songs → depends on artists, projects, releases (remove track rows before their parents)
-          // 3. releases → depends on artists (planned releases point back to artist roster)
-          // 4. projects → depends on artists (projects reference artist owners)
-          // 5. mood_events → depends on artists (events track artist history)
-          // 6. artists → depends only on game state once children are gone
-          // 7. roles / weekly_actions / music_labels / emails / executives → all hang directly off game_state
-          // The inserts later run in the exact reverse order so parents exist before their dependent rows.
-
-          console.log('[RESTORE] Step 2: Deleting release_songs junction table...');
-          // Clear junction table first so dependent release/song deletions don't hit FK constraints
-          const releaseRows = await tx
-            .select({ id: releases.id })
-            .from(releases)
-            .where(eq(releases.gameId, sourceGameId));
-
-          if (releaseRows.length > 0) {
-            const releaseIds = releaseRows.map(({ id }) => id);
-            await tx
-              .delete(releaseSongs)
-              .where(inArray(releaseSongs.releaseId, releaseIds));
-          }
-
-          console.log('[RESTORE] Step 3: Deleting songs (depends on artists, projects, releases)...');
-          // Remove songs before their parent releases/projects/artists to keep FK chain intact
-          await tx.delete(songs).where(eq(songs.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 4: Deleting releases (depends on artists)...');
-          // Releases reference artists; with tracks gone we can safely drop the release rows
-          await tx.delete(releases).where(eq(releases.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 5: Deleting projects (depends on artists)...');
-          // Projects still point at artists, so they must disappear before we remove the roster
-          await tx.delete(projects).where(eq(projects.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 6: Deleting mood_events (depends on artists)...');
-          // Mood history also references artists; delete events prior to artist removal
-          await tx.delete(moodEvents).where(eq(moodEvents.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 7: Deleting artists (no more dependencies)...');
-          // With all child tables cleared we can drop artist rows
-          await tx.delete(artists).where(eq(artists.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 8: Deleting roles...');
-          // Remaining tables (roles/weekly_actions/label/emails/executives) hang directly off game_state
-          await tx.delete(roles).where(eq(roles.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 9: Deleting weekly_actions...');
-          await tx.delete(weeklyActions).where(eq(weeklyActions.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 10: Deleting music_labels...');
-          await tx.delete(musicLabels).where(eq(musicLabels.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 11: Deleting emails...');
-          await tx.delete(emails).where(eq(emails.gameId, sourceGameId));
-
-          console.log('[RESTORE] Step 12: Deleting executives...');
-          await tx.delete(executives).where(eq(executives.gameId, sourceGameId));
-
-          // Now insert everything back in reverse order (parents first, children last)
-
-          console.log('[RESTORE] Step 13: Reinserting music_labels...');
-          // Rebuild parents first so dependent collections have targets
-          if (snapshot.musicLabel) {
-            await tx.insert(musicLabels).values(
-              convertTimestamps({
-                ...snapshot.musicLabel,
-                gameId: sourceGameId,
-              }) as any
-            );
-          }
-
-          console.log('[RESTORE] Step 14: Reinserting weekly_actions...');
-          // Weekly history depends only on game state, insert early for clarity
-          if (Array.isArray(snapshot.weeklyActions) && snapshot.weeklyActions.length > 0) {
-            await tx.insert(weeklyActions).values(
-              snapshot.weeklyActions.map((action) =>
-                convertTimestamps({
-                  ...action,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 15: Reinserting roles...');
-          // Roles also hang off the game directly
-          if (Array.isArray(snapshot.roles) && snapshot.roles.length > 0) {
-            await tx.insert(roles).values(
-              snapshot.roles.map((role) =>
-                convertTimestamps({
-                  ...role,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 16: Reinserting artists...');
-          // Restore roster before any collection that references artist IDs
-          if (Array.isArray(snapshot.artists) && snapshot.artists.length > 0) {
-            await tx.insert(artists).values(
-              snapshot.artists.map((artist) =>
-                convertTimestamps({
-                  ...artist,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 17: Reinserting mood_events...');
-          // Mood events can now target their owning artists
-          if (Array.isArray(snapshot.moodEvents) && snapshot.moodEvents.length > 0) {
-            await tx.insert(moodEvents).values(
-              snapshot.moodEvents.map((event: any) =>
-                convertTimestamps({
-                  ...event,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 18: Reinserting projects...');
-          // Projects require artist IDs but must exist before songs referencing project_id
-          if (Array.isArray(snapshot.projects) && snapshot.projects.length > 0) {
-            await tx.insert(projects).values(
-              snapshot.projects.map((project) =>
-                convertTimestamps({
-                  ...project,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 19: Reinserting releases...');
-          // Releases depend on artists and are parents for songs/release_songs
-          if (Array.isArray(snapshot.releases) && snapshot.releases.length > 0) {
-            await tx.insert(releases).values(
-              snapshot.releases.map((release) =>
-                convertTimestamps({
-                  ...release,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 20: Reinserting songs...');
-          // Songs can now safely reference artists/projects/releases
-          if (Array.isArray(snapshot.songs) && snapshot.songs.length > 0) {
-            await tx.insert(songs).values(
-              snapshot.songs.map((song) =>
-                convertTimestamps({
-                  ...song,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 21: Reinserting release_songs...');
-          // Junction requires both song and release rows to exist first
-          if (Array.isArray(snapshot.releaseSongs) && snapshot.releaseSongs.length > 0) {
-            await tx.insert(releaseSongs).values(
-              snapshot.releaseSongs.map((entry: any) => ({
-                releaseId: entry.releaseId,
-                songId: entry.songId,
-                trackNumber: entry.trackNumber ?? 0,
-                isSingle: entry.isSingle ?? false,
-              })) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 22: Reinserting executives...');
-          // Executives and emails only reference the game so they can go near the end
-          if (Array.isArray(snapshot.executives) && snapshot.executives.length > 0) {
-            await tx.insert(executives).values(
-              snapshot.executives.map((exec: any) =>
-                convertTimestamps({
-                  ...exec,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Step 23: Reinserting emails...');
-          // Final pass restores inbox entries tied to the game
-          if (Array.isArray(snapshot.emails) && snapshot.emails.length > 0) {
-            await tx.insert(emails).values(
-              snapshot.emails.map((email) =>
-                convertTimestamps({
-                  ...email,
-                  gameId: sourceGameId,
-                })
-              ) as any,
-            );
-          }
-
-          console.log('[RESTORE] Transaction complete!');
+      if ((error as any)?.code === 'UNAUTHORIZED') {
+        return res.status(403).json({
+          error: 'UNAUTHORIZED',
+          message: 'You do not have permission to restore this game',
         });
-
-        return res.json({ gameId: sourceGameId });
       }
-
-      const idMap = new Map<string, string>();
-      const mapId = (value?: string | null, create = true) => {
-        if (!value) return value;
-        if (!idMap.has(value)) {
-          if (!create) {
-            return value;
-          }
-          idMap.set(value, randomUUID());
-        }
-        return idMap.get(value)!;
-      };
-
-      const mapReference = (value?: string | null) => mapId(value, false);
-
-      const newGameId = mapId(sourceGameId)!;
-
-      if (snapshot.musicLabel) {
-        mapId((snapshot.musicLabel as any).id ?? undefined);
-      }
-      if (Array.isArray(snapshot.weeklyActions)) {
-        snapshot.weeklyActions.forEach((action) => mapId(action.id));
-      }
-      if (Array.isArray(snapshot.artists)) {
-        snapshot.artists.forEach((artist) => mapId(artist.id));
-      }
-      if (Array.isArray(snapshot.projects)) {
-        snapshot.projects.forEach((project) => mapId(project.id));
-      }
-      if (Array.isArray(snapshot.roles)) {
-        snapshot.roles.forEach((role) => mapId(role.id));
-      }
-      if (Array.isArray(snapshot.releases)) {
-        snapshot.releases.forEach((release) => mapId(release.id));
-      }
-      if (Array.isArray(snapshot.songs)) {
-        snapshot.songs.forEach((song) => mapId(song.id));
-      }
-      if (Array.isArray(snapshot.executives)) {
-        snapshot.executives.forEach((exec) => mapId(exec.id));
-      }
-      if (Array.isArray(snapshot.moodEvents)) {
-        snapshot.moodEvents.forEach((event) => mapId(event.id));
-      }
-      if (Array.isArray(snapshot.emails)) {
-        snapshot.emails.forEach((email) => mapId((email as any).id));
-      }
-
-      await db.transaction(async (tx) => {
-        await tx.insert(gameStates).values({
-          id: newGameId,
-          userId: req.userId!,
-          currentWeek: targetGameState.currentWeek,
-          money: targetGameState.money,
-          reputation: targetGameState.reputation,
-          creativeCapital: targetGameState.creativeCapital,
-          focusSlots: targetGameState.focusSlots ?? 3,
-          usedFocusSlots: targetGameState.usedFocusSlots ?? 0,
-          arOfficeSlotUsed: targetGameState.arOfficeSlotUsed ?? false,
-          arOfficeSourcingType: targetGameState.arOfficeSourcingType ?? null,
-          arOfficePrimaryGenre: targetGameState.arOfficePrimaryGenre ?? null,
-          arOfficeSecondaryGenre: targetGameState.arOfficeSecondaryGenre ?? null,
-          arOfficeOperationStart: targetGameState.arOfficeOperationStart ?? null,
-          playlistAccess: targetGameState.playlistAccess ?? 'none',
-          pressAccess: targetGameState.pressAccess ?? 'none',
-          venueAccess: targetGameState.venueAccess ?? 'none',
-          campaignType: targetGameState.campaignType ?? 'Balanced',
-          campaignCompleted: targetGameState.campaignCompleted ?? false,
-          rngSeed: targetGameState.rngSeed ?? null,
-          flags: targetGameState.flags ?? {},
-          weeklyStats: targetGameState.weeklyStats ?? {},
-          tierUnlockHistory: targetGameState.tierUnlockHistory ?? {},
-        });
-
-        if (snapshot.musicLabel) {
-          await tx.insert(musicLabels).values(
-            convertTimestamps({
-              ...snapshot.musicLabel,
-              id: mapId((snapshot.musicLabel as any).id ?? undefined),
-              gameId: newGameId,
-            }) as any
-          );
-        }
-
-        if (Array.isArray(snapshot.weeklyActions) && snapshot.weeklyActions.length > 0) {
-          await tx.insert(weeklyActions).values(
-            snapshot.weeklyActions.map((action) =>
-              convertTimestamps({
-                ...action,
-                id: mapId(action.id),
-                gameId: newGameId,
-                targetId: mapReference(action.targetId as string | undefined),
-                choiceId: mapReference(action.choiceId as string | undefined),
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.artists) && snapshot.artists.length > 0) {
-          await tx.insert(artists).values(
-            snapshot.artists.map((artist) =>
-              convertTimestamps({
-                ...artist,
-                id: mapId(artist.id),
-                gameId: newGameId,
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.projects) && snapshot.projects.length > 0) {
-          await tx.insert(projects).values(
-            snapshot.projects.map((project) =>
-              convertTimestamps({
-                ...project,
-                id: mapId(project.id),
-                gameId: newGameId,
-                artistId: mapReference(project.artistId),
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.roles) && snapshot.roles.length > 0) {
-          await tx.insert(roles).values(
-            snapshot.roles.map((role) =>
-              convertTimestamps({
-                ...role,
-                id: mapId(role.id),
-                gameId: newGameId,
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.executives) && snapshot.executives.length > 0) {
-          await tx.insert(executives).values(
-            snapshot.executives.map((exec) =>
-              convertTimestamps({
-                ...exec,
-                id: mapId(exec.id),
-                gameId: newGameId,
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.releases) && snapshot.releases.length > 0) {
-          await tx.insert(releases).values(
-            snapshot.releases.map((release) =>
-              convertTimestamps({
-                ...release,
-                id: mapId(release.id),
-                gameId: newGameId,
-                artistId: mapReference(release.artistId),
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.songs) && snapshot.songs.length > 0) {
-          await tx.insert(songs).values(
-            snapshot.songs.map((song) =>
-              convertTimestamps({
-                ...song,
-                id: mapId(song.id),
-                gameId: newGameId,
-                artistId: mapReference(song.artistId),
-                projectId: mapReference(song.projectId),
-                releaseId: mapReference(song.releaseId),
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.releaseSongs) && snapshot.releaseSongs.length > 0) {
-          await tx.insert(releaseSongs).values(
-            snapshot.releaseSongs.map((entry: any) => ({
-              releaseId: mapReference(entry.releaseId) ?? entry.releaseId,
-              songId: mapReference(entry.songId) ?? entry.songId,
-              trackNumber: entry.trackNumber ?? 0,
-              isSingle: entry.isSingle ?? false,
-            })) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.moodEvents) && snapshot.moodEvents.length > 0) {
-          await tx.insert(moodEvents).values(
-            snapshot.moodEvents.map((event) =>
-              convertTimestamps({
-                ...event,
-                id: mapId(event.id),
-                gameId: newGameId,
-                artistId: mapReference(event.artistId) ?? event.artistId,
-              })
-            ) as any,
-          );
-        }
-
-        if (Array.isArray(snapshot.emails) && snapshot.emails.length > 0) {
-          await tx.insert(emails).values(
-            snapshot.emails.map((email) =>
-              convertTimestamps({
-                ...email,
-                id: mapId((email as any).id),
-                gameId: newGameId,
-              })
-            ) as any,
-          );
-        }
-      });
-
-      res.json({ gameId: newGameId });
-    } catch (error) {
       if ((error as any)?.code === 'INVALID_SNAPSHOT_COLLECTIONS') {
         return res.status(400).json({
           error: 'INVALID_SNAPSHOT_COLLECTIONS',
@@ -680,19 +115,19 @@ const validateSnapshotCollections = (snapshot: GameSaveSnapshot) => {
 
   router.delete("/api/saves/:saveId", requireClerkUser, async (req, res) => {
     try {
-      const deleted = await storage.deleteGameSave(req.params.saveId, req.userId!);
-      if (deleted === 0) {
+      const result = await saveService.deleteSave(req.params.saveId, req.userId!);
+
+      res.json({
+        message: 'Save deleted successfully',
+        deletedSaveId: result.deletedSaveId,
+      });
+    } catch (error) {
+      if ((error as any)?.code === 'SAVE_NOT_FOUND') {
         return res.status(404).json({
           error: 'SAVE_NOT_FOUND',
           message: 'Save file not found or does not belong to this user',
         });
       }
-
-      res.json({
-        message: 'Save deleted successfully',
-        deletedSaveId: req.params.saveId,
-      });
-    } catch (error) {
       console.error("Failed to delete save:", error);
       res.status(500).json({
         error: 'DELETE_SAVE_ERROR',

--- a/server/services/saveService.ts
+++ b/server/services/saveService.ts
@@ -1,0 +1,698 @@
+/**
+ * saveService.ts
+ *
+ * Backend service for save creation, restore (overwrite + fork), and deletion.
+ * Extracted from the fat server/routes/saves.ts handlers (Phase 1, PR-16).
+ * Follows the GameCreationService convention: a class with explicit
+ * dependencies defaulted to the module singletons, plus an exported singleton.
+ *
+ * Behavior is intentionally byte-equivalent to the pre-extraction handlers,
+ * including every '[RESTORE] Step N:' console.log, the children-first deletion
+ * ordering, and the id-remapping fork logic. Service methods throw CODED errors
+ * (error.code); the routes map those codes to HTTP status + the exact JSON
+ * bodies they returned before the extraction.
+ *
+ * Coded errors thrown by this service (route -> status):
+ *   INVALID_SNAPSHOT              -> 400
+ *   SAVE_NOT_FOUND               -> 404
+ *   UNSUPPORTED_SNAPSHOT_VERSION -> 400
+ *   INVALID_SNAPSHOT_COLLECTIONS -> 400 (carries .details)
+ *   UNAUTHORIZED                 -> 403
+ * ZodErrors from parsing continue to propagate and are caught in the route.
+ */
+
+import { randomUUID } from 'crypto';
+import { storage as storageSingleton } from '../storage';
+import { db as dbSingleton } from '../db';
+import { eq, inArray } from 'drizzle-orm';
+import {
+  gameSaveSnapshotSchema,
+  gameStates,
+  weeklyActions,
+  projects,
+  songs,
+  artists,
+  releases,
+  releaseSongs,
+  roles,
+  executives,
+  musicLabels,
+  moodEvents,
+  emails,
+  type GameSaveSnapshot,
+  type InsertGameSave,
+  SNAPSHOT_VERSION,
+} from '@shared/schema';
+
+/** Create a coded error the route can map to an HTTP status. */
+function codedError(code: string, message: string, details?: unknown): Error {
+  const error = new Error(message);
+  (error as any).code = code;
+  if (details !== undefined) {
+    (error as any).details = details;
+  }
+  return error;
+}
+
+const validateSnapshotCollections = (snapshot: GameSaveSnapshot) => {
+  const errors: string[] = [];
+
+  const ensureArray = (value: unknown, name: string): value is unknown[] => {
+    if (value === undefined || value === null) return false;
+    if (!Array.isArray(value)) {
+      errors.push(`${name} must be an array`);
+      return false;
+    }
+    return true;
+  };
+
+  if (ensureArray(snapshot.releaseSongs, 'releaseSongs')) {
+    snapshot.releaseSongs.forEach((entry, index) => {
+      if (!entry || typeof entry.releaseId !== 'string' || typeof entry.songId !== 'string') {
+        errors.push(`releaseSongs[${index}] is missing required releaseId/songId`);
+      }
+    });
+  }
+
+  if (ensureArray(snapshot.executives, 'executives')) {
+    snapshot.executives.forEach((exec: any, index) => {
+      if (!exec || typeof exec.id !== 'string' || typeof exec.role !== 'string') {
+        errors.push(`executives[${index}] is missing required id/role`);
+      }
+    });
+  }
+
+  if (ensureArray(snapshot.moodEvents, 'moodEvents')) {
+    snapshot.moodEvents.forEach((event: any, index) => {
+      if (!event || typeof event.id !== 'string' || typeof event.artistId !== 'string') {
+        errors.push(`moodEvents[${index}] is missing required id/artistId`);
+      }
+    });
+  }
+
+  if (ensureArray(snapshot.emails, 'emails')) {
+    snapshot.emails.forEach((email: any, index) => {
+      if (!email || typeof (email as any).id !== 'string' || typeof email.subject !== 'string') {
+        errors.push(`emails[${index}] is missing required id/subject`);
+      }
+    });
+  }
+
+  if (errors.length > 0) {
+    const error = new Error('Invalid snapshot collections');
+    (error as any).code = 'INVALID_SNAPSHOT_COLLECTIONS';
+    (error as any).details = errors;
+    throw error;
+  }
+};
+
+// Helper function to convert timestamp strings to Date objects
+const convertTimestamps = (obj: any): any => {
+  if (!obj || typeof obj !== 'object') return obj;
+
+  if (Array.isArray(obj)) {
+    return obj.map(item => convertTimestamps(item));
+  }
+
+  const converted: any = {};
+  for (const [key, value] of Object.entries(obj)) {
+    // Convert fields that end with 'At' or are known timestamp fields
+    if ((key.endsWith('At') || key === 'createdAt' || key === 'updatedAt') &&
+        typeof value === 'string' && value) {
+      converted[key] = new Date(value);
+    } else if (value && typeof value === 'object') {
+      converted[key] = convertTimestamps(value);
+    } else {
+      converted[key] = value;
+    }
+  }
+  return converted;
+};
+
+export class SaveService {
+  constructor(
+    private storage = storageSingleton,
+    private db = dbSingleton,
+  ) {}
+
+  /**
+   * Create a new save for the given user from already-validated insert data.
+   * The route parses the body with insertGameSaveSchema (ZodError -> 400) and
+   * passes the result here. Throws INVALID_SNAPSHOT (400) when the snapshot has
+   * no game identifier. Returns the created GameSave.
+   */
+  async createSave(userId: string, validatedData: InsertGameSave) {
+    const snapshot = validatedData.gameState;
+    const snapshotGameId = snapshot?.gameState?.id;
+
+    if (!snapshotGameId) {
+      throw codedError('INVALID_SNAPSHOT', 'Save snapshot is missing game identifier');
+    }
+
+    const save = await this.storage.createGameSave({
+      ...validatedData,
+      week: snapshot.gameState.currentWeek,
+      userId,
+    });
+
+    if (validatedData.isAutosave) {
+      await this.storage.purgeOldAutosaves(userId, snapshotGameId, 3);
+    }
+
+    return save;
+  }
+
+  /**
+   * Shared setup for both restore modes: fetch + ownership-check the save,
+   * parse the snapshot, validate version + collections + game identifier.
+   * Throws SAVE_NOT_FOUND (404), UNSUPPORTED_SNAPSHOT_VERSION (400),
+   * INVALID_SNAPSHOT_COLLECTIONS (400), INVALID_SNAPSHOT (400), or a ZodError
+   * from snapshot parsing. Returns the parsed snapshot + derived ids.
+   */
+  private async loadRestoreSnapshot(saveId: string, userId: string) {
+    const save = await this.storage.getGameSaveForUser(saveId, userId);
+    if (!save) {
+      throw codedError(
+        'SAVE_NOT_FOUND',
+        'Save file not found or does not belong to this user',
+      );
+    }
+
+    const snapshot = gameSaveSnapshotSchema.parse(save.gameState) as GameSaveSnapshot;
+    if ((snapshot.snapshotVersion ?? 1) !== SNAPSHOT_VERSION) {
+      throw codedError(
+        'UNSUPPORTED_SNAPSHOT_VERSION',
+        `Snapshot version ${snapshot.snapshotVersion ?? 1} is not supported. Expected version ${SNAPSHOT_VERSION}.`,
+      );
+    }
+    const targetGameState = snapshot.gameState;
+    const sourceGameId = targetGameState?.id;
+
+    validateSnapshotCollections(snapshot);
+
+    if (!sourceGameId) {
+      throw codedError('INVALID_SNAPSHOT', 'Save snapshot is missing game identifier');
+    }
+
+    return { snapshot, targetGameState, sourceGameId };
+  }
+
+  /**
+   * Restore a save onto its original game (overwrite mode). Deletes all child
+   * rows children-first, then reinserts them parents-first inside one
+   * transaction. Throws SAVE_NOT_FOUND (404), UNSUPPORTED_SNAPSHOT_VERSION
+   * (400), INVALID_SNAPSHOT_COLLECTIONS (400), INVALID_SNAPSHOT (400), or
+   * UNAUTHORIZED (403). Returns { gameId }.
+   */
+  async restoreOverwrite(saveId: string, userId: string) {
+    const { snapshot, targetGameState, sourceGameId } = await this.loadRestoreSnapshot(saveId, userId);
+
+    console.log('[RESTORE] Starting overwrite mode for game:', sourceGameId);
+    const existingGame = await this.storage.getGameState(sourceGameId);
+    if (!existingGame || existingGame.userId !== userId) {
+      throw codedError('UNAUTHORIZED', 'You do not have permission to restore this game');
+    }
+
+    console.log('[RESTORE] Beginning transaction...');
+    await this.db.transaction(async (tx) => {
+      console.log('[RESTORE] Step 1: Updating game_states...');
+      await tx.update(gameStates)
+        .set({
+          currentWeek: targetGameState.currentWeek,
+          money: targetGameState.money,
+          reputation: targetGameState.reputation,
+          creativeCapital: targetGameState.creativeCapital,
+          focusSlots: targetGameState.focusSlots ?? existingGame.focusSlots,
+          usedFocusSlots: targetGameState.usedFocusSlots ?? 0,
+          arOfficeSlotUsed: targetGameState.arOfficeSlotUsed ?? false,
+          arOfficeSourcingType: targetGameState.arOfficeSourcingType ?? null,
+          arOfficePrimaryGenre: targetGameState.arOfficePrimaryGenre ?? null,
+          arOfficeSecondaryGenre: targetGameState.arOfficeSecondaryGenre ?? null,
+          arOfficeOperationStart: targetGameState.arOfficeOperationStart ?? null,
+          playlistAccess: targetGameState.playlistAccess ?? existingGame.playlistAccess,
+          pressAccess: targetGameState.pressAccess ?? existingGame.pressAccess,
+          venueAccess: targetGameState.venueAccess ?? existingGame.venueAccess,
+          campaignType: targetGameState.campaignType ?? existingGame.campaignType,
+          campaignCompleted: targetGameState.campaignCompleted ?? existingGame.campaignCompleted,
+          rngSeed: targetGameState.rngSeed ?? existingGame.rngSeed,
+          flags: targetGameState.flags ?? existingGame.flags ?? {},
+          weeklyStats: targetGameState.weeklyStats ?? existingGame.weeklyStats ?? {},
+          tierUnlockHistory: targetGameState.tierUnlockHistory ?? existingGame.tierUnlockHistory ?? {},
+          userId: userId,
+          updatedAt: new Date(),
+        })
+        .where(eq(gameStates.id, sourceGameId));
+
+      // IMPORTANT: Delete in order of foreign key dependencies (children first, parents last)
+      // Deletion ordering summary:
+      // 1. release_songs → depends on releases & songs (junction table must be cleared first)
+      // 2. songs → depends on artists, projects, releases (remove track rows before their parents)
+      // 3. releases → depends on artists (planned releases point back to artist roster)
+      // 4. projects → depends on artists (projects reference artist owners)
+      // 5. mood_events → depends on artists (events track artist history)
+      // 6. artists → depends only on game state once children are gone
+      // 7. roles / weekly_actions / music_labels / emails / executives → all hang directly off game_state
+      // The inserts later run in the exact reverse order so parents exist before their dependent rows.
+
+      console.log('[RESTORE] Step 2: Deleting release_songs junction table...');
+      // Clear junction table first so dependent release/song deletions don't hit FK constraints
+      const releaseRows = await tx
+        .select({ id: releases.id })
+        .from(releases)
+        .where(eq(releases.gameId, sourceGameId));
+
+      if (releaseRows.length > 0) {
+        const releaseIds = releaseRows.map(({ id }) => id);
+        await tx
+          .delete(releaseSongs)
+          .where(inArray(releaseSongs.releaseId, releaseIds));
+      }
+
+      console.log('[RESTORE] Step 3: Deleting songs (depends on artists, projects, releases)...');
+      // Remove songs before their parent releases/projects/artists to keep FK chain intact
+      await tx.delete(songs).where(eq(songs.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 4: Deleting releases (depends on artists)...');
+      // Releases reference artists; with tracks gone we can safely drop the release rows
+      await tx.delete(releases).where(eq(releases.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 5: Deleting projects (depends on artists)...');
+      // Projects still point at artists, so they must disappear before we remove the roster
+      await tx.delete(projects).where(eq(projects.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 6: Deleting mood_events (depends on artists)...');
+      // Mood history also references artists; delete events prior to artist removal
+      await tx.delete(moodEvents).where(eq(moodEvents.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 7: Deleting artists (no more dependencies)...');
+      // With all child tables cleared we can drop artist rows
+      await tx.delete(artists).where(eq(artists.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 8: Deleting roles...');
+      // Remaining tables (roles/weekly_actions/label/emails/executives) hang directly off game_state
+      await tx.delete(roles).where(eq(roles.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 9: Deleting weekly_actions...');
+      await tx.delete(weeklyActions).where(eq(weeklyActions.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 10: Deleting music_labels...');
+      await tx.delete(musicLabels).where(eq(musicLabels.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 11: Deleting emails...');
+      await tx.delete(emails).where(eq(emails.gameId, sourceGameId));
+
+      console.log('[RESTORE] Step 12: Deleting executives...');
+      await tx.delete(executives).where(eq(executives.gameId, sourceGameId));
+
+      // Now insert everything back in reverse order (parents first, children last)
+
+      console.log('[RESTORE] Step 13: Reinserting music_labels...');
+      // Rebuild parents first so dependent collections have targets
+      if (snapshot.musicLabel) {
+        await tx.insert(musicLabels).values(
+          convertTimestamps({
+            ...snapshot.musicLabel,
+            gameId: sourceGameId,
+          }) as any
+        );
+      }
+
+      console.log('[RESTORE] Step 14: Reinserting weekly_actions...');
+      // Weekly history depends only on game state, insert early for clarity
+      if (Array.isArray(snapshot.weeklyActions) && snapshot.weeklyActions.length > 0) {
+        await tx.insert(weeklyActions).values(
+          snapshot.weeklyActions.map((action) =>
+            convertTimestamps({
+              ...action,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 15: Reinserting roles...');
+      // Roles also hang off the game directly
+      if (Array.isArray(snapshot.roles) && snapshot.roles.length > 0) {
+        await tx.insert(roles).values(
+          snapshot.roles.map((role) =>
+            convertTimestamps({
+              ...role,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 16: Reinserting artists...');
+      // Restore roster before any collection that references artist IDs
+      if (Array.isArray(snapshot.artists) && snapshot.artists.length > 0) {
+        await tx.insert(artists).values(
+          snapshot.artists.map((artist) =>
+            convertTimestamps({
+              ...artist,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 17: Reinserting mood_events...');
+      // Mood events can now target their owning artists
+      if (Array.isArray(snapshot.moodEvents) && snapshot.moodEvents.length > 0) {
+        await tx.insert(moodEvents).values(
+          snapshot.moodEvents.map((event: any) =>
+            convertTimestamps({
+              ...event,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 18: Reinserting projects...');
+      // Projects require artist IDs but must exist before songs referencing project_id
+      if (Array.isArray(snapshot.projects) && snapshot.projects.length > 0) {
+        await tx.insert(projects).values(
+          snapshot.projects.map((project) =>
+            convertTimestamps({
+              ...project,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 19: Reinserting releases...');
+      // Releases depend on artists and are parents for songs/release_songs
+      if (Array.isArray(snapshot.releases) && snapshot.releases.length > 0) {
+        await tx.insert(releases).values(
+          snapshot.releases.map((release) =>
+            convertTimestamps({
+              ...release,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 20: Reinserting songs...');
+      // Songs can now safely reference artists/projects/releases
+      if (Array.isArray(snapshot.songs) && snapshot.songs.length > 0) {
+        await tx.insert(songs).values(
+          snapshot.songs.map((song) =>
+            convertTimestamps({
+              ...song,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 21: Reinserting release_songs...');
+      // Junction requires both song and release rows to exist first
+      if (Array.isArray(snapshot.releaseSongs) && snapshot.releaseSongs.length > 0) {
+        await tx.insert(releaseSongs).values(
+          snapshot.releaseSongs.map((entry: any) => ({
+            releaseId: entry.releaseId,
+            songId: entry.songId,
+            trackNumber: entry.trackNumber ?? 0,
+            isSingle: entry.isSingle ?? false,
+          })) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 22: Reinserting executives...');
+      // Executives and emails only reference the game so they can go near the end
+      if (Array.isArray(snapshot.executives) && snapshot.executives.length > 0) {
+        await tx.insert(executives).values(
+          snapshot.executives.map((exec: any) =>
+            convertTimestamps({
+              ...exec,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Step 23: Reinserting emails...');
+      // Final pass restores inbox entries tied to the game
+      if (Array.isArray(snapshot.emails) && snapshot.emails.length > 0) {
+        await tx.insert(emails).values(
+          snapshot.emails.map((email) =>
+            convertTimestamps({
+              ...email,
+              gameId: sourceGameId,
+            })
+          ) as any,
+        );
+      }
+
+      console.log('[RESTORE] Transaction complete!');
+    });
+
+    return { gameId: sourceGameId };
+  }
+
+  /**
+   * Restore a save into a NEW game (fork mode). Remaps every entity id to a
+   * fresh UUID (keeping cross-references consistent) and inserts everything
+   * under the new game owned by the user. Throws the same load-time coded
+   * errors as overwrite (SAVE_NOT_FOUND / UNSUPPORTED_SNAPSHOT_VERSION /
+   * INVALID_SNAPSHOT_COLLECTIONS / INVALID_SNAPSHOT). Returns { gameId }.
+   */
+  async restoreFork(saveId: string, userId: string) {
+    const { snapshot, targetGameState, sourceGameId } = await this.loadRestoreSnapshot(saveId, userId);
+
+    const idMap = new Map<string, string>();
+    const mapId = (value?: string | null, create = true) => {
+      if (!value) return value;
+      if (!idMap.has(value)) {
+        if (!create) {
+          return value;
+        }
+        idMap.set(value, randomUUID());
+      }
+      return idMap.get(value)!;
+    };
+
+    const mapReference = (value?: string | null) => mapId(value, false);
+
+    const newGameId = mapId(sourceGameId)!;
+
+    if (snapshot.musicLabel) {
+      mapId((snapshot.musicLabel as any).id ?? undefined);
+    }
+    if (Array.isArray(snapshot.weeklyActions)) {
+      snapshot.weeklyActions.forEach((action) => mapId(action.id));
+    }
+    if (Array.isArray(snapshot.artists)) {
+      snapshot.artists.forEach((artist) => mapId(artist.id));
+    }
+    if (Array.isArray(snapshot.projects)) {
+      snapshot.projects.forEach((project) => mapId(project.id));
+    }
+    if (Array.isArray(snapshot.roles)) {
+      snapshot.roles.forEach((role) => mapId(role.id));
+    }
+    if (Array.isArray(snapshot.releases)) {
+      snapshot.releases.forEach((release) => mapId(release.id));
+    }
+    if (Array.isArray(snapshot.songs)) {
+      snapshot.songs.forEach((song) => mapId(song.id));
+    }
+    if (Array.isArray(snapshot.executives)) {
+      snapshot.executives.forEach((exec) => mapId(exec.id));
+    }
+    if (Array.isArray(snapshot.moodEvents)) {
+      snapshot.moodEvents.forEach((event) => mapId(event.id));
+    }
+    if (Array.isArray(snapshot.emails)) {
+      snapshot.emails.forEach((email) => mapId((email as any).id));
+    }
+
+    await this.db.transaction(async (tx) => {
+      await tx.insert(gameStates).values({
+        id: newGameId,
+        userId: userId,
+        currentWeek: targetGameState.currentWeek,
+        money: targetGameState.money,
+        reputation: targetGameState.reputation,
+        creativeCapital: targetGameState.creativeCapital,
+        focusSlots: targetGameState.focusSlots ?? 3,
+        usedFocusSlots: targetGameState.usedFocusSlots ?? 0,
+        arOfficeSlotUsed: targetGameState.arOfficeSlotUsed ?? false,
+        arOfficeSourcingType: targetGameState.arOfficeSourcingType ?? null,
+        arOfficePrimaryGenre: targetGameState.arOfficePrimaryGenre ?? null,
+        arOfficeSecondaryGenre: targetGameState.arOfficeSecondaryGenre ?? null,
+        arOfficeOperationStart: targetGameState.arOfficeOperationStart ?? null,
+        playlistAccess: targetGameState.playlistAccess ?? 'none',
+        pressAccess: targetGameState.pressAccess ?? 'none',
+        venueAccess: targetGameState.venueAccess ?? 'none',
+        campaignType: targetGameState.campaignType ?? 'Balanced',
+        campaignCompleted: targetGameState.campaignCompleted ?? false,
+        rngSeed: targetGameState.rngSeed ?? null,
+        flags: targetGameState.flags ?? {},
+        weeklyStats: targetGameState.weeklyStats ?? {},
+        tierUnlockHistory: targetGameState.tierUnlockHistory ?? {},
+      });
+
+      if (snapshot.musicLabel) {
+        await tx.insert(musicLabels).values(
+          convertTimestamps({
+            ...snapshot.musicLabel,
+            id: mapId((snapshot.musicLabel as any).id ?? undefined),
+            gameId: newGameId,
+          }) as any
+        );
+      }
+
+      if (Array.isArray(snapshot.weeklyActions) && snapshot.weeklyActions.length > 0) {
+        await tx.insert(weeklyActions).values(
+          snapshot.weeklyActions.map((action) =>
+            convertTimestamps({
+              ...action,
+              id: mapId(action.id),
+              gameId: newGameId,
+              targetId: mapReference(action.targetId as string | undefined),
+              choiceId: mapReference(action.choiceId as string | undefined),
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.artists) && snapshot.artists.length > 0) {
+        await tx.insert(artists).values(
+          snapshot.artists.map((artist) =>
+            convertTimestamps({
+              ...artist,
+              id: mapId(artist.id),
+              gameId: newGameId,
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.projects) && snapshot.projects.length > 0) {
+        await tx.insert(projects).values(
+          snapshot.projects.map((project) =>
+            convertTimestamps({
+              ...project,
+              id: mapId(project.id),
+              gameId: newGameId,
+              artistId: mapReference(project.artistId),
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.roles) && snapshot.roles.length > 0) {
+        await tx.insert(roles).values(
+          snapshot.roles.map((role) =>
+            convertTimestamps({
+              ...role,
+              id: mapId(role.id),
+              gameId: newGameId,
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.executives) && snapshot.executives.length > 0) {
+        await tx.insert(executives).values(
+          snapshot.executives.map((exec) =>
+            convertTimestamps({
+              ...exec,
+              id: mapId(exec.id),
+              gameId: newGameId,
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.releases) && snapshot.releases.length > 0) {
+        await tx.insert(releases).values(
+          snapshot.releases.map((release) =>
+            convertTimestamps({
+              ...release,
+              id: mapId(release.id),
+              gameId: newGameId,
+              artistId: mapReference(release.artistId),
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.songs) && snapshot.songs.length > 0) {
+        await tx.insert(songs).values(
+          snapshot.songs.map((song) =>
+            convertTimestamps({
+              ...song,
+              id: mapId(song.id),
+              gameId: newGameId,
+              artistId: mapReference(song.artistId),
+              projectId: mapReference(song.projectId),
+              releaseId: mapReference(song.releaseId),
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.releaseSongs) && snapshot.releaseSongs.length > 0) {
+        await tx.insert(releaseSongs).values(
+          snapshot.releaseSongs.map((entry: any) => ({
+            releaseId: mapReference(entry.releaseId) ?? entry.releaseId,
+            songId: mapReference(entry.songId) ?? entry.songId,
+            trackNumber: entry.trackNumber ?? 0,
+            isSingle: entry.isSingle ?? false,
+          })) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.moodEvents) && snapshot.moodEvents.length > 0) {
+        await tx.insert(moodEvents).values(
+          snapshot.moodEvents.map((event) =>
+            convertTimestamps({
+              ...event,
+              id: mapId(event.id),
+              gameId: newGameId,
+              artistId: mapReference(event.artistId) ?? event.artistId,
+            })
+          ) as any,
+        );
+      }
+
+      if (Array.isArray(snapshot.emails) && snapshot.emails.length > 0) {
+        await tx.insert(emails).values(
+          snapshot.emails.map((email) =>
+            convertTimestamps({
+              ...email,
+              id: mapId((email as any).id),
+              gameId: newGameId,
+            })
+          ) as any,
+        );
+      }
+    });
+
+    return { gameId: newGameId };
+  }
+
+  /**
+   * Delete a save owned by the user. Throws SAVE_NOT_FOUND (404) when no row
+   * was deleted. Returns { deletedSaveId }.
+   */
+  async deleteSave(saveId: string, userId: string) {
+    const deleted = await this.storage.deleteGameSave(saveId, userId);
+    if (deleted === 0) {
+      throw codedError(
+        'SAVE_NOT_FOUND',
+        'Save file not found or does not belong to this user',
+      );
+    }
+
+    return { deletedSaveId: saveId };
+  }
+}
+
+// Export singleton instance
+export const saveService = new SaveService();

--- a/tests/endpoints/save-restore.characterization.test.ts
+++ b/tests/endpoints/save-restore.characterization.test.ts
@@ -1,0 +1,500 @@
+// @vitest-environment node
+/**
+ * Save/restore characterization test (Phase 1, PR-16).
+ *
+ * The fat POST /api/saves/:saveId/restore handler (overwrite + fork) plus
+ * POST /api/saves and DELETE /api/saves/:saveId had no endpoint-level coverage.
+ * This test pins the observable behavior of the save/restore endpoints BEFORE
+ * the logic is extracted into saveService, so the extraction can be proven
+ * behavior-preserving (green before AND after).
+ *
+ * It drives the real registerRoutes() router over supertest against the real
+ * test Postgres (Docker, localhost:5433). Clerk auth is mocked to a fixed test
+ * user; server/db is mocked to a non-SSL pool pointed at the test DB (the
+ * production pool forces SSL, which the local test container rejects).
+ *
+ * IMPORTANT snapshot shape: `musicLabel` and all collections are SIBLINGS of
+ * `gameState` in the save snapshot, NOT nested inside it.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { randomUUID } from 'crypto';
+
+// Must be set before any module that reads DATABASE_URL at import time.
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+// Fixed clerk id / resolved userId for the mocked authenticated user.
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+// A second user, used for ownership / not-found characterization.
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+// --- Mock server/db with a non-SSL pool at the test DB. storage.ts imports
+//     `db` from ./db, so this single mock reroutes storage + handlers + service.
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+// --- Mock server/auth so requireClerkUser injects the fixed test userId and
+//     everything else is a passthrough. Handlers only depend on req.userId.
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = TEST_USER_ID;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import {
+  gameStates,
+  users,
+  artists,
+  projects,
+  songs,
+  releases,
+  releaseSongs,
+  gameSaves,
+  SNAPSHOT_VERSION,
+} from '@shared/schema';
+import { eq } from 'drizzle-orm';
+
+let app: Express;
+
+interface SeededGame {
+  gameId: string;
+  artistId: string;
+  projectId: string;
+  songId: string;
+  releaseId: string;
+}
+
+/**
+ * Seed a small game owned by `ownerId` with 1 artist + 1 project + 1 song +
+ * 1 release + 1 releaseSong junction row. Returns all the ids.
+ */
+async function seedGame(ownerId: string): Promise<SeededGame> {
+  const gameId = randomUUID();
+  const artistId = randomUUID();
+  const projectId = randomUUID();
+  const songId = randomUUID();
+  const releaseId = randomUUID();
+
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: ownerId,
+    currentWeek: 5,
+    money: 50000,
+    reputation: 10,
+    creativeCapital: 20,
+  });
+
+  await db.insert(artists).values({
+    id: artistId,
+    gameId,
+    name: 'Seed Artist',
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood: 50,
+    energy: 50,
+    popularity: 50,
+    talent: 60,
+    workEthic: 70,
+    temperament: 50,
+    signed: true,
+  });
+
+  await db.insert(projects).values({
+    id: projectId,
+    gameId,
+    artistId,
+    title: 'Seed Project',
+    type: 'Single',
+    stage: 'planning',
+  });
+
+  await db.insert(songs).values({
+    id: songId,
+    gameId,
+    artistId,
+    projectId,
+    title: 'Seed Song',
+    genre: 'pop',
+    quality: 75,
+    isRecorded: true,
+    isReleased: true,
+  });
+
+  await db.insert(releases).values({
+    id: releaseId,
+    gameId,
+    artistId,
+    title: 'Seed Release',
+    type: 'single',
+    status: 'released',
+  });
+
+  await db.insert(releaseSongs).values({
+    releaseId,
+    songId,
+    trackNumber: 1,
+    isSingle: true,
+  });
+
+  return { gameId, artistId, projectId, songId, releaseId };
+}
+
+/** Build a snapshot object from the seeded game rows (siblings of gameState). */
+function buildSnapshot(seed: SeededGame, overrides: Record<string, any> = {}) {
+  return {
+    snapshotVersion: SNAPSHOT_VERSION,
+    gameState: {
+      id: seed.gameId,
+      currentWeek: 5,
+      money: 50000,
+      reputation: 10,
+      creativeCapital: 20,
+    },
+    musicLabel: null,
+    artists: [
+      {
+        id: seed.artistId,
+        gameId: seed.gameId,
+        name: 'Seed Artist',
+        archetype: 'Workhorse',
+        genre: 'pop',
+        mood: 50,
+        energy: 50,
+        popularity: 50,
+        talent: 60,
+        workEthic: 70,
+        temperament: 50,
+        signed: true,
+      },
+    ],
+    projects: [
+      {
+        id: seed.projectId,
+        gameId: seed.gameId,
+        artistId: seed.artistId,
+        title: 'Seed Project',
+        type: 'Single',
+        stage: 'planning',
+      },
+    ],
+    roles: [],
+    songs: [
+      {
+        id: seed.songId,
+        gameId: seed.gameId,
+        artistId: seed.artistId,
+        projectId: seed.projectId,
+        title: 'Seed Song',
+        genre: 'pop',
+        quality: 75,
+        isRecorded: true,
+        isReleased: true,
+      },
+    ],
+    releases: [
+      {
+        id: seed.releaseId,
+        gameId: seed.gameId,
+        artistId: seed.artistId,
+        title: 'Seed Release',
+        type: 'single',
+        status: 'released',
+      },
+    ],
+    releaseSongs: [
+      {
+        releaseId: seed.releaseId,
+        songId: seed.songId,
+        trackNumber: 1,
+        isSingle: true,
+      },
+    ],
+    executives: [],
+    moodEvents: [],
+    weeklyActions: [],
+    emails: [],
+    ...overrides,
+  };
+}
+
+/** Insert a game_saves row owned by `ownerId` holding `snapshot`. Returns saveId. */
+async function insertSave(ownerId: string, snapshot: any): Promise<string> {
+  const saveId = randomUUID();
+  await db.insert(gameSaves).values({
+    id: saveId,
+    userId: ownerId,
+    name: 'Characterization Save',
+    week: snapshot?.gameState?.currentWeek ?? 1,
+    gameState: snapshot,
+    isAutosave: false,
+  });
+  return saveId;
+}
+
+beforeAll(async () => {
+  const { registerRoutes } = await import('../../server/routes');
+  app = express();
+  app.use(express.json());
+  const server = await registerRoutes(app);
+  server.close();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+beforeEach(async () => {
+  const { sql } = await import('drizzle-orm');
+  await db.execute(sql`TRUNCATE TABLE users, game_states, game_saves RESTART IDENTITY CASCADE`);
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+describe('POST /api/saves/:saveId/restore — fork mode (characterization)', () => {
+  it('creates a NEW gameId and remaps artist/song/release ids consistently', async () => {
+    const seed = await seedGame(TEST_USER_ID);
+    const snapshot = buildSnapshot(seed);
+    const saveId = await insertSave(TEST_USER_ID, snapshot);
+
+    const res = await request(app)
+      .post(`/api/saves/${saveId}/restore`)
+      .send({ mode: 'fork' });
+
+    expect(res.status).toBe(200);
+    const newGameId: string = res.body.gameId;
+    expect(newGameId).toBeTruthy();
+    expect(newGameId).not.toBe(seed.gameId);
+
+    // Original game still exists (fork does not delete it)
+    const [origGame] = await db.select().from(gameStates).where(eq(gameStates.id, seed.gameId));
+    expect(origGame).toBeTruthy();
+
+    // New game exists and is owned by the authenticated user
+    const [forkedGame] = await db.select().from(gameStates).where(eq(gameStates.id, newGameId));
+    expect(forkedGame).toBeTruthy();
+    expect(forkedGame.userId).toBe(TEST_USER_ID);
+
+    // Forked rows have NEW ids and FK references line up within the new game.
+    const forkedArtists = await db.select().from(artists).where(eq(artists.gameId, newGameId));
+    const forkedProjects = await db.select().from(projects).where(eq(projects.gameId, newGameId));
+    const forkedSongs = await db.select().from(songs).where(eq(songs.gameId, newGameId));
+    const forkedReleases = await db.select().from(releases).where(eq(releases.gameId, newGameId));
+
+    expect(forkedArtists).toHaveLength(1);
+    expect(forkedProjects).toHaveLength(1);
+    expect(forkedSongs).toHaveLength(1);
+    expect(forkedReleases).toHaveLength(1);
+
+    const newArtistId = forkedArtists[0].id;
+    const newProjectId = forkedProjects[0].id;
+    const newReleaseId = forkedReleases[0].id;
+
+    // Ids are remapped (differ from originals)
+    expect(newArtistId).not.toBe(seed.artistId);
+    expect(forkedSongs[0].id).not.toBe(seed.songId);
+    expect(newReleaseId).not.toBe(seed.releaseId);
+
+    // FK references line up: the forked song points at the forked artist/project/release
+    expect(forkedSongs[0].artistId).toBe(newArtistId);
+    expect(forkedSongs[0].projectId).toBe(newProjectId);
+    expect(forkedProjects[0].artistId).toBe(newArtistId);
+    expect(forkedReleases[0].artistId).toBe(newArtistId);
+
+    // release_songs junction was remapped to the new release + song ids
+    const forkedReleaseSongs = await db
+      .select()
+      .from(releaseSongs)
+      .where(eq(releaseSongs.releaseId, newReleaseId));
+    expect(forkedReleaseSongs).toHaveLength(1);
+    expect(forkedReleaseSongs[0].songId).toBe(forkedSongs[0].id);
+  });
+});
+
+describe('POST /api/saves/:saveId/restore — overwrite mode (characterization)', () => {
+  it('restores onto the original gameId and row counts match', async () => {
+    const seed = await seedGame(TEST_USER_ID);
+    const snapshot = buildSnapshot(seed);
+    const saveId = await insertSave(TEST_USER_ID, snapshot);
+
+    const res = await request(app)
+      .post(`/api/saves/${saveId}/restore`)
+      .send({ mode: 'overwrite' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.gameId).toBe(seed.gameId);
+
+    // Same gameId retains its rows (deleted + reinserted with same ids)
+    const restoredArtists = await db.select().from(artists).where(eq(artists.gameId, seed.gameId));
+    const restoredSongs = await db.select().from(songs).where(eq(songs.gameId, seed.gameId));
+    const restoredReleases = await db.select().from(releases).where(eq(releases.gameId, seed.gameId));
+
+    expect(restoredArtists).toHaveLength(1);
+    expect(restoredSongs).toHaveLength(1);
+    expect(restoredReleases).toHaveLength(1);
+
+    // Ids are preserved on overwrite
+    expect(restoredArtists[0].id).toBe(seed.artistId);
+    expect(restoredSongs[0].id).toBe(seed.songId);
+    expect(restoredReleases[0].id).toBe(seed.releaseId);
+
+    const restoredReleaseSongs = await db
+      .select()
+      .from(releaseSongs)
+      .where(eq(releaseSongs.releaseId, seed.releaseId));
+    expect(restoredReleaseSongs).toHaveLength(1);
+    expect(restoredReleaseSongs[0].songId).toBe(seed.songId);
+  });
+
+  it('defaults to overwrite mode when body omits mode', async () => {
+    const seed = await seedGame(TEST_USER_ID);
+    const snapshot = buildSnapshot(seed);
+    const saveId = await insertSave(TEST_USER_ID, snapshot);
+
+    const res = await request(app).post(`/api/saves/${saveId}/restore`).send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.gameId).toBe(seed.gameId);
+  });
+});
+
+describe('POST /api/saves/:saveId/restore — error paths (characterization)', () => {
+  it('returns 400 UNSUPPORTED_SNAPSHOT_VERSION on a wrong snapshotVersion', async () => {
+    const seed = await seedGame(TEST_USER_ID);
+    const snapshot = buildSnapshot(seed, { snapshotVersion: SNAPSHOT_VERSION + 999 });
+    const saveId = await insertSave(TEST_USER_ID, snapshot);
+
+    const res = await request(app).post(`/api/saves/${saveId}/restore`).send({ mode: 'overwrite' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('UNSUPPORTED_SNAPSHOT_VERSION');
+    expect(res.body.message).toBe(
+      `Snapshot version ${SNAPSHOT_VERSION + 999} is not supported. Expected version ${SNAPSHOT_VERSION}.`
+    );
+  });
+
+  it('returns 400 INVALID_SNAPSHOT_COLLECTIONS with details when releaseSongs entries are malformed', async () => {
+    const seed = await seedGame(TEST_USER_ID);
+    const snapshot = buildSnapshot(seed, {
+      // songId is a number, not a string -> malformed
+      releaseSongs: [{ releaseId: seed.releaseId, songId: 12345, trackNumber: 1, isSingle: true }],
+    });
+    const saveId = await insertSave(TEST_USER_ID, snapshot);
+
+    const res = await request(app).post(`/api/saves/${saveId}/restore`).send({ mode: 'overwrite' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_SNAPSHOT_COLLECTIONS');
+    expect(res.body.message).toBe(
+      'Snapshot collections are missing required fields or are malformed'
+    );
+    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.details).toContain('releaseSongs[0] is missing required releaseId/songId');
+  });
+
+  it('returns 404 SAVE_NOT_FOUND for a save owned by another user', async () => {
+    const seed = await seedGame(OTHER_USER_ID);
+    const snapshot = buildSnapshot(seed);
+    const saveId = await insertSave(OTHER_USER_ID, snapshot);
+
+    const res = await request(app).post(`/api/saves/${saveId}/restore`).send({ mode: 'overwrite' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('SAVE_NOT_FOUND');
+    expect(res.body.message).toBe('Save file not found or does not belong to this user');
+  });
+
+  it('returns 403 UNAUTHORIZED when overwriting a game owned by another user', async () => {
+    // Save row belongs to the authenticated user, but the snapshot points at a
+    // game owned by OTHER_USER_ID -> overwrite ownership check must 403.
+    const otherSeed = await seedGame(OTHER_USER_ID);
+    const snapshot = buildSnapshot(otherSeed);
+    const saveId = await insertSave(TEST_USER_ID, snapshot);
+
+    const res = await request(app).post(`/api/saves/${saveId}/restore`).send({ mode: 'overwrite' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('UNAUTHORIZED');
+    expect(res.body.message).toBe('You do not have permission to restore this game');
+  });
+});
+
+describe('DELETE /api/saves/:saveId (characterization)', () => {
+  it('returns 404 SAVE_NOT_FOUND for a missing save', async () => {
+    const res = await request(app).delete(`/api/saves/${randomUUID()}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('SAVE_NOT_FOUND');
+    expect(res.body.message).toBe('Save file not found or does not belong to this user');
+  });
+
+  it('deletes an owned save and returns the deletedSaveId', async () => {
+    const seed = await seedGame(TEST_USER_ID);
+    const snapshot = buildSnapshot(seed);
+    const saveId = await insertSave(TEST_USER_ID, snapshot);
+
+    const res = await request(app).delete(`/api/saves/${saveId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Save deleted successfully');
+    expect(res.body.deletedSaveId).toBe(saveId);
+
+    const remaining = await db.select().from(gameSaves).where(eq(gameSaves.id, saveId));
+    expect(remaining).toHaveLength(0);
+  });
+});
+
+describe('POST /api/saves (characterization)', () => {
+  it('creates a save when the snapshot carries a game identifier', async () => {
+    const seed = await seedGame(TEST_USER_ID);
+    const snapshot = buildSnapshot(seed);
+
+    const res = await request(app)
+      // `week` must match snapshot currentWeek (insertGameSaveSchema.superRefine)
+      .post('/api/saves')
+      .send({ name: 'My Save', week: snapshot.gameState.currentWeek, gameState: snapshot, isAutosave: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBeTruthy();
+    expect(res.body.week).toBe(snapshot.gameState.currentWeek);
+
+    const [row] = await db.select().from(gameSaves).where(eq(gameSaves.id, res.body.id));
+    expect(row).toBeTruthy();
+    expect(row.userId).toBe(TEST_USER_ID);
+  });
+
+  it('returns a Zod 400 when snapshot.gameState.id is missing', async () => {
+    // NOTE: gameSaveSnapshotSchema requires gameState.id (z.string()), so an
+    // omitted id fails Zod parsing FIRST and never reaches the handler's own
+    // INVALID_SNAPSHOT guard. The observable result is the generic Zod 400.
+    const snapshot = {
+      snapshotVersion: SNAPSHOT_VERSION,
+      gameState: { currentWeek: 3, money: 0, reputation: 0, creativeCapital: 0 }, // no id
+    };
+
+    const res = await request(app)
+      .post('/api/saves')
+      .send({ name: 'No Id Save', week: 3, gameState: snapshot, isAutosave: false });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Invalid save data');
+    expect(Array.isArray(res.body.errors)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- PR-16 of the Phase 1 routes refactor plan: extracts `server/services/saveService.ts` from `server/routes/saves.ts` (629 → 139 lines)
- Service methods: `createSave`, `restoreOverwrite`, `restoreFork`, `deleteSave`; `validateSnapshotCollections` + `convertTimestamps` are now private to the service
- Routes stay thin and keep all HTTP status mapping; service throws coded errors (`SAVE_NOT_FOUND`, `UNSUPPORTED_SNAPSHOT_VERSION`, `INVALID_SNAPSHOT`, `UNAUTHORIZED`, `INVALID_SNAPSHOT_COLLECTIONS`) mapped to byte-identical response bodies
- Characterization-test-first: commit 1 adds `tests/endpoints/save-restore.characterization.test.ts` (11 tests, green against the old code); commit 2 is the extraction, everything still green

## Verification
- `npm run check` clean before and after
- 27/27 across characterization + save-load-snapshot-integrity + game-spine-advance-save-restore + save-load-email-system + route-manifest (manifest unchanged: same paths, same middleware)
- All `[RESTORE] Step N` logs, deletion/reinsert ordering, and fork idMap remapping moved verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)