### PR TITLE
refactor(releases): extract releasePlanningService with ownership + budget validation (PR-17)

### DIFF
--- a/server/middleware/requireGameOwner.ts
+++ b/server/middleware/requireGameOwner.ts
@@ -1,0 +1,66 @@
+/**
+ * requireGameOwner.ts
+ *
+ * Shared game-ownership middleware (Phase 1, PR-17). Promotes the inline
+ * ownership check used across emails.ts (46-57) and the releases router into a
+ * single reusable middleware, closing the broken-object-level-authorization
+ * (IDOR) gap documented in OWNERSHIP_AUTHORIZATION_SWEEP_2026-07-02.md.
+ *
+ * Reads `req.params.gameId`, loads the game scoped by BOTH id AND
+ * `req.userId`, and 404s (not 403) if no such row exists so we don't leak
+ * whether a given gameId exists to a non-owner. On success it stashes the
+ * loaded game row on `req.gameState` so downstream handlers can reuse it
+ * without a second query.
+ *
+ * MUST run after requireClerkUser (which populates req.userId).
+ */
+import type { Request, Response, NextFunction } from 'express';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { gameStates, type GameState } from '@shared/schema';
+
+export async function requireGameOwner(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = req.userId;
+    if (!userId) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    const gameId = req.params.gameId;
+    if (!gameId) {
+      return res.status(400).json({
+        error: 'MISSING_GAME_ID',
+        message: 'gameId route parameter is required',
+      });
+    }
+
+    const [game] = await db
+      .select()
+      .from(gameStates)
+      .where(and(eq(gameStates.id, gameId), eq(gameStates.userId, userId)))
+      .limit(1);
+
+    if (!game) {
+      // 404 (not 403): do not leak whether a game with this id exists to a
+      // caller who does not own it.
+      return res.status(404).json({
+        error: 'GAME_NOT_FOUND',
+        message: 'Game not found or does not belong to this user',
+      });
+    }
+
+    req.gameState = game;
+    next();
+  } catch (error) {
+    console.error('[requireGameOwner] Failed to verify game ownership', error);
+    res.status(500).json({ message: 'Failed to verify game ownership' });
+  }
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      gameState?: GameState;
+    }
+  }
+}

--- a/server/routes/releases.ts
+++ b/server/routes/releases.ts
@@ -1,19 +1,39 @@
 import { Router } from 'express';
+import { z } from 'zod';
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { db } from '../db';
 import { storage } from '../storage';
 import { requireClerkUser } from '../auth';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 import { serverGameData } from '../data/gameData';
 import { artists, gameStates, releases, releaseSongs, songs } from '@shared/schema';
 import { GameEngine } from '@shared/engine/game-engine';
 import { ChartService } from '@shared/engine/ChartService';
+import { releasePlanningService, ReleaseServiceError } from '../services/releasePlanningService';
 
 const router = Router();
+
+// Whitelist for POST /api/game/:gameId/releases (plain create). Only fields the
+// handler actually consumes are accepted; server-computed columns
+// (revenueGenerated, streamsGenerated, peakChartPosition, gameId, id,
+// createdAt/updatedAt) are NOT client-settable. `.strict()` rejects any unknown
+// field with a 400 so mass-assignment can't smuggle extra columns.
+const createReleaseSchema = z.object({
+  artistId: z.string(),
+  title: z.string(),
+  type: z.string(),
+  releaseWeek: z.number().optional(),
+  totalQuality: z.number().optional(),
+  marketingBudget: z.number().optional(),
+  status: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+  songIds: z.array(z.string()).optional(),
+}).strict();
 
   // Phase 1: Song and Release Management API Routes
 
   // Get songs for a game
-  router.get("/api/game/:gameId/songs", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/songs", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const songs = await serverGameData.getSongsByGame(req.params.gameId);
       res.json(songs);
@@ -23,7 +43,7 @@ const router = Router();
   });
 
   // Get songs for a specific artist
-  router.get("/api/game/:gameId/artists/:artistId/songs", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/artists/:artistId/songs", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId, artistId } = req.params;
 
@@ -94,7 +114,7 @@ const router = Router();
   });
 
   // Get releases for a game
-  router.get("/api/game/:gameId/releases", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/releases", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const releases = await serverGameData.getReleasesByGame(req.params.gameId);
       res.json(releases);
@@ -103,17 +123,11 @@ const router = Router();
     }
   });
 
-  router.get("/api/game/:gameId/release-songs", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/release-songs", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState || gameState.userId !== req.userId) {
-        return res.status(403).json({
-          error: 'UNAUTHORIZED',
-          message: 'You do not have permission to access this game'
-        });
-      }
-
+      // Ownership verified by requireGameOwner (its 404 replaces the previous
+      // inline 403 UNAUTHORIZED check).
       const releaseSongsRows = await storage.getReleaseSongsByGame(gameId);
       res.json(releaseSongsRows);
     } catch (error) {
@@ -123,10 +137,23 @@ const router = Router();
   });
 
   // Create a new release (Single/EP/Album)
