### PR TITLE
fix(security): remove zero-auth debug/select-actions routes, admin-gate markets-config

### DIFF
--- a/server/routes/devTools.ts
+++ b/server/routes/devTools.ts
@@ -4,9 +4,9 @@ import path from 'path';
 import { serverGameData } from '../data/gameData';
 import { gameDataLoader } from '@shared/utils/dataLoader';
 import { db } from '../db';
-import { gameStates, projects, songs } from '@shared/schema';
-import { eq, and } from 'drizzle-orm';
-import { requireClerkUser } from '../auth';
+import { gameStates } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import { requireClerkUser, requireAdmin } from '../auth';
 
 const router = Router();
 
@@ -164,66 +164,6 @@ router.get("/api/validate-types", requireClerkUser, async (req, res) => {
     }
   });
 
-  // DEBUG: Check project and song revenue status
-  // TODO(phase-1): this endpoint has NO auth middleware (no requireClerkUser) and
-  // exposes game data by gameId. Preserved as-is during the Phase 1 pure move; auth
-  // hardening is a deliberate, separately-reviewed change (see plan §6).
-  router.get("/api/debug/game/:gameId/revenue", async (req, res) => {
-    try {
-      const gameId = req.params.gameId;
-
-      // Get all projects for this game
-      const allProjects = await db.select().from(projects).where(eq(projects.gameId, gameId));
-
-      // Get all songs for this game
-      const allSongs = await db.select().from(songs).where(eq(songs.gameId, gameId));
-
-      // Get released projects specifically
-      const releasedProjects = await db.select().from(projects)
-        .where(and(eq(projects.gameId, gameId), eq(projects.stage, 'released')));
-
-      res.json({
-        summary: {
-          totalProjects: allProjects.length,
-          releasedProjects: releasedProjects.length,
-          totalSongs: allSongs.length,
-          releasedSongs: allSongs.filter(s => s.isReleased).length
-        },
-        projects: allProjects.map(p => ({
-          id: p.id,
-          title: p.title,
-          type: p.type,
-          stage: p.stage,
-          artistId: p.artistId,
-          songCount: p.songCount,
-          songsCreated: p.songsCreated,
-          startWeek: p.startWeek,
-          metadata: p.metadata
-        })),
-        songs: allSongs.map(s => ({
-          id: s.id,
-          title: s.title,
-          artistId: s.artistId,
-          quality: s.quality,
-          isRecorded: s.isRecorded,
-          isReleased: s.isReleased,
-          createdWeek: s.createdWeek,
-          metadata: s.metadata
-        })),
-        releasedProjects: releasedProjects.map(p => ({
-          id: p.id,
-          title: p.title,
-          metadata: p.metadata,
-          hasRevenue: !!(p.metadata as any)?.revenue,
-          hasStreams: !!(p.metadata as any)?.streams
-        }))
-      });
-    } catch (error) {
-      console.error('[DEBUG] Error fetching revenue debug status:', error);
-      res.status(500).json({ message: "Failed to fetch revenue debug status" });
-    }
-  });
-
   // Developer tools endpoints
   router.get('/api/dev/markets-config', requireClerkUser, async (req, res) => {
     try {
@@ -237,11 +177,8 @@ router.get("/api/validate-types", requireClerkUser, async (req, res) => {
     }
   });
 
-  // TODO(phase-1): this write endpoint uses requireClerkUser (any authenticated
-  // user), NOT requireAdmin — it likely should be admin-gated since it writes to
-  // data/balance/markets.json. Preserved as-is during the Phase 1 pure move; auth
-  // hardening is a deliberate, separately-reviewed change (see plan §6).
-  router.post('/api/dev/markets-config', requireClerkUser, async (req, res) => {
+  // Admin-gated: writes to data/balance/markets.json (global economy config).
+  router.post('/api/dev/markets-config', requireClerkUser, requireAdmin, async (req, res) => {
     try {
       const { config } = req.body;
 

--- a/server/routes/gameLoop.ts
+++ b/server/routes/gameLoop.ts
@@ -8,7 +8,6 @@ import { serverGameData } from '../data/gameData';
 import { GameEngine } from '../../shared/engine/game-engine';
 import {
   AdvanceWeekRequest,
-  SelectActionsRequest,
   validateRequest,
   createErrorResponse,
 } from '@shared/api/contracts';
@@ -397,87 +396,6 @@ const router = Router();
       res.status(500).json(createErrorResponse(
         'ADVANCE_WEEK_ERROR',
         errorMessage
-      ));
-    }
-  });
-
-  // TODO(phase-2): orphaned endpoint, no client callers, no auth — delete
-  // Save player action selections with transactions
-  router.post("/api/select-actions", async (req, res) => {
-    try {
-      // Validate request using shared contract
-      const request = validateRequest(SelectActionsRequest, req.body);
-      const { gameId, selectedActions } = request;
-
-      // Wrap in transaction
-      const result = await db.transaction(async (tx) => {
-        // Get current game state
-        const [gameState] = await tx
-          .select()
-          .from(gameStates)
-          .where(eq(gameStates.id, gameId));
-
-        if (!gameState) {
-          throw new Error('Game not found');
-        }
-
-        // Get starting values from balance configuration
-        const startingValues = await serverGameData.getStartingValues();
-
-        // Convert database gameState to proper GameState type
-        const gameStateForEngine = {
-          ...gameState,
-          currentWeek: gameState.currentWeek || 1,
-          money: gameState.money ?? startingValues.money,
-          reputation: gameState.reputation ?? startingValues.reputation,
-          creativeCapital: gameState.creativeCapital ?? startingValues.creativeCapital,
-          focusSlots: gameState.focusSlots ?? 3,
-          usedFocusSlots: gameState.usedFocusSlots ?? 0,
-          // A&R Office fields
-          arOfficeSlotUsed: (gameState as any).arOfficeSlotUsed || false,
-          arOfficeSourcingType: (gameState as any).arOfficeSourcingType || null,
-          playlistAccess: gameState.playlistAccess ?? 'none',
-          pressAccess: gameState.pressAccess ?? 'none',
-          venueAccess: gameState.venueAccess ?? 'none',
-          campaignType: gameState.campaignType ?? 'standard',
-          rngSeed: gameState.rngSeed ?? Math.random().toString(36).substring(7),
-          flags: gameState.flags ?? {},
-          weeklyStats: gameState.weeklyStats ?? {}
-        };
-
-        // Create GameEngine instance and update action selection
-        const gameEngine = new GameEngine(gameStateForEngine, serverGameData, storage);
-        const updatedGameState = gameStateForEngine; // For now, just return current state
-
-        // Update in database
-        await tx
-          .update(gameStates)
-          .set({
-            usedFocusSlots: updatedGameState.usedFocusSlots,
-            flags: updatedGameState.flags,
-            updatedAt: new Date()
-          })
-          .where(eq(gameStates.id, gameId));
-
-        return {
-          success: true,
-          gameState: updatedGameState
-        };
-      });
-
-      res.json(result);
-    } catch (error) {
-      console.error('Select actions error:', error);
-      if (error instanceof z.ZodError) {
-        return res.status(400).json(createErrorResponse(
-          'VALIDATION_ERROR',
-          'Invalid request data',
-          error.errors
-        ));
-      }
-      res.status(500).json(createErrorResponse(
-        'SELECT_ACTIONS_ERROR',
-        error instanceof Error ? error.message : 'Failed to save action selection'
       ));
     }
   });

--- a/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
+++ b/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
@@ -156,11 +156,6 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
   },
   {
     "method": "GET",
-    "middleware": [],
-    "path": "/api/debug/game/:gameId/revenue",
-  },
-  {
-    "method": "GET",
     "middleware": [
       "requireClerkUser",
     ],
@@ -170,6 +165,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireAdmin",
     ],
     "path": "/api/dev/markets-config",
   },
@@ -533,11 +529,6 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
       "requireClerkUser",
     ],
     "path": "/api/saves/:saveId/restore",
-  },
-  {
-    "method": "POST",
-    "middleware": [],
-    "path": "/api/select-actions",
   },
   {
     "method": "PATCH",


### PR DESCRIPTION
## Summary
Executes recommendation #1 of `docs/98-research/OWNERSHIP_AUTHORIZATION_SWEEP_2026-07-02.md` (CRITICAL bucket):
- Delete `GET /api/debug/game/:gameId/revenue` (devTools.ts) — zero auth middleware; dumped any game's projects/songs/revenue by gameId. Was TODO-flagged for this removal.
- Delete `POST /api/select-actions` (gameLoop.ts) — zero auth middleware; mutated any game's focus slots/flags via body-supplied gameId. Orphaned (no client callers; verified by repo-wide search — only an unused `shared/api/client.ts` method references it, left untouched).
- Admin-gate `POST /api/dev/markets-config` — was `requireClerkUser` only, letting any authenticated user overwrite the global `data/balance/markets.json`; now `requireClerkUser, requireAdmin` matching admin.ts.
- Route-manifest snapshot updated accordingly; unused imports (`projects`, `songs`, `and`, `SelectActionsRequest`) removed with per-file reference verification.

## Verification
- `tsc --noEmit` clean (run against the branch worktree)
- Manifest snapshot hand-updated; the CI vitest job re-derives it against a real Postgres and will fail if the edit is wrong — treat the vitest check as the gate here

🤖 Generated with [Claude Code](https://claude.com/claude-code)