### PR TITLE
refactor(artists): extract artistService with server-derived signing costs (PR-18)

### DIFF
--- a/server/routes/artists.ts
+++ b/server/routes/artists.ts
@@ -1,9 +1,13 @@
 import { Router } from 'express';
 import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../db';
 import { storage } from '../storage';
 import { requireClerkUser } from '../auth';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 import { serverGameData } from '../data/gameData';
-import { insertArtistSchema } from '@shared/schema';
+import { artists, gameStates } from '@shared/schema';
+import { artistService, ArtistServiceError } from '../services/artistService';
 import {
   ArtistDialogueRequestSchema,
   ArtistDialogueResponse,
@@ -15,7 +19,7 @@ const router = Router();
 // Artist Dialogue Endpoint
 // ========================================
 
-router.post("/api/game/:gameId/artist-dialogue", requireClerkUser, async (req, res) => {
+router.post("/api/game/:gameId/artist-dialogue", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       // 1. Extract and validate request data
       const { gameId } = req.params;
@@ -34,14 +38,9 @@ router.post("/api/game/:gameId/artist-dialogue", requireClerkUser, async (req, r
       const { artistId, sceneId, choiceId } = validationResult.data;
       console.log(`Processing artist dialogue - Game: ${gameId}, Artist: ${artistId}, Scene: ${sceneId}, Choice: ${choiceId}`);
 
-      // 2. Validate game and artist
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) {
-        return res.status(404).json({
-          success: false,
-          message: "Game not found"
-        });
-      }
+      // 2. Validate game and artist. Game ownership is verified by
+      //    requireGameOwner; gameState is available on req.gameState.
+      const gameState = req.gameState!;
 
       const artist = await storage.getArtist(artistId);
       if (!artist) {
@@ -161,151 +160,68 @@ router.post("/api/game/:gameId/artist-dialogue", requireClerkUser, async (req, r
     }
   });
 
-  // Artist routes
-  router.post("/api/game/:gameId/artists", requireClerkUser, async (req, res) => {
+  // Sign an artist to the roster. Thin route: ownership + validation are the
+  // middleware's job; all economic derivation, guards, atomicity, and flags
+  // bookkeeping live in artistService.signArtist (PR-18). Status mapping stays
+  // here via ArtistServiceError.
+  router.post("/api/game/:gameId/artists", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
-      const signingCost = req.body.signingCost || 0;
-
-      // Get current game state to check money
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) {
-        return res.status(404).json({ message: "Game not found" });
-      }
-
-      // Check if player has enough money
-      if ((gameState.money || 0) < signingCost) {
-        return res.status(400).json({ message: "Insufficient funds to sign artist" });
-      }
-
-      // Prevent duplicate signings by name (case-insensitive) within the same game
-      const existing = await storage.getArtistsByGame(gameId);
-      const incomingName = String(req.body?.name || '').toLowerCase();
-      if (incomingName && existing.some(a => (a.name || '').toLowerCase() === incomingName)) {
-        return res.status(409).json({ code: 'DUPLICATE_ARTIST', message: 'This artist is already signed to your roster.' });
-      }
-
-      // Prepare artist data
-      const validatedData = insertArtistSchema.parse({
-        ...req.body,
-        gameId: gameId,
-        weeklyCost: req.body.weeklyCost || 1200 // Store weekly cost from JSON data
-      });
-
-      // Create artist and deduct money in a transaction-like operation
-      const artist = await storage.createArtist(validatedData);
-
-      // Update game state to deduct signing cost and track artist count
-      if (signingCost > 0) {
-        await storage.updateGameState(gameId, {
-          money: Math.max(0, (gameState.money || 0) - signingCost)
-        });
-      }
-
-      // Update artist count flag for GameEngine weekly costs
-      const currentArtists = await storage.getArtistsByGame(gameId);
-      const flags = (gameState.flags || {}) as any;
-      (flags as any)['signed_artists_count'] = currentArtists.length + 1; // +1 for the new artist
-
-      if (signingCost > 0) {
-        const signingEvent = {
-          artistId: artist.id,
-          name: artist.name,
-          amount: signingCost,
-          week: gameState.currentWeek || 1,
-          recordedAt: new Date().toISOString(),
-        };
-
-        if (!Array.isArray(flags.pending_signing_fees)) {
-          flags.pending_signing_fees = [];
-        }
-        flags.pending_signing_fees.push(signingEvent);
-      }
-
-      // Remove this artist from discovered collections using discovered (content) ID or name
-      if (flags.ar_office_discovered_artists) {
-        const discoveredId = req.body?.id;
-        const signedNameLc = String(artist.name || '').toLowerCase();
-        flags.ar_office_discovered_artists = flags.ar_office_discovered_artists.filter((a: any) => {
-          const aNameLc = String(a?.name || '').toLowerCase();
-          return (discoveredId ? a.id !== discoveredId : true) && aNameLc !== signedNameLc;
-        });
-        console.log('[A&R DEBUG] Removed signed artist from discovered collection. Remaining:', flags.ar_office_discovered_artists.length);
-      }
-
-      // Legacy cleanup: If this artist is the persisted discovered one, clear it now
-      if ((flags as any).ar_office_discovered_artist_id) {
-        const discoveredId = req.body?.id;
-        if ((flags as any).ar_office_discovered_artist_id === discoveredId) {
-          delete flags.ar_office_discovered_artist_id;
-          delete flags.ar_office_discovered_artist_info;
-        }
-      }
-
-      await storage.updateGameState(gameId, { flags });
-
-      // Generate welcome email for signed artist
-      try {
-        const labelDisplay = ((gameState as any).labelName) || ((gameState as any).musicLabel?.name) || 'your label';
-        const emailBody = {
-          artistId: artist.id,
-          name: artist.name,
-          archetype: artist.archetype ?? 'Unknown',
-          talent: artist.talent ?? 0,
-          genre: artist.genre ?? null,
-          signingCost: signingCost,
-          weeklyCost: artist.weeklyCost ?? null,
-        };
-
-        await storage.createEmail({
-          gameId: gameId,
-          week: gameState.currentWeek ?? 1,
-          category: 'ar',
-          sender: 'Marcus "Mac" Rodriguez',
-          senderRoleId: 'head_ar',
-          subject: `Artist Signed – ${artist.name}`,
-          preview: `${artist.name} has officially signed with ${labelDisplay}!`,
-          body: emailBody,
-          metadata: emailBody,
-          isRead: false,
-        });
-        console.log(`[ARTIST SIGNING] Generated welcome email for ${artist.name}`);
-      } catch (emailError) {
-        console.error('[ARTIST SIGNING] Failed to generate welcome email:', emailError);
-        // Don't fail the signing if email generation fails
-      }
-
+      const artist = await artistService.signArtist(req.userId, gameId, req.gameState!, req.body);
       res.json(artist);
     } catch (error) {
-      if (error instanceof z.ZodError) {
-        res.status(400).json({ message: "Invalid artist data", errors: error.errors });
-      } else {
-        console.error('Artist signing error:', error);
-        res.status(500).json({ message: "Failed to sign artist" });
+      if (error instanceof ArtistServiceError) {
+        return res.status(error.status).json(error.body);
       }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: "Invalid artist data", errors: error.errors });
+      }
+      console.error('Artist signing error:', error);
+      res.status(500).json({ message: "Failed to sign artist" });
     }
   });
 
   router.patch("/api/artists/:id", requireClerkUser, async (req, res) => {
     try {
-      const artist = await storage.updateArtist(req.params.id, req.body);
-      res.json(artist);
+      const userId = req.userId;
+      if (!userId) {
+        return res.status(401).json({ error: 'UNAUTHORIZED', message: 'User authentication required' });
+      }
+
+      // Entity-walk ownership check (mirrors PATCH /api/songs/:songId in
+      // releases.ts): artist → gameId → game.userId; 404 if not owned so we
+      // don't leak existence to a non-owner.
+      const [artist] = await db.select({ id: artists.id, gameId: artists.gameId })
+        .from(artists)
+        .where(eq(artists.id, req.params.id))
+        .limit(1);
+
+      if (!artist) {
+        return res.status(404).json({ error: 'ARTIST_NOT_FOUND', message: 'Artist not found' });
+      }
+
+      const [game] = await db.select()
+        .from(gameStates)
+        .where(and(eq(gameStates.id, artist.gameId), eq(gameStates.userId, userId)))
+        .limit(1);
+
+      if (!game) {
+        return res.status(404).json({ error: 'ARTIST_NOT_FOUND', message: 'Artist not found' });
+      }
+
+      // TODO(phase-2): whitelist mutable artist fields — raw body pass-through is mass-assignment
+      const updated = await storage.updateArtist(req.params.id, req.body);
+      res.json(updated);
     } catch (error) {
       res.status(500).json({ message: "Failed to update artist" });
     }
   });
 
-  router.get("/api/game/:gameId/mood-events", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/mood-events", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState || gameState.userId !== req.userId) {
-        return res.status(403).json({
-          error: 'UNAUTHORIZED',
-          message: 'You do not have permission to access this game'
-        });
-      }
-
+      // Ownership verified by requireGameOwner (its 404 replaces the previous
+      // inline 403 UNAUTHORIZED check).
       const events = await storage.getMoodEventsByGame(gameId);
       res.json(events);
     } catch (error) {

--- a/server/services/artistService.ts
+++ b/server/services/artistService.ts
@@ -1,0 +1,240 @@
+/**
+ * artistService.ts
+ *
+ * Backend service for signing an artist to the roster. Extracted from the fat
+ * sign handler in server/routes/artists.ts (Phase 1, PR-18):
+ *   - POST /api/game/:gameId/artists  (was routes/artists.ts:165-287)
+ *
+ * Follows the class+singleton convention of gameCreationService.ts /
+ * releasePlanningService.ts. The service throws coded ArtistServiceError
+ * instances; the route layer keeps ALL HTTP status mapping (each error carries
+ * the exact JSON body the route must send).
+ *
+ * HARDENING (PR-18), addressing findings B1/B2/B5/B6 in
+ * AR_OFFICE_DISCOVERY_SIGNING_CODE_REVIEW_2026-07-02.md:
+ *   B1 — Signing cost and stats are now DERIVED SERVER-SIDE from
+ *        data/artists.json keyed by the discovered record's content id, with
+ *        the discovered record's own stats as fallback. Client-supplied
+ *        signingCost / talent / popularity / weeklyCost / archetype / genre are
+ *        IGNORED. Only presentation fields the client legitimately owns
+ *        (signedWeek, signed) plus the name (for confirmation) pass through.
+ *        Also: the artist MUST be present in flags.ar_office_discovered_artists
+ *        (ARTIST_NOT_DISCOVERED otherwise) — you can no longer fabricate one.
+ *   B2 — createArtist + money deduction + flags update now run in ONE db
+ *        transaction, recomputing flags from a FRESH read inside the tx so a
+ *        concurrent flags write is not lost.
+ *   B5 — The 3-artist roster cap is now enforced server-side (ROSTER_FULL).
+ *   B6 — The dead, off-by-one `signed_artists_count` flag write is DELETED.
+ */
+import { eq } from 'drizzle-orm';
+import { db as dbSingleton } from '../db';
+import { storage } from '../storage';
+import { serverGameData } from '../data/gameData';
+import { artists, gameStates, emails, type GameState } from '@shared/schema';
+
+// HARDCODED: roster cap should live in balance config
+const ROSTER_CAP = 3;
+
+/**
+ * A coded error whose `body` is the EXACT JSON payload the route returns for
+ * this failure mode, and whose `status` is the HTTP status the route sends.
+ * The route layer maps: res.status(err.status).json(err.body).
+ */
+export class ArtistServiceError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    public readonly body: Record<string, unknown>,
+  ) {
+    super(code);
+    this.name = 'ArtistServiceError';
+  }
+}
+
+export class ArtistService {
+  constructor(private db = dbSingleton) {}
+
+  /**
+   * Sign an artist to the roster: resolve the discovered-pool record, derive
+   * cost/stats server-side, enforce funds + roster cap + duplicate-name guards,
+   * then in a single transaction create the artist, deduct the derived cost, and
+   * update the discovered/pending-fee flags. Generates the welcome email
+   * (non-fatally) after the transaction commits.
+   *
+   * `gameState` is the owner-verified game row (from requireGameOwner). Returns
+   * the created artist row (the route wraps it as res.json(artist)).
+   */
+  async signArtist(userId: string | undefined, gameId: string, gameState: GameState, body: any) {
+    const flags = (gameState.flags || {}) as Record<string, any>;
+    const discoveredPool: any[] = Array.isArray(flags.ar_office_discovered_artists)
+      ? flags.ar_office_discovered_artists
+      : [];
+
+    // 1. Resolve the discovered record: match by content id first, then by
+    //    name (case-insensitive) as a fallback (identity is fragile — the pool
+    //    carries both id and name).
+    const requestedId = body?.id;
+    const requestedNameLc = String(body?.name || '').toLowerCase();
+    const discovered =
+      (requestedId && discoveredPool.find((a) => a?.id === requestedId)) ||
+      (requestedNameLc && discoveredPool.find((a) => String(a?.name || '').toLowerCase() === requestedNameLc)) ||
+      null;
+
+    if (!discovered) {
+      throw new ArtistServiceError('ARTIST_NOT_DISCOVERED', 400, {
+        error: 'ARTIST_NOT_DISCOVERED',
+        message: 'Artist is not in your discovered pool',
+      });
+    }
+
+    // 2. Derive cost + stats server-side. data/artists.json is authoritative;
+    //    fall back to the discovered record's own stats for fields JSON lacks.
+    //    Client-supplied signingCost/talent/popularity/weeklyCost/archetype/
+    //    genre are IGNORED (B1).
+    const jsonArtists = await serverGameData.getAllArtists();
+    const jsonRecord: any = jsonArtists.find((a: any) => a.id === discovered.id) || {};
+
+    const signingCost = Number(jsonRecord.signingCost ?? discovered.signingCost ?? 0);
+    const weeklyCost = Number(jsonRecord.weeklyCost ?? discovered.weeklyCost ?? 1200);
+    const talent = Number(jsonRecord.talent ?? discovered.talent ?? 50);
+    const popularity = Number(jsonRecord.popularity ?? discovered.popularity ?? 0);
+    const archetype = String(jsonRecord.archetype ?? discovered.archetype ?? 'Unknown');
+    const genre = jsonRecord.genre ?? discovered.genre ?? null;
+    const name = String(discovered.name ?? jsonRecord.name ?? body?.name ?? 'Unknown');
+
+    // 3. Roster cap (B5). HARDCODED: 3 — see ROSTER_CAP above.
+    const existing = await storage.getArtistsByGame(gameId);
+    if (existing.length >= ROSTER_CAP) {
+      throw new ArtistServiceError('ROSTER_FULL', 409, {
+        error: 'ROSTER_FULL',
+        message: 'Roster is full (3 artists max)',
+      });
+    }
+
+    // 4. Duplicate-name guard (case-insensitive), preserved from the original.
+    const nameLc = name.toLowerCase();
+    if (nameLc && existing.some((a) => (a.name || '').toLowerCase() === nameLc)) {
+      throw new ArtistServiceError('DUPLICATE_ARTIST', 409, {
+        code: 'DUPLICATE_ARTIST',
+        message: 'This artist is already signed to your roster.',
+      });
+    }
+
+    // 5. Funds check against the DERIVED cost (preserving original status/body).
+    if ((gameState.money || 0) < signingCost) {
+      throw new ArtistServiceError('INSUFFICIENT_FUNDS', 400, {
+        message: 'Insufficient funds to sign artist',
+      });
+    }
+
+    // 6. Atomic: create artist + deduct money + update flags in one tx (B2).
+    //    Flags are recomputed from a FRESH read inside the tx so a concurrent
+    //    write is not clobbered by the stale snapshot.
+    const artist = await this.db.transaction(async (tx) => {
+      const [created] = await tx
+        .insert(artists)
+        .values({
+          gameId,
+          // Presentation fields the client legitimately owns.
+          name,
+          signedWeek: body?.signedWeek ?? gameState.currentWeek ?? 1,
+          signed: body?.signed ?? true,
+          // Server-derived economic + stat fields.
+          signingCost,
+          weeklyCost,
+          talent,
+          popularity,
+          archetype,
+          genre,
+        })
+        .returning();
+
+      // Deduct the derived cost.
+      if (signingCost > 0) {
+        await tx
+          .update(gameStates)
+          .set({ money: Math.max(0, (gameState.money || 0) - signingCost) })
+          .where(eq(gameStates.id, gameId));
+      }
+
+      // Recompute flags from a fresh read INSIDE the transaction.
+      const [freshGame] = await tx.select().from(gameStates).where(eq(gameStates.id, gameId));
+      const freshFlags = (freshGame?.flags || {}) as Record<string, any>;
+
+      // B6: the dead, off-by-one `signed_artists_count` write is intentionally
+      // NOT re-added here — it was never read anywhere.
+
+      // Append the pending signing fee (only when there is a cost).
+      if (signingCost > 0) {
+        if (!Array.isArray(freshFlags.pending_signing_fees)) {
+          freshFlags.pending_signing_fees = [];
+        }
+        freshFlags.pending_signing_fees.push({
+          artistId: created.id,
+          name: created.name,
+          amount: signingCost,
+          week: gameState.currentWeek || 1,
+          recordedAt: new Date().toISOString(),
+        });
+      }
+
+      // Remove this artist from the discovered collection by content id / name.
+      if (Array.isArray(freshFlags.ar_office_discovered_artists)) {
+        const signedNameLc = String(created.name || '').toLowerCase();
+        freshFlags.ar_office_discovered_artists = freshFlags.ar_office_discovered_artists.filter((a: any) => {
+          const aNameLc = String(a?.name || '').toLowerCase();
+          return (discovered.id ? a.id !== discovered.id : true) && aNameLc !== signedNameLc;
+        });
+      }
+
+      // Legacy cleanup: clear the persisted singular discovered fields when they
+      // point at this artist.
+      if (freshFlags.ar_office_discovered_artist_id && freshFlags.ar_office_discovered_artist_id === discovered.id) {
+        delete freshFlags.ar_office_discovered_artist_id;
+        delete freshFlags.ar_office_discovered_artist_info;
+      }
+
+      await tx.update(gameStates).set({ flags: freshFlags as any }).where(eq(gameStates.id, gameId));
+
+      return created;
+    });
+
+    // 7. Welcome email (non-fatal, preserved behavior). Uses the label name off
+    //    the game state; failures are logged but do not fail the signing.
+    try {
+      const labelDisplay =
+        (gameState as any).labelName || (gameState as any).musicLabel?.name || 'your label';
+      const emailBody = {
+        artistId: artist.id,
+        name: artist.name,
+        archetype: artist.archetype ?? 'Unknown',
+        talent: artist.talent ?? 0,
+        genre: artist.genre ?? null,
+        signingCost,
+        weeklyCost: artist.weeklyCost ?? null,
+      };
+
+      await storage.createEmail({
+        gameId,
+        week: gameState.currentWeek ?? 1,
+        category: 'ar',
+        sender: 'Marcus "Mac" Rodriguez',
+        senderRoleId: 'head_ar',
+        subject: `Artist Signed – ${artist.name}`,
+        preview: `${artist.name} has officially signed with ${labelDisplay}!`,
+        body: emailBody,
+        metadata: emailBody,
+        isRead: false,
+      });
+      console.log(`[ARTIST SIGNING] Generated welcome email for ${artist.name}`);
+    } catch (emailError) {
+      console.error('[ARTIST SIGNING] Failed to generate welcome email:', emailError);
+      // Don't fail the signing if email generation fails.
+    }
+
+    return artist;
+  }
+}
+
+// Export singleton instance
+export const artistService = new ArtistService();