-  router.post("/api/game/:gameId/releases", requireClerkUser, async (req, res) => {
+  router.post("/api/game/:gameId/releases", requireClerkUser, requireGameOwner, async (req, res) => {
+    // HARDENING (PR-17): whitelist fields with a .strict() schema so
+    // server-computed columns (revenueGenerated/streamsGenerated/
+    // peakChartPosition/gameId/...) can't be mass-assigned by the client.
+    const parsed = createReleaseSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'INVALID_RELEASE_FIELDS',
+        message: 'Release payload contains missing or unexpected fields',
+        details: parsed.error.errors,
+      });
+    }
+
     try {
+      const { songIds, ...releaseFields } = parsed.data;
       const releaseData = {
-        ...req.body,
+        ...releaseFields,
         gameId: req.params.gameId,
         createdAt: new Date(),
         updatedAt: new Date()
@@ -135,11 +162,11 @@ const router = Router();
       const release = await serverGameData.createRelease(releaseData);
 
       // If songs are provided, create the release-song relationships
-      if (req.body.songIds && req.body.songIds.length > 0) {
-        for (let i = 0; i < req.body.songIds.length; i++) {
+      if (songIds && songIds.length > 0) {
+        for (let i = 0; i < songIds.length; i++) {
           await serverGameData.createReleaseSong({
             releaseId: release.id,
-            songId: req.body.songIds[i],
+            songId: songIds[i],
             trackNumber: i + 1
           });
         }
@@ -155,7 +182,7 @@ const router = Router();
   // PLAN RELEASE ENDPOINTS
 
   // Get artists with ready songs for release planning
-  router.get("/api/game/:gameId/artists/ready-for-release", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/artists/ready-for-release", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
       const minSongs = parseInt(req.query.minSongs as string) || 1;
@@ -216,7 +243,7 @@ const router = Router();
   });
 
   // Get ready songs for a specific artist
-  router.get("/api/game/:gameId/artists/:artistId/songs/ready", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/artists/:artistId/songs/ready", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId, artistId } = req.params;
       const includeDrafts = req.query.includeDrafts === 'true';
@@ -311,7 +338,7 @@ const router = Router();
   });
 
   // Calculate release preview metrics
-  router.post("/api/game/:gameId/releases/preview", requireClerkUser, async (req, res) => {
+  router.post("/api/game/:gameId/releases/preview", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
       const {
@@ -432,226 +459,21 @@ const router = Router();
   });
 
   // Create planned release
-  router.post("/api/game/:gameId/releases/plan", requireClerkUser, async (req, res) => {
+  router.post("/api/game/:gameId/releases/plan", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
-      const {
-        artistId,
-        title,
-        type,
-        songIds,
-        leadSingleId,
-        seasonalTiming,
-        scheduledReleaseWeek,
-        marketingBudget,
-        leadSingleStrategy,
-        metadata
-      } = req.body;
-
-      // Validate inputs
-      if (!artistId || !title || !type || !songIds || songIds.length === 0) {
-        return res.status(400).json({
-          error: 'VALIDATION_ERROR',
-          message: 'Release validation failed',
-          details: [
-            { field: 'artistId', error: 'Required' },
-            { field: 'title', error: 'Required' },
-            { field: 'type', error: 'Required' },
-            { field: 'songIds', error: 'Must have at least one song' }
-          ]
-        });
-      }
-
-      // Check if user has sufficient funds
-      const [gameState] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
-      if (!gameState) {
-        return res.status(404).json({
-          error: 'GAME_NOT_FOUND',
-          message: 'Game session not found',
-          gameId
-        });
-      }
-
-      // Validate release week is in the future
-      const currentWeek = gameState.currentWeek || 1;
-      if (scheduledReleaseWeek && scheduledReleaseWeek <= currentWeek) {
-        return res.status(400).json({
-          error: 'INVALID_RELEASE_WEEK',
-          message: 'Cannot plan releases for current or past weeks',
-          currentWeek,
-          scheduledReleaseWeek,
-          details: [
-            { field: 'scheduledReleaseWeek', error: `Must be greater than current week (${currentWeek})` }
-          ]
-        });
-      }
-
-      // Validate lead single week if provided
-      if (leadSingleStrategy?.leadSingleReleaseWeek) {
-        if (leadSingleStrategy.leadSingleReleaseWeek <= currentWeek) {
-          return res.status(400).json({
-            error: 'INVALID_LEAD_SINGLE_WEEK',
-            message: 'Cannot plan lead single for current or past weeks',
-            currentWeek,
-            leadSingleReleaseWeek: leadSingleStrategy.leadSingleReleaseWeek,
-            details: [
-              { field: 'leadSingleReleaseWeek', error: `Must be greater than current week (${currentWeek})` }
-            ]
-          });
-        }
-      }
-
-      const totalBudget = Object.values(marketingBudget || {}).reduce((sum: number, budget) => sum + (budget as number), 0) +
-        (leadSingleStrategy ? Object.values(leadSingleStrategy.leadSingleBudget || {}).reduce((sum: number, budget) => sum + (budget as number), 0) : 0);
-
-      // Check if user has sufficient creative capital
-      const currentCreativeCapital = gameState.creativeCapital || 0;
-      if (currentCreativeCapital < 1) {
-        return res.status(402).json({
-          error: 'INSUFFICIENT_CREATIVE_CAPITAL',
-          message: 'Insufficient creative capital. You need 1 creative capital to plan a release.',
-          required: 1,
-          available: currentCreativeCapital
-        });
-      }
-
-      if ((gameState.money || 0) < totalBudget) {
-        return res.status(402).json({
-          error: 'INSUFFICIENT_FUNDS',
-          message: 'Not enough money for marketing budget',
-          required: totalBudget,
-          available: gameState.money || 0,
-          suggestions: [
-            { action: 'REDUCE_BUDGET', description: 'Reduce marketing allocation', potentialSavings: totalBudget - (gameState.money || 0) }
-          ]
-        });
-      }
-
-      // Check for song conflicts (songs already scheduled for release)
-      const conflictingSongs = await db
-        .select()
-        .from(songs)
-        .where(and(
-          eq(songs.gameId, gameId),
-          inArray(songs.id, songIds),
-          sql`${songs.releaseId} IS NOT NULL`
-        ));
-
-      if (conflictingSongs.length > 0) {
-        return res.status(409).json({
-          error: 'SONG_ALREADY_SCHEDULED',
-          message: 'Some songs are already part of a planned release',
-          conflictingSongs: conflictingSongs.map(c => ({
-            songId: c.id,
-            songTitle: c.title,
-            conflictingReleaseId: c.releaseId,
-            conflictingReleaseTitle: 'Unknown Release'
-          })),
-          resolutionOptions: [
-            { action: 'CHOOSE_DIFFERENT_SONGS', description: 'Select different songs for this release' }
-          ]
-        });
-      }
-
-      // Create the planned release in a transaction
-      const result = await db.transaction(async (tx) => {
-        // CRITICAL FIX: Single deduction of marketing budget and creative capital
-        await tx.update(gameStates)
-          .set({
-            money: (gameState.money || 0) - totalBudget,
-            creativeCapital: currentCreativeCapital - 1
-          })
-          .where(eq(gameStates.id, gameId));
-
-        console.log(`[PLAN RELEASE] Deducted $${totalBudget} and 1 creative capital for release planning`);
-
-        // Create release record
-        const [newRelease] = await tx.insert(releases).values({
-          gameId,
-          artistId,
-          title,
-          type,
-          releaseWeek: scheduledReleaseWeek,
-          status: 'planned',
-          marketingBudget: totalBudget,
-          metadata: {
-            ...metadata,
-            seasonalTiming,
-            scheduledReleaseWeek,
-            marketingChannels: Object.keys(marketingBudget || {}),
-            marketingBudgetBreakdown: marketingBudget || {}, // CRITICAL FIX: Store per-channel budgets for release execution
-            leadSingleStrategy: leadSingleStrategy ? {
-              ...leadSingleStrategy,
-              leadSingleBudgetBreakdown: leadSingleStrategy.leadSingleBudget || {} // Store per-channel breakdown for lead single too
-            } : null
-          }
-        }).returning();
-
-        // Update songs to mark them as reserved for this release
-        await tx.update(songs)
-          .set({ releaseId: newRelease.id })
-          .where(inArray(songs.id, songIds));
-
-        // CRITICAL FIX: Also create entries in the junction table for proper song-release association
-        // This ensures songs are properly linked when releases are executed
-        const releaseSongEntries = songIds.map((songId: string, index: number) => ({
-          id: crypto.randomUUID(),
-          releaseId: newRelease.id,
-          songId: songId,
-          trackNumber: index + 1, // Track order based on selection order
-          createdAt: new Date()
-        }));
-
-        await tx.insert(releaseSongs).values(releaseSongEntries);
-        console.log(`[PLAN RELEASE] Created ${releaseSongEntries.length} junction table entries for release ${newRelease.id}`);
-
-        return newRelease;
-      });
-
-      // Get updated game state and planned releases
-      const [updatedGameState] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
-      const plannedReleases = await db.select().from(releases)
-        .where(and(eq(releases.gameId, gameId), eq(releases.status, 'planned')));
-
-      res.status(201).json({
-        success: true,
-        release: {
-          id: result.id,
-          title: result.title,
-          type: result.type,
-          artistId: result.artistId,
-          artistName: 'Artist Name', // Would need artist lookup
-          songIds,
-          leadSingleId,
-          scheduledReleaseWeek,
-          status: 'planned',
-          estimatedMetrics: {
-            streams: metadata?.estimatedStreams || 0,
-            revenue: metadata?.estimatedRevenue || 0,
-            roi: metadata?.projectedROI || 0,
-            chartPotential: 50
-          },
-          createdAt: result.createdAt?.toISOString(),
-          createdByWeek: updatedGameState.currentWeek
-        },
-        updatedGameState: {
-          money: updatedGameState.money,
-          plannedReleases: plannedReleases.map(r => ({
-            id: r.id,
-            title: r.title,
-            artistName: 'Artist Name', // Would need artist lookup
-            type: r.type,
-            scheduledWeek: r.releaseWeek,
-            status: r.status
-          })),
-          artistsAffected: [{
-            artistId,
-            songsReserved: songIds.length,
-            moodImpact: 5 // Positive mood boost from planned release
-          }]
-        }
-      });
+      // gameState is the owner-verified row from requireGameOwner.
+      const payload = await releasePlanningService.planRelease(
+        req.userId,
+        gameId,
+        req.gameState!,
+        req.body,
+      );
+      res.status(201).json(payload);
     } catch (error) {
+      if (error instanceof ReleaseServiceError) {
+        return res.status(error.status).json(error.body);
+      }
       console.error("Failed to create planned release:", error);
       console.error("Error stack:", (error as Error).stack);
       console.error("Error message:", (error as Error).message);
@@ -668,7 +490,7 @@ const router = Router();
 
 
   // Song conflict resolution endpoints
-  router.get("/api/game/:gameId/songs/conflicts", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/songs/conflicts", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
 
@@ -807,7 +629,7 @@ const router = Router();
   });
 
   // Clear all song reservations (for debugging/testing)
-  router.post("/api/game/:gameId/songs/clear-reservations", requireClerkUser, async (req, res) => {
+  router.post("/api/game/:gameId/songs/clear-reservations", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
 
@@ -840,63 +662,18 @@ const router = Router();
 
 
   // Delete a planned release and free up its songs
-  router.delete("/api/game/:gameId/releases/:releaseId", requireClerkUser, async (req, res) => {
+  router.delete("/api/game/:gameId/releases/:releaseId", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
       const releaseId = req.params.releaseId;
-
-      // Get the release to return marketing budget
-      const [release] = await db.select().from(releases)
-        .where(and(eq(releases.id, releaseId), eq(releases.gameId, gameId)));
-
-      if (!release) {
-        return res.status(404).json({
-          error: 'RELEASE_NOT_FOUND',
-          message: 'Planned release not found'
-        });
-      }
-
-      if (release.status !== 'planned') {
-        return res.status(400).json({
-          error: 'CANNOT_DELETE_RELEASED',
-          message: 'Cannot delete a release that has already been executed'
-        });
-      }
-
-      // Execute deletion in transaction
-      const result = await db.transaction(async (tx) => {
-        // Free up songs reserved for this release
-        const freedSongs = await tx.update(songs)
-          .set({ releaseId: null })
-          .where(eq(songs.releaseId, releaseId))
-          .returning();
-
-        // Return marketing budget to player
-        const [gameState] = await tx.select().from(gameStates)
-          .where(eq(gameStates.id, gameId));
-
-        if (gameState) {
-          await tx.update(gameStates)
-            .set({ money: (gameState.money || 0) + (release.marketingBudget || 0) })
-            .where(eq(gameStates.id, gameId));
-        }
-
-        // Delete the planned release
-        await tx.delete(releases).where(eq(releases.id, releaseId));
-
-        return { freedSongs, refundedAmount: release.marketingBudget || 0 };
-      });
-
-      res.json({
-        success: true,
-        message: `Deleted planned release "${release.title}"`,
-        freedSongs: result.freedSongs.map(s => ({
-          songId: s.id,
-          songTitle: s.title
-        })),
-        refundedAmount: result.refundedAmount
-      });
+      // Ownership verified by requireGameOwner. Refund comes from the STORED
+      // release.marketingBudget inside the service, never from client input.
+      const payload = await releasePlanningService.deleteRelease(req.userId, gameId, releaseId);
+      res.json(payload);
     } catch (error) {
+      if (error instanceof ReleaseServiceError) {
+        return res.status(error.status).json(error.body);
+      }
       console.error("Failed to delete planned release:", error);
       res.status(500).json({
         error: 'DELETE_RELEASE_ERROR',

--- a/server/services/releasePlanningService.ts
+++ b/server/services/releasePlanningService.ts
@@ -1,0 +1,362 @@
+/**
+ * releasePlanningService.ts
+ *
+ * Backend service for planned-release creation and deletion. Extracted from the
+ * two fat mutation handlers in server/routes/releases.ts (Phase 1, PR-17):
+ *   - POST /api/game/:gameId/releases/plan   (was routes/releases.ts:435-666)
+ *   - DELETE /api/game/:gameId/releases/:releaseId (was routes/releases.ts:843-906)
+ *
+ * Follows the class+singleton convention of gameCreationService.ts. The service
+ * throws coded ReleaseServiceError instances; the route layer keeps ALL HTTP
+ * status mapping with byte-identical response bodies (each error carries the
+ * exact JSON body the original handler returned).
+ *
+ * Behavior is intentionally equivalent to the pre-extraction handlers, with two
+ * deliberate hardening additions flagged in the PR-17 report:
+ *   1. Marketing-budget validation: every channel value (and lead-single budget
+ *      value) must be a finite number >= 0. Previously a negative channel value
+ *      would REDUCE totalBudget (and, at the extreme, could credit money) — this
+ *      is now rejected with INVALID_MARKETING_BUDGET (400).
+ *   2. deleteRelease refunds strictly from the STORED release.marketingBudget,
+ *      never from client input (already true pre-extraction; preserved).
+ */
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { db as dbSingleton } from '../db';
+import { gameStates, releases, releaseSongs, songs } from '@shared/schema';
+
+/**
+ * A coded error whose `body` is the EXACT JSON payload the original route
+ * returned for this failure mode, and whose `status` is the HTTP status the
+ * route must send. The route layer maps: res.status(err.status).json(err.body).
+ */
+export class ReleaseServiceError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    public readonly body: Record<string, unknown>,
+  ) {
+    super(code);
+    this.name = 'ReleaseServiceError';
+  }
+}
+
+/**
+ * Sum a per-channel budget object, validating every value is a finite number
+ * >= 0. Throws INVALID_MARKETING_BUDGET (400) on any negative / non-finite
+ * value. `label` distinguishes the marketing vs. lead-single budget in the
+ * error field for debuggability.
+ */
+function sumValidatedBudget(budget: Record<string, unknown> | undefined | null, label: string): number {
+  if (!budget) return 0;
+  let total = 0;
+  for (const [channel, raw] of Object.entries(budget)) {
+    const value = raw as number;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+      throw new ReleaseServiceError('INVALID_MARKETING_BUDGET', 400, {
+        error: 'INVALID_MARKETING_BUDGET',
+        message: 'Marketing budget values must be finite numbers greater than or equal to zero',
+        details: [
+          { field: `${label}.${channel}`, error: 'Must be a finite number >= 0' },
+        ],
+      });
+    }
+    total += value;
+  }
+  return total;
+}
+
+export class ReleasePlanningService {
+  constructor(private db = dbSingleton) {}
+
+  /**
+   * Create a planned release: validate inputs, funds, and creative capital;
+   * then in a single transaction deduct marketing budget + 1 creative capital,
+   * insert the release + release_songs junction rows, and reserve the songs.
+   *
+   * `gameState` is the owner-verified game row (from requireGameOwner). It is
+   * used for the money/creativeCapital/currentWeek reads; the transaction still
+   * writes against gameStates by id.
+   *
+   * Returns the exact response payload the original POST .../plan handler sent
+   * (the route wraps it as res.status(201).json(payload)).
+   */
+  async planRelease(userId: string | undefined, gameId: string, gameState: typeof gameStates.$inferSelect, body: any) {
+    const {
+      artistId,
+      title,
+      type,
+      songIds,
+      leadSingleId,
+      seasonalTiming,
+      scheduledReleaseWeek,
+      marketingBudget,
+      leadSingleStrategy,
+      metadata,
+    } = body;
+
+    // Validate inputs
+    if (!artistId || !title || !type || !songIds || songIds.length === 0) {
+      throw new ReleaseServiceError('VALIDATION_ERROR', 400, {
+        error: 'VALIDATION_ERROR',
+        message: 'Release validation failed',
+        details: [
+          { field: 'artistId', error: 'Required' },
+          { field: 'title', error: 'Required' },
+          { field: 'type', error: 'Required' },
+          { field: 'songIds', error: 'Must have at least one song' },
+        ],
+      });
+    }
+
+    // HARDENING (PR-17): reject negative / non-finite budget values BEFORE any
+    // totals are summed (a negative channel would otherwise reduce totalBudget
+    // and could credit money).
+    const marketingTotal = sumValidatedBudget(marketingBudget, 'marketingBudget');
+    const leadSingleTotal = leadSingleStrategy
+      ? sumValidatedBudget(leadSingleStrategy.leadSingleBudget, 'leadSingleBudget')
+      : 0;
+
+    // Validate release week is in the future
+    const currentWeek = gameState.currentWeek || 1;
+    if (scheduledReleaseWeek && scheduledReleaseWeek <= currentWeek) {
+      throw new ReleaseServiceError('INVALID_RELEASE_WEEK', 400, {
+        error: 'INVALID_RELEASE_WEEK',
+        message: 'Cannot plan releases for current or past weeks',
+        currentWeek,
+        scheduledReleaseWeek,
+        details: [
+          { field: 'scheduledReleaseWeek', error: `Must be greater than current week (${currentWeek})` },
+        ],
+      });
+    }
+
+    // Validate lead single week if provided
+    if (leadSingleStrategy?.leadSingleReleaseWeek) {
+      if (leadSingleStrategy.leadSingleReleaseWeek <= currentWeek) {
+        throw new ReleaseServiceError('INVALID_LEAD_SINGLE_WEEK', 400, {
+          error: 'INVALID_LEAD_SINGLE_WEEK',
+          message: 'Cannot plan lead single for current or past weeks',
+          currentWeek,
+          leadSingleReleaseWeek: leadSingleStrategy.leadSingleReleaseWeek,
+          details: [
+            { field: 'leadSingleReleaseWeek', error: `Must be greater than current week (${currentWeek})` },
+          ],
+        });
+      }
+    }
+
+    const totalBudget = marketingTotal + leadSingleTotal;
+
+    // Check if user has sufficient creative capital
+    const currentCreativeCapital = gameState.creativeCapital || 0;
+    if (currentCreativeCapital < 1) {
+      throw new ReleaseServiceError('INSUFFICIENT_CREATIVE_CAPITAL', 402, {
+        error: 'INSUFFICIENT_CREATIVE_CAPITAL',
+        message: 'Insufficient creative capital. You need 1 creative capital to plan a release.',
+        required: 1,
+        available: currentCreativeCapital,
+      });
+    }
+
+    if ((gameState.money || 0) < totalBudget) {
+      throw new ReleaseServiceError('INSUFFICIENT_FUNDS', 402, {
+        error: 'INSUFFICIENT_FUNDS',
+        message: 'Not enough money for marketing budget',
+        required: totalBudget,
+        available: gameState.money || 0,
+        suggestions: [
+          { action: 'REDUCE_BUDGET', description: 'Reduce marketing allocation', potentialSavings: totalBudget - (gameState.money || 0) },
+        ],
+      });
+    }
+
+    // Check for song conflicts (songs already scheduled for release)
+    const conflictingSongs = await this.db
+      .select()
+      .from(songs)
+      .where(and(
+        eq(songs.gameId, gameId),
+        inArray(songs.id, songIds),
+        sql`${songs.releaseId} IS NOT NULL`
+      ));
+
+    if (conflictingSongs.length > 0) {
+      throw new ReleaseServiceError('SONG_ALREADY_SCHEDULED', 409, {
+        error: 'SONG_ALREADY_SCHEDULED',
+        message: 'Some songs are already part of a planned release',
+        conflictingSongs: conflictingSongs.map(c => ({
+          songId: c.id,
+          songTitle: c.title,
+          conflictingReleaseId: c.releaseId,
+          conflictingReleaseTitle: 'Unknown Release',
+        })),
+        resolutionOptions: [
+          { action: 'CHOOSE_DIFFERENT_SONGS', description: 'Select different songs for this release' },
+        ],
+      });
+    }
+
+    // Create the planned release in a transaction
+    const result = await this.db.transaction(async (tx) => {
+      // CRITICAL FIX: Single deduction of marketing budget and creative capital
+      await tx.update(gameStates)
+        .set({
+          money: (gameState.money || 0) - totalBudget,
+          creativeCapital: currentCreativeCapital - 1,
+        })
+        .where(eq(gameStates.id, gameId));
+
+      console.log(`[PLAN RELEASE] Deducted $${totalBudget} and 1 creative capital for release planning`);
+
+      // Create release record
+      const [newRelease] = await tx.insert(releases).values({
+        gameId,
+        artistId,
+        title,
+        type,
+        releaseWeek: scheduledReleaseWeek,
+        status: 'planned',
+        marketingBudget: totalBudget,
+        metadata: {
+          ...metadata,
+          seasonalTiming,
+          scheduledReleaseWeek,
+          marketingChannels: Object.keys(marketingBudget || {}),
+          marketingBudgetBreakdown: marketingBudget || {}, // CRITICAL FIX: Store per-channel budgets for release execution
+          leadSingleStrategy: leadSingleStrategy ? {
+            ...leadSingleStrategy,
+            leadSingleBudgetBreakdown: leadSingleStrategy.leadSingleBudget || {}, // Store per-channel breakdown for lead single too
+          } : null,
+        },
+      }).returning();
+
+      // Update songs to mark them as reserved for this release
+      await tx.update(songs)
+        .set({ releaseId: newRelease.id })
+        .where(inArray(songs.id, songIds));
+
+      // CRITICAL FIX: Also create entries in the junction table for proper song-release association
+      // This ensures songs are properly linked when releases are executed
+      const releaseSongEntries = songIds.map((songId: string, index: number) => ({
+        id: crypto.randomUUID(),
+        releaseId: newRelease.id,
+        songId: songId,
+        trackNumber: index + 1, // Track order based on selection order
+        createdAt: new Date(),
+      }));
+
+      await tx.insert(releaseSongs).values(releaseSongEntries);
+      console.log(`[PLAN RELEASE] Created ${releaseSongEntries.length} junction table entries for release ${newRelease.id}`);
+
+      return newRelease;
+    });
+
+    // Get updated game state and planned releases
+    const [updatedGameState] = await this.db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    const plannedReleases = await this.db.select().from(releases)
+      .where(and(eq(releases.gameId, gameId), eq(releases.status, 'planned')));
+
+    return {
+      success: true,
+      release: {
+        id: result.id,
+        title: result.title,
+        type: result.type,
+        artistId: result.artistId,
+        artistName: 'Artist Name', // Would need artist lookup
+        songIds,
+        leadSingleId,
+        scheduledReleaseWeek,
+        status: 'planned',
+        estimatedMetrics: {
+          streams: metadata?.estimatedStreams || 0,
+          revenue: metadata?.estimatedRevenue || 0,
+          roi: metadata?.projectedROI || 0,
+          chartPotential: 50,
+        },
+        createdAt: result.createdAt?.toISOString(),
+        createdByWeek: updatedGameState.currentWeek,
+      },
+      updatedGameState: {
+        money: updatedGameState.money,
+        plannedReleases: plannedReleases.map(r => ({
+          id: r.id,
+          title: r.title,
+          artistName: 'Artist Name', // Would need artist lookup
+          type: r.type,
+          scheduledWeek: r.releaseWeek,
+          status: r.status,
+        })),
+        artistsAffected: [{
+          artistId,
+          songsReserved: songIds.length,
+          moodImpact: 5, // Positive mood boost from planned release
+        }],
+      },
+    };
+  }
+
+  /**
+   * Delete a planned release and free up its songs, refunding the STORED
+   * marketing budget (never a client-supplied amount) back to the game's money.
+   *
+   * Returns the exact response payload the original DELETE handler sent (the
+   * route wraps it as res.json(payload)).
+   */
+  async deleteRelease(userId: string | undefined, gameId: string, releaseId: string) {
+    // Get the release to return marketing budget
+    const [release] = await this.db.select().from(releases)
+      .where(and(eq(releases.id, releaseId), eq(releases.gameId, gameId)));
+
+    if (!release) {
+      throw new ReleaseServiceError('RELEASE_NOT_FOUND', 404, {
+        error: 'RELEASE_NOT_FOUND',
+        message: 'Planned release not found',
+      });
+    }
+
+    if (release.status !== 'planned') {
+      throw new ReleaseServiceError('CANNOT_DELETE_RELEASED', 400, {
+        error: 'CANNOT_DELETE_RELEASED',
+        message: 'Cannot delete a release that has already been executed',
+      });
+    }
+
+    // Execute deletion in transaction
+    const result = await this.db.transaction(async (tx) => {
+      // Free up songs reserved for this release
+      const freedSongs = await tx.update(songs)
+        .set({ releaseId: null })
+        .where(eq(songs.releaseId, releaseId))
+        .returning();
+
+      // Return marketing budget to player (from STORED release data, not client)
+      const [gameState] = await tx.select().from(gameStates)
+        .where(eq(gameStates.id, gameId));
+
+      if (gameState) {
+        await tx.update(gameStates)
+          .set({ money: (gameState.money || 0) + (release.marketingBudget || 0) })
+          .where(eq(gameStates.id, gameId));
+      }
+
+      // Delete the planned release
+      await tx.delete(releases).where(eq(releases.id, releaseId));
+
+      return { freedSongs, refundedAmount: release.marketingBudget || 0 };
+    });
+
+    return {
+      success: true,
+      message: `Deleted planned release "${release.title}"`,
+      freedSongs: result.freedSongs.map(s => ({
+        songId: s.id,
+        songTitle: s.title,
+      })),
+      refundedAmount: result.refundedAmount,
+    };
+  }
+}
+
+// Export singleton instance
+export const releasePlanningService = new ReleasePlanningService();

--- a/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
+++ b/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
@@ -262,6 +262,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/artists/:artistId/songs",
   },
@@ -269,6 +270,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/artists/:artistId/songs/ready",
   },
@@ -276,6 +278,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/artists/ready-for-release",
   },
@@ -367,6 +370,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/release-songs",
   },
@@ -374,6 +378,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/releases",
   },
@@ -381,6 +386,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/releases",
   },
@@ -388,6 +394,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "DELETE",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/releases/:releaseId",
   },
@@ -395,6 +402,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/releases/plan",
   },
@@ -402,6 +410,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/releases/preview",
   },
@@ -409,6 +418,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/songs",
   },
@@ -416,6 +426,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/songs/clear-reservations",
   },
@@ -423,6 +434,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/songs/conflicts",
   },

--- a/tests/endpoints/releases.characterization.test.ts
+++ b/tests/endpoints/releases.characterization.test.ts
@@ -1,0 +1,507 @@
+// @vitest-environment node
+/**
+ * Release-planning characterization test (Phase 1, PR-17).
+ *
+ * The two fat mutation routes on the releases router (POST .../releases/plan and
+ * DELETE .../releases/:releaseId) plus the plain create + list reads had no
+ * HTTP-layer coverage. This test pins the observable behavior of the CURRENT
+ * (pre-extraction) handlers BEFORE they are extracted into
+ * releasePlanningService and hardened with ownership/budget validation, so the
+ * extraction can be proven behavior-preserving (green before AND after).
+ *
+ * It drives the real releases router over supertest against the real test
+ * Postgres (Docker, localhost:5433). Clerk auth is mocked to a fixed test user;
+ * server/db is mocked to a non-SSL pool pointed at the test DB (the production
+ * pool forces SSL, which the local test container rejects).
+ *
+ * The blocks tagged "(post-hardening)" below only pass AFTER Commit 2 lands
+ * (requireGameOwner + budget validation + .strict() whitelist). They are kept in
+ * this same file per the PR-17 brief; run them against the hardened code.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+// Must be set before any module that reads DATABASE_URL at import time.
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+// Fixed clerk id / resolved userId for the mocked authenticated user (owner).
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+// A second user, used for cross-tenant assertions.
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+// --- Mock server/db with a non-SSL pool at the test DB. storage.ts imports
+//     `db` from ./db, so this single mock reroutes storage + handlers + service.
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+// --- Mock server/auth so requireClerkUser injects the fixed test userId and
+//     everything else is a passthrough. The injected userId is mutable so
+//     individual tests can impersonate a second user for cross-tenant checks.
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import {
+  gameStates,
+  users,
+  artists,
+  songs,
+  releases,
+  releaseSongs,
+} from '@shared/schema';
+import { eq, and } from 'drizzle-orm';
+import releasesRouter from '../../server/routes/releases';
+
+let app: Express;
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(releasesRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+/** Seed a game owned by ownerId with the given money/creativeCapital/currentWeek,
+ *  one artist, and N recorded-unreleased-unreserved songs. Returns ids. */
+async function seedGameWithSongs(opts: {
+  ownerId: string;
+  money?: number;
+  creativeCapital?: number;
+  currentWeek?: number;
+  songCount?: number;
+}) {
+  const gameId = crypto.randomUUID();
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: opts.ownerId,
+    currentWeek: opts.currentWeek ?? 1,
+    money: opts.money ?? 100000,
+    reputation: 0,
+    creativeCapital: opts.creativeCapital ?? 5,
+  });
+
+  const artistId = crypto.randomUUID();
+  await db.insert(artists).values({
+    id: artistId,
+    gameId,
+    name: 'Test Artist',
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood: 50,
+    energy: 50,
+  });
+
+  const songIds: string[] = [];
+  for (let i = 0; i < (opts.songCount ?? 2); i++) {
+    const songId = crypto.randomUUID();
+    await db.insert(songs).values({
+      id: songId,
+      gameId,
+      artistId,
+      title: `Song ${i + 1}`,
+      quality: 75,
+      genre: 'pop',
+      isRecorded: true,
+      isReleased: false,
+    });
+    songIds.push(songId);
+  }
+
+  return { gameId, artistId, songIds };
+}
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+describe('POST /api/game/:gameId/releases/plan (characterization)', () => {
+  it('happy path: 201, deducts money + creative capital, creates release + release_songs, reserves songs', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      creativeCapital: 5,
+      currentWeek: 1,
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases/plan`)
+      .send({
+        artistId,
+        title: 'My EP',
+        type: 'ep',
+        songIds,
+        scheduledReleaseWeek: 5,
+        marketingBudget: { radio: 3000, digital: 2000 },
+        metadata: { estimatedStreams: 1000, estimatedRevenue: 5000, projectedROI: 1.5 },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.release.title).toBe('My EP');
+    expect(res.body.release.type).toBe('ep');
+    expect(res.body.release.status).toBe('planned');
+    expect(res.body.release.songIds).toEqual(songIds);
+    expect(res.body.release.estimatedMetrics).toEqual({
+      streams: 1000,
+      revenue: 5000,
+      roi: 1.5,
+      chartPotential: 50,
+    });
+
+    // Money deducted by total marketing budget (5000), creative capital by 1.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(95000);
+    expect(gs.creativeCapital).toBe(4);
+    expect(res.body.updatedGameState.money).toBe(95000);
+
+    // Release row exists with total marketing budget and stored breakdown.
+    const [rel] = await db.select().from(releases).where(eq(releases.gameId, gameId));
+    expect(rel.marketingBudget).toBe(5000);
+    expect((rel.metadata as any).marketingBudgetBreakdown).toEqual({ radio: 3000, digital: 2000 });
+
+    // Junction rows created; songs reserved (releaseId set).
+    const junction = await db.select().from(releaseSongs).where(eq(releaseSongs.releaseId, rel.id));
+    expect(junction).toHaveLength(songIds.length);
+    const reserved = await db.select().from(songs).where(eq(songs.releaseId, rel.id));
+    expect(reserved).toHaveLength(songIds.length);
+  });
+
+  it('402 when marketing budget exceeds available money', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({
+      ownerId: TEST_USER_ID,
+      money: 1000,
+      creativeCapital: 5,
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases/plan`)
+      .send({
+        artistId,
+        title: 'Too Expensive',
+        type: 'single',
+        songIds: [songIds[0]],
+        scheduledReleaseWeek: 5,
+        marketingBudget: { radio: 5000 },
+      });
+
+    expect(res.status).toBe(402);
+    expect(res.body.error).toBe('INSUFFICIENT_FUNDS');
+  });
+
+  it('402 when creative capital is below 1', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      creativeCapital: 0,
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases/plan`)
+      .send({
+        artistId,
+        title: 'No Capital',
+        type: 'single',
+        songIds: [songIds[0]],
+        scheduledReleaseWeek: 5,
+        marketingBudget: { radio: 1000 },
+      });
+
+    expect(res.status).toBe(402);
+    expect(res.body.error).toBe('INSUFFICIENT_CREATIVE_CAPITAL');
+  });
+
+  it('409 when a song is already reserved for another release', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      creativeCapital: 5,
+    });
+
+    // Reserve the first song against a pre-existing release.
+    const existingReleaseId = crypto.randomUUID();
+    await db.insert(releases).values({
+      id: existingReleaseId,
+      gameId,
+      artistId,
+      title: 'Existing',
+      type: 'single',
+      status: 'planned',
+    });
+    await db.update(songs).set({ releaseId: existingReleaseId }).where(eq(songs.id, songIds[0]));
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases/plan`)
+      .send({
+        artistId,
+        title: 'Conflict',
+        type: 'single',
+        songIds: [songIds[0]],
+        scheduledReleaseWeek: 5,
+        marketingBudget: { radio: 1000 },
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('SONG_ALREADY_SCHEDULED');
+  });
+
+  it('400 when scheduledReleaseWeek is not in the future', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      creativeCapital: 5,
+      currentWeek: 5,
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases/plan`)
+      .send({
+        artistId,
+        title: 'Past Week',
+        type: 'single',
+        songIds: [songIds[0]],
+        scheduledReleaseWeek: 5, // equal to currentWeek → invalid
+        marketingBudget: { radio: 1000 },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_RELEASE_WEEK');
+  });
+});
+
+describe('DELETE /api/game/:gameId/releases/:releaseId (characterization)', () => {
+  async function seedPlannedRelease(ownerId: string, money = 50000, refund = 5000) {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({
+      ownerId,
+      money,
+      creativeCapital: 5,
+    });
+    const releaseId = crypto.randomUUID();
+    await db.insert(releases).values({
+      id: releaseId,
+      gameId,
+      artistId,
+      title: 'To Delete',
+      type: 'single',
+      status: 'planned',
+      marketingBudget: refund,
+    });
+    await db.update(songs).set({ releaseId }).where(eq(songs.id, songIds[0]));
+    return { gameId, artistId, songIds, releaseId };
+  }
+
+  it('happy path: frees songs, refunds marketing budget, deletes release', async () => {
+    const { gameId, releaseId, songIds } = await seedPlannedRelease(TEST_USER_ID, 50000, 5000);
+
+    const res = await request(app).delete(`/api/game/${gameId}/releases/${releaseId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Deleted planned release "To Delete"');
+    expect(res.body.refundedAmount).toBe(5000);
+    expect(res.body.freedSongs).toEqual([
+      expect.objectContaining({ songId: songIds[0] }),
+    ]);
+
+    // Release gone, song freed, money refunded.
+    const remaining = await db.select().from(releases).where(eq(releases.id, releaseId));
+    expect(remaining).toHaveLength(0);
+    const [song] = await db.select().from(songs).where(eq(songs.id, songIds[0]));
+    expect(song.releaseId).toBeNull();
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(55000);
+  });
+
+  it('404 when the release does not exist', async () => {
+    const { gameId } = await seedGameWithSongs({ ownerId: TEST_USER_ID });
+    const res = await request(app)
+      .delete(`/api/game/${gameId}/releases/${crypto.randomUUID()}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('RELEASE_NOT_FOUND');
+  });
+});
+
+describe('POST /api/game/:gameId/releases (plain create, characterization)', () => {
+  it('happy path: creates a release and links songs', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({ ownerId: TEST_USER_ID });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases`)
+      .send({
+        artistId,
+        title: 'Plain Release',
+        type: 'single',
+        songIds: [songIds[0]],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Plain Release');
+    expect(res.body.gameId).toBe(gameId);
+
+    const junction = await db.select().from(releaseSongs).where(eq(releaseSongs.releaseId, res.body.id));
+    expect(junction).toHaveLength(1);
+  });
+});
+
+describe('GET /api/game/:gameId/releases (characterization)', () => {
+  it('happy path: returns releases for the game', async () => {
+    const { gameId, artistId } = await seedGameWithSongs({ ownerId: TEST_USER_ID });
+    await db.insert(releases).values({
+      gameId,
+      artistId,
+      title: 'Listed Release',
+      type: 'album',
+      status: 'planned',
+    });
+
+    const res = await request(app).get(`/api/game/${gameId}/releases`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.some((r: any) => r.title === 'Listed Release')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-hardening behavior (Commit 2). These assert the NEW ownership + budget
+// validation + whitelist. They only pass against the hardened code.
+// ---------------------------------------------------------------------------
+describe('ownership + validation hardening (post-hardening)', () => {
+  it('plan: 404 GAME_NOT_FOUND when the game belongs to another user', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID; // impersonate non-owner
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases/plan`)
+      .send({
+        artistId,
+        title: 'Cross Tenant',
+        type: 'single',
+        songIds: [songIds[0]],
+        scheduledReleaseWeek: 5,
+        marketingBudget: { radio: 1000 },
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+
+    // No money was touched on the victim's game.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.creativeCapital).toBe(5);
+  });
+
+  it('delete: 404 GAME_NOT_FOUND when the game belongs to another user', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({ ownerId: OTHER_USER_ID });
+    const releaseId = crypto.randomUUID();
+    await db.insert(releases).values({
+      id: releaseId, gameId, artistId, title: 'Victim', type: 'single', status: 'planned', marketingBudget: 5000,
+    });
+    await db.update(songs).set({ releaseId }).where(eq(songs.id, songIds[0]));
+    currentUserId = TEST_USER_ID;
+
+    const res = await request(app).delete(`/api/game/${gameId}/releases/${releaseId}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+
+    // Release still present.
+    const remaining = await db.select().from(releases).where(eq(releases.id, releaseId));
+    expect(remaining).toHaveLength(1);
+  });
+
+  it('create: 404 GAME_NOT_FOUND when the game belongs to another user', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases`)
+      .send({ artistId, title: 'X', type: 'single', songIds: [songIds[0]] });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('reads: 404 GAME_NOT_FOUND on GET releases for another user', async () => {
+    const { gameId } = await seedGameWithSongs({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+
+    const res = await request(app).get(`/api/game/${gameId}/releases`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('plan: 400 INVALID_MARKETING_BUDGET on a negative channel value', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      creativeCapital: 5,
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases/plan`)
+      .send({
+        artistId,
+        title: 'Negative Budget',
+        type: 'single',
+        songIds: [songIds[0]],
+        scheduledReleaseWeek: 5,
+        marketingBudget: { radio: -5000 },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_MARKETING_BUDGET');
+
+    // Money untouched.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(100000);
+    expect(gs.creativeCapital).toBe(5);
+  });
+
+  it('create: rejects unknown / server-computed fields with 400', async () => {
+    const { gameId, artistId, songIds } = await seedGameWithSongs({ ownerId: TEST_USER_ID });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/releases`)
+      .send({
+        artistId,
+        title: 'Hax',
+        type: 'single',
+        songIds: [songIds[0]],
+        revenueGenerated: 999999, // server-computed, must not be client-settable
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_RELEASE_FIELDS');
+  });
+});


### PR DESCRIPTION
## Summary
PR-17 of the Phase 1 plan, extended with the ownership hardening from `docs/98-research/OWNERSHIP_AUTHORIZATION_SWEEP_2026-07-02.md`:
- Extracts `server/services/releasePlanningService.ts` (362 lines): `planRelease` + `deleteRelease`, verbatim moves of the two fat mutation handlers; routes keep all status mapping (releases.ts 908 → 685 lines)
- New shared `server/middleware/requireGameOwner.ts` — the emails.ts ownership pattern promoted to middleware, applied to all 12 `:gameId` routes in releases.ts. Returns 404 (not 403) so game existence isn't leaked to non-owners; stashes the loaded row on `req.gameState`
- **Fixes a live money exploit**: negative marketing-budget channel values (e.g. `{radio: -5000}`) passed the funds check and *credited* the player on deduction. Now rejected 400 `INVALID_MARKETING_BUDGET`, with a regression test
- Field whitelist (`.strict()` zod) on `POST /api/game/:gameId/releases` — server-computed columns no longer client-settable
- Verified `DELETE` refund already used the stored `release.marketingBudget`, not client input (safe side of the C40 pattern)

## Behavior changes (intentional, beyond the pure move)
1. Cross-tenant access to any releases route now 404s (previously readable/mutable by any authenticated user)
2. `release-songs` inline check's 403 became the middleware's 404; plan's no-game body lost its `gameId` echo
3. Plain-create rejects unknown/malformed fields with 400 `INVALID_RELEASE_FIELDS`

## Verification
- Characterization-first: commit 1 pins current behavior (9 tests green pre-extraction); commit 2 adds the hardening + 6 new tests — 15/15, plus route-manifest (12 middleware-only entries changed, no paths) and save-restore integrity: 20/20 across 3 files
- `npm run check` green at both commits

Flagged for follow-up (not in this PR): plan handler's hardcoded `artistName: 'Artist Name'` placeholder, 500 handlers leaking `stack`, artistId/songIds not yet entity-scoped to the owned game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)