--- a/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
+++ b/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
@@ -248,6 +248,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/artist-dialogue",
   },
@@ -255,6 +256,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/artists",
   },
@@ -356,6 +358,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/mood-events",
   },

--- a/tests/endpoints/artist-signing.characterization.test.ts
+++ b/tests/endpoints/artist-signing.characterization.test.ts
@@ -1,0 +1,448 @@
+// @vitest-environment node
+/**
+ * Artist-signing characterization test (Phase 1, PR-18).
+ *
+ * The sign-artist route (POST /api/game/:gameId/artists) plus artist-dialogue
+ * and mood-events had no HTTP-layer coverage. This file pins the observable
+ * behavior of the CURRENT (pre-extraction) handlers BEFORE they are extracted
+ * into artistService and hardened (server-derived costs, requireGameOwner,
+ * roster cap, atomic transaction), so the extraction can be proven
+ * behavior-preserving where intended and the deliberate flips are explicit.
+ *
+ * It drives the real artists router over supertest against the real test
+ * Postgres (Docker, localhost:5433). Clerk auth is mocked to a fixed test user;
+ * server/db is mocked to a non-SSL pool pointed at the test DB (the production
+ * pool forces SSL, which the local test container rejects).
+ *
+ * The blocks tagged "(post-hardening)" only pass AFTER Commit 2 lands. They are
+ * kept in this same file per the PR-17/18 pattern; run them against hardened code.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+// Must be set before any module that reads DATABASE_URL at import time.
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+// Fixed clerk id / resolved userId for the mocked authenticated user (owner).
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+// A second user, used for cross-tenant assertions.
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+// --- Mock server/db with a non-SSL pool at the test DB. storage.ts imports
+//     `db` from ./db, so this single mock reroutes storage + handlers + service.
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+// --- Mock server/auth so requireClerkUser injects the fixed test userId and
+//     everything else is a passthrough. The injected userId is mutable so
+//     individual tests can impersonate a second user for cross-tenant checks.
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import {
+  gameStates,
+  users,
+  artists,
+  emails,
+  moodEvents,
+} from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import artistsRouter from '../../server/routes/artists';
+
+let app: Express;
+
+// A known JSON artist (data/artists.json → art_1 Nova Sterling).
+const KNOWN_ARTIST = {
+  id: 'art_1',
+  name: 'Nova Sterling',
+  archetype: 'Visionary',
+  talent: 85,
+  popularity: 10,
+  genre: 'Pop',
+  signingCost: 8000,
+  weeklyCost: 1200,
+};
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(artistsRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+/** Seed a game owned by ownerId, optionally pre-populating the discovered pool
+ *  with the given discovered records. Returns the gameId. */
+async function seedGame(opts: {
+  ownerId: string;
+  money?: number;
+  currentWeek?: number;
+  discovered?: any[];
+  extraFlags?: Record<string, any>;
+}) {
+  const gameId = crypto.randomUUID();
+  const flags: Record<string, any> = { ...(opts.extraFlags ?? {}) };
+  if (opts.discovered) flags.ar_office_discovered_artists = opts.discovered;
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: opts.ownerId,
+    currentWeek: opts.currentWeek ?? 1,
+    money: opts.money ?? 100000,
+    reputation: 0,
+    creativeCapital: 5,
+    flags,
+  });
+  return gameId;
+}
+
+/** Insert a signed artist row directly (for roster-cap / dup-name seeding). */
+async function seedSignedArtist(gameId: string, name: string) {
+  const artistId = crypto.randomUUID();
+  await db.insert(artists).values({
+    id: artistId,
+    gameId,
+    name,
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood: 50,
+    energy: 50,
+  });
+  return artistId;
+}
+
+/** The real payload gameStore.signArtist posts: the whole discovered artist
+ *  record spread, plus signedWeek/signed. */
+function clientSignPayload(discovered: any, overrides: Record<string, any> = {}) {
+  return {
+    ...discovered,
+    signedWeek: 1,
+    signed: true,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+// ===========================================================================
+// CURRENT behavior (pins). Some pins are intentionally flipped by Commit 2;
+// where flipped, the pre-hardening expectation is called out in a comment.
+// ===========================================================================
+describe('POST /api/game/:gameId/artists — sign (characterization)', () => {
+  it('happy path: creates artist, deducts signingCost, removes from discovered, appends pending_signing_fees', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      discovered: [KNOWN_ARTIST],
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { signingCost: 8000 }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Nova Sterling');
+    expect(res.body.gameId).toBe(gameId);
+    expect(res.body.id).toBeTruthy();
+
+    // Artist row created.
+    const roster = await db.select().from(artists).where(eq(artists.gameId, gameId));
+    expect(roster).toHaveLength(1);
+    expect(roster[0].name).toBe('Nova Sterling');
+
+    // Money deducted by the derived cost (8000). Pre-hardening this equalled
+    // the client-sent signingCost; post-hardening it is server-derived — for
+    // this artist both are 8000, so the assertion holds across the flip.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(92000);
+
+    // Removed from discovered pool.
+    const flags = gs.flags as any;
+    expect(flags.ar_office_discovered_artists).toEqual([]);
+
+    // pending_signing_fees appended.
+    expect(Array.isArray(flags.pending_signing_fees)).toBe(true);
+    expect(flags.pending_signing_fees).toHaveLength(1);
+    expect(flags.pending_signing_fees[0]).toMatchObject({
+      name: 'Nova Sterling',
+      amount: 8000,
+      week: 1,
+    });
+
+    // Welcome email row created.
+    const emailRows = await db.select().from(emails).where(eq(emails.gameId, gameId));
+    expect(emailRows).toHaveLength(1);
+    expect(emailRows[0].category).toBe('ar');
+    expect(emailRows[0].subject).toContain('Nova Sterling');
+  });
+
+  it('409 DUPLICATE_ARTIST on case-insensitive duplicate name', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      discovered: [KNOWN_ARTIST],
+    });
+    await seedSignedArtist(gameId, 'nova sterling'); // lower-case existing
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { signingCost: 8000 }));
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('DUPLICATE_ARTIST');
+  });
+
+  it('400 insufficient funds when money < derived cost', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 1000, // less than 8000 derived cost
+      discovered: [KNOWN_ARTIST],
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { signingCost: 8000 }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/insufficient funds/i);
+
+    // No artist created.
+    const roster = await db.select().from(artists).where(eq(artists.gameId, gameId));
+    expect(roster).toHaveLength(0);
+  });
+});
+
+describe('GET /api/game/:gameId/mood-events (characterization)', () => {
+  it('happy path: returns mood events for the owned game', async () => {
+    const gameId = await seedGame({ ownerId: TEST_USER_ID });
+    const artistId = await seedSignedArtist(gameId, 'Moody Artist');
+    await db.insert(moodEvents).values({
+      gameId,
+      artistId,
+      eventType: 'release_success',
+      moodChange: 5,
+      moodBefore: 50,
+      moodAfter: 55,
+      description: 'A hit release',
+      weekOccurred: 1,
+    });
+
+    const res = await request(app).get(`/api/game/${gameId}/mood-events`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].eventType).toBe('release_success');
+  });
+
+  it('rejects access to a game owned by another user', async () => {
+    // Pre-hardening: inline check returns 403 UNAUTHORIZED.
+    // Post-hardening: requireGameOwner returns 404 GAME_NOT_FOUND.
+    const gameId = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID; // impersonate non-owner
+
+    const res = await request(app).get(`/api/game/${gameId}/mood-events`);
+    expect([403, 404]).toContain(res.status);
+  });
+});
+
+describe('POST /api/game/:gameId/artist-dialogue (characterization)', () => {
+  it('404 when the artist is unknown', async () => {
+    const gameId = await seedGame({ ownerId: TEST_USER_ID });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artist-dialogue`)
+      .send({
+        artistId: crypto.randomUUID(),
+        sceneId: 'some_scene',
+        choiceId: 'some_choice',
+      });
+
+    // Unknown artist → 404 Artist not found (validated before dialogue lookup).
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-hardening behavior (Commit 2). These assert the NEW ownership +
+// server-derived-cost + roster-cap + discovered-pool validation. They only
+// pass against the hardened code.
+// ---------------------------------------------------------------------------
+describe('sign hardening (post-hardening)', () => {
+  it('404 GAME_NOT_FOUND when signing into a game owned by another user', async () => {
+    const gameId = await seedGame({
+      ownerId: OTHER_USER_ID,
+      money: 100000,
+      discovered: [KNOWN_ARTIST],
+    });
+    currentUserId = TEST_USER_ID; // impersonate non-owner
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { signingCost: 8000 }));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+
+    // Victim untouched.
+    const roster = await db.select().from(artists).where(eq(artists.gameId, gameId));
+    expect(roster).toHaveLength(0);
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(100000);
+  });
+
+  it('ignores a client-sent (too-low) signingCost and deducts the derived cost', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      discovered: [KNOWN_ARTIST],
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { signingCost: 0 })); // attacker: free signing
+
+    expect(res.status).toBe(200);
+
+    // Derived cost (8000 from data/artists.json) deducted, NOT the client's 0.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(92000);
+    const flags = gs.flags as any;
+    expect(flags.pending_signing_fees[0].amount).toBe(8000);
+  });
+
+  it('$0/free signing is no longer possible via omitted cost — derived cost applies', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      discovered: [KNOWN_ARTIST],
+    });
+
+    const payload = clientSignPayload(KNOWN_ARTIST);
+    delete (payload as any).signingCost; // omit entirely
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(92000); // 8000 derived cost still charged
+  });
+
+  it('ignores client-sent talent/popularity and derives them server-side', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      discovered: [KNOWN_ARTIST],
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { talent: 100, popularity: 100, weeklyCost: 1 }));
+
+    expect(res.status).toBe(200);
+    const [row] = await db.select().from(artists).where(eq(artists.gameId, gameId));
+    // Derived from data/artists.json (talent 85, popularity 10, weeklyCost 1200).
+    expect(row.talent).toBe(85);
+    expect(row.popularity).toBe(10);
+    expect(row.weeklyCost).toBe(1200);
+  });
+
+  it('409 ROSTER_FULL when the roster already has 3 artists', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      discovered: [KNOWN_ARTIST],
+    });
+    await seedSignedArtist(gameId, 'A One');
+    await seedSignedArtist(gameId, 'A Two');
+    await seedSignedArtist(gameId, 'A Three');
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { signingCost: 8000 }));
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('ROSTER_FULL');
+
+    // No 4th artist, money untouched.
+    const roster = await db.select().from(artists).where(eq(artists.gameId, gameId));
+    expect(roster).toHaveLength(3);
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(100000);
+  });
+
+  it('400 ARTIST_NOT_DISCOVERED when the artist is not in the discovered pool', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      money: 100000,
+      discovered: [], // empty pool
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artists`)
+      .send(clientSignPayload(KNOWN_ARTIST, { signingCost: 8000 }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('ARTIST_NOT_DISCOVERED');
+
+    const roster = await db.select().from(artists).where(eq(artists.gameId, gameId));
+    expect(roster).toHaveLength(0);
+  });
+
+  it('dialogue: 404 GAME_NOT_FOUND when the game belongs to another user', async () => {
+    const gameId = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/artist-dialogue`)
+      .send({ artistId: crypto.randomUUID(), sceneId: 's', choiceId: 'c' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('mood-events: 404 GAME_NOT_FOUND when the game belongs to another user', async () => {
+    const gameId = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+
+    const res = await request(app).get(`/api/game/${gameId}/mood-events`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+});


### PR DESCRIPTION
## Summary
PR-18, the final Phase 1 service extraction — stacked on #63 (will be retargeted to main once #63 merges). Extracts `server/services/artistService.ts` (240 lines; artists.ts 317 → 233) and closes the sign-artist findings from `docs/98-research/AR_OFFICE_DISCOVERY_SIGNING_CODE_REVIEW_2026-07-02.md`:

- **B1 — client-trusted signing killed.** The artist must exist in `flags.ar_office_discovered_artists` (400 `ARTIST_NOT_DISCOVERED` otherwise); `signingCost`/`weeklyCost`/`talent`/`popularity`/`archetype`/`genre` are derived server-side from `data/artists.json` keyed by the discovered record's content id. Client-sent values for those fields are ignored — free/$0 signing and fabricated max-stat artists are no longer possible.
- **B2 — atomic signing.** createArtist + money deduction + flags update run in one `db.transaction`, with flags recomputed from a fresh read inside the tx (fixes the concurrent-flags-clobber).
- **B5 — roster cap server-enforced**: 409 `ROSTER_FULL` at 3 artists (`// HARDCODED` flagged for balance config).
- **B6 — dead `signed_artists_count` write deleted** (off-by-one, never read anywhere).
- `requireGameOwner` (from #63) applied to sign, artist-dialogue, and mood-events; `PATCH /api/artists/:id` gets the minimal entity-walk ownership check (artist→game→user, 404) with the mass-assignment whitelist left as a flagged phase-2 TODO.

## Verification
- Characterization-first: commit 1 pins current behavior green (6 tests, including a pin documenting the free-signing bug); commit 2 flips exactly two pins (free-signing → derived-cost, mood-events cross-tenant 403 → 404) and adds 8 hardening tests
- Final gate: artist-signing (14) + releases characterization (15) + route-manifest (3) + artist-mood-constraints (4) = 36/36; `npm run check` clean at both commits
- Route-manifest: exactly 3 middleware-only insertions, no path changes
- Welcome email, `pending_signing_fees`, duplicate-name guard, legacy singular-key cleanup preserved verbatim (email now sends after tx commit, still non-fatal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)