### PR TITLE
fix(projects): server-side cost recompute, field whitelist, ownership, atomic create (B1-B4)

### DIFF
--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -1,12 +1,56 @@
 import { Router } from 'express';
 import { z } from 'zod';
+import { eq } from 'drizzle-orm';
 import { storage } from '../storage';
+import { db } from '../db';
 import { requireClerkUser } from '../auth';
 import { serverGameData } from '../data/gameData';
-import { insertProjectSchema } from '@shared/schema';
+import { gameStates, projects as projectsTable } from '@shared/schema';
 import { FinancialSystem } from '@shared/engine/FinancialSystem';
 
 const router = Router();
+
+// B3: strict whitelist of the fields an honest client is allowed to supply on
+// project creation. Unknown keys (quality, songsCreated, budget, ...) are
+// REJECTED (.strict) to close mass-assignment. stage/startWeek/totalCost are
+// tolerated because the live client (gameStore.createProject) still sends
+// stage:'planning' + startWeek, but the server IGNORES them and sets its own
+// authoritative values — a client-sent stage:'production' cannot skip planning.
+const createProjectInputSchema = z
+  .object({
+    title: z.string().min(1),
+    type: z.enum(['Single', 'EP', 'Mini-Tour']),
+    artistId: z.string().uuid().optional(),
+    budgetPerSong: z.number().int().nonnegative().optional(),
+    totalCost: z.number().int().nonnegative().optional(),
+    songCount: z.number().int().positive().optional(),
+    producerTier: z.enum(['local', 'regional', 'national', 'legendary']).optional(),
+    timeInvestment: z.enum(['rushed', 'standard', 'extended', 'perfectionist']).optional(),
+    metadata: z.any().optional(),
+    // Tolerated-but-ignored (live client sends these; server overrides them).
+    stage: z.any().optional(),
+    startWeek: z.any().optional(),
+  })
+  .strict();
+
+// B3/B1: strict whitelist for PATCH. Only stage progression is a legitimate
+// client-driven update on an existing project; everything cost/quality-bearing
+// is engine-owned. Unknown keys are rejected (.strict) to close mass-assignment.
+const patchProjectInputSchema = z
+  .object({
+    stage: z.enum(['planning', 'production', 'recorded', 'cancelled']).optional(),
+    title: z.string().min(1).optional(),
+  })
+  .strict();
+
+// Legit song-count bounds per recording type (design contract; economy.json only
+// carries song_count_default). Keeps a huge songCount from gaming the per-song
+// minimum (minPerSong = min / songCount).
+// HARDCODED: mirror data/balance design (Single 1-3, EP 3-5); move to config later.
+const SONG_COUNT_BOUNDS: Record<string, { min: number; max: number }> = {
+  Single: { min: 1, max: 3 },
+  EP: { min: 3, max: 5 },
+};
 
 // Calculate budget info for project creation
 router.post("/api/budget-calculation", requireClerkUser, async (req, res) => {
@@ -72,93 +116,152 @@ router.post("/api/budget-calculation", requireClerkUser, async (req, res) => {
   // Project routes
   router.post("/api/game/:gameId/projects", requireClerkUser, async (req, res) => {
     try {
+      // B3: whitelist client-supplied fields; strip unknown/server-owned keys.
+      const input = createProjectInputSchema.parse(req.body);
+      const gameId = req.params.gameId;
+
       console.log('[PROJECT CREATION] Raw request body received:', JSON.stringify({
-        title: req.body.title,
-        type: req.body.type,
-        budgetPerSong: req.body.budgetPerSong,
-        totalCost: req.body.totalCost,
-        songCount: req.body.songCount,
-        producerTier: req.body.producerTier,
-        timeInvestment: req.body.timeInvestment,
-        artistId: req.body.artistId
+        title: input.title,
+        type: input.type,
+        budgetPerSong: input.budgetPerSong,
+        totalCost: input.totalCost,
+        songCount: input.songCount,
+        producerTier: input.producerTier,
+        timeInvestment: input.timeInvestment,
+        artistId: input.artistId
       }, null, 2));
 
-      const validatedData = insertProjectSchema.parse({
-        ...req.body,
-        gameId: req.params.gameId
-      });
+      // B1: verify the game exists AND belongs to the caller. game-scoped query
+      // (emails.ts pattern) — 404 GAME_NOT_FOUND so we don't leak existence.
+      const [gameState] = await db
+        .select()
+        .from(gameStates)
+        .where(eq(gameStates.id, gameId));
+      if (!gameState || gameState.userId !== req.userId) {
+        return res.status(404).json({
+          error: 'GAME_NOT_FOUND',
+          message: 'Game not found or does not belong to this user'
+        });
+      }
 
-      // Additional budget validation based on economy.json
+      // Entity-scoping: the artist (if provided) must belong to THIS game.
+      if (input.artistId) {
+        const artist = await storage.getArtist(input.artistId);
+        if (!artist || artist.gameId !== gameId) {
+          return res.status(400).json({
+            error: 'ARTIST_NOT_IN_GAME',
+            message: 'Artist does not belong to this game'
+          });
+        }
+      }
+
+      // Budget validation based on economy.json project_costs.
       const projectTypes = await serverGameData.getProjectTypes();
-      const projectTypeKey = validatedData.type === 'Single' ? 'single' :
-                            validatedData.type === 'EP' ? 'ep' : 'mini_tour';
+      const projectTypeKey = input.type === 'Single' ? 'single' :
+                            input.type === 'EP' ? 'ep' : 'mini_tour';
       const projectTypeConfig = projectTypes[projectTypeKey];
 
-      // Debug log to verify the configuration
-      console.log(`[PROJECT CREATION] Project type config for ${validatedData.type}:`, projectTypeConfig);
+      console.log(`[PROJECT CREATION] Project type config for ${input.type}:`, projectTypeConfig);
 
-      if (projectTypeConfig && validatedData.type !== 'Mini-Tour') {
-        // For recording projects, validate budget per song
-        const budgetPerSong = validatedData.budgetPerSong || 0;
-        const songCount = validatedData.songCount || projectTypeConfig.song_count_default || 1;
+      const isRecording = input.type === 'Single' || input.type === 'EP';
+
+      // Server-computed cost. For recording projects (B2) we IGNORE client
+      // totalCost and recompute from budgetPerSong. Tours keep their existing
+      // client-totalCost path verbatim (a separate creation flow / backlog C40).
+      let projectCost: number;
+      let songCount = input.songCount ?? projectTypeConfig?.song_count_default ?? 1;
+
+      if (isRecording && projectTypeConfig) {
+        // B3: bound songCount to the type's legit range so a huge count can't
+        // depress the per-song minimum below.
+        const bounds = SONG_COUNT_BOUNDS[input.type];
+        if (bounds && (songCount < bounds.min || songCount > bounds.max)) {
+          return res.status(400).json({
+            error: 'INVALID_SONG_COUNT',
+            message: `${input.type} projects must have between ${bounds.min} and ${bounds.max} songs`
+          });
+        }
+
+        // Per-song budget bounds (unchanged from prior behavior).
+        const budgetPerSong = input.budgetPerSong || 0;
         const minPerSong = Math.round(projectTypeConfig.min / songCount);
         const maxPerSong = Math.round(projectTypeConfig.max / songCount);
-
         if (budgetPerSong < minPerSong) {
-          throw new Error(`Budget per song must be at least $${minPerSong.toLocaleString()} for ${validatedData.type} projects`);
+          throw new Error(`Budget per song must be at least $${minPerSong.toLocaleString()} for ${input.type} projects`);
         }
         if (budgetPerSong > maxPerSong) {
-          throw new Error(`Budget per song cannot exceed $${maxPerSong.toLocaleString()} for ${validatedData.type} projects`);
+          throw new Error(`Budget per song cannot exceed $${maxPerSong.toLocaleString()} for ${input.type} projects`);
         }
+
+        // B2: recompute total cost SERVER-SIDE via the same shared engine math
+        // the quality/economy uses (FinancialSystem.calculatePerSongProjectCost:
+        // round(budgetPerSong * songCount * producerMult * timeMult)). Client
+        // totalCost is discarded.
+        const financialSystem = new FinancialSystem(serverGameData, () => Math.random());
+        const computed = financialSystem.calculatePerSongProjectCost(
+          budgetPerSong,
+          songCount,
+          input.producerTier || 'local',
+          input.timeInvestment || 'standard'
+        );
+        projectCost = computed.totalCost;
       } else if (projectTypeConfig) {
-        // For tour projects, validate total budget
-        const totalCost = validatedData.totalCost || 0;
+        // Tour projects: validate + charge the client-supplied total budget
+        // (preserved verbatim; not in scope for B2's recording-cost recompute).
+        const totalCost = input.totalCost || 0;
         if (totalCost < projectTypeConfig.min) {
-          throw new Error(`Budget must be at least $${projectTypeConfig.min.toLocaleString()} for ${validatedData.type} projects`);
+          throw new Error(`Budget must be at least $${projectTypeConfig.min.toLocaleString()} for ${input.type} projects`);
         }
         if (totalCost > projectTypeConfig.max) {
-          throw new Error(`Budget cannot exceed $${projectTypeConfig.max.toLocaleString()} for ${validatedData.type} projects`);
+          throw new Error(`Budget cannot exceed $${projectTypeConfig.max.toLocaleString()} for ${input.type} projects`);
         }
+        projectCost = totalCost;
+      } else {
+        projectCost = input.totalCost || input.budgetPerSong || 0;
       }
 
-      console.log('[PROJECT CREATION] Validated data after schema parse and budget validation:', JSON.stringify({
-        title: validatedData.title,
-        type: validatedData.type,
-        budgetPerSong: validatedData.budgetPerSong,
-        totalCost: validatedData.totalCost,
-        songCount: validatedData.songCount,
-        producerTier: validatedData.producerTier,
-        timeInvestment: validatedData.timeInvestment,
-        artistId: validatedData.artistId,
-        gameId: validatedData.gameId
-      }, null, 2));
-
-      // Check if user has sufficient funds BEFORE creating project
-      if (!validatedData.gameId) {
-        throw new Error('Game ID is required');
-      }
-      const gameState = await storage.getGameState(validatedData.gameId);
-      if (!gameState) {
-        throw new Error('Game state not found');
-      }
-
-      // Check if user has sufficient creative capital
+      // Check sufficient creative capital.
       const currentCreativeCapital = gameState.creativeCapital || 0;
       if (currentCreativeCapital < 1) {
         throw new Error(`Insufficient creative capital. You need 1 creative capital to start a new project, but you have ${currentCreativeCapital}.`);
       }
 
-      const projectCost = validatedData.totalCost || validatedData.budgetPerSong || 0;
       if (projectCost > (gameState.money ?? 0)) {
         throw new Error(`Insufficient funds. Project costs $${projectCost.toLocaleString()} but you only have $${(gameState.money ?? 0).toLocaleString()}`);
       }
 
-      const project = await storage.createProject(validatedData);
+      // Server-owned creation record: stage/startWeek/totalCost/songsCreated/
+      // quality are set here, NOT trusted from the client.
+      const insertValues = {
+        title: input.title,
+        type: input.type,
+        artistId: input.artistId ?? null,
+        gameId,
+        budgetPerSong: isRecording ? (input.budgetPerSong ?? 0) : 0,
+        totalCost: projectCost,
+        songCount: isRecording ? songCount : 1,
+        songsCreated: 0,
+        quality: 0,
+        producerTier: input.producerTier ?? 'local',
+        timeInvestment: input.timeInvestment ?? 'standard',
+        stage: 'planning' as const,
+        startWeek: gameState.currentWeek ?? null,
+        metadata: input.metadata ?? null,
+      };
 
-      // IMMEDIATELY deduct project cost and creative capital to prevent timing exploit
-      await storage.updateGameState(validatedData.gameId!, {
-        money: (gameState.money ?? 0) - projectCost,
-        creativeCapital: currentCreativeCapital - 1
+      // B4: create + deduct atomically. A crash between them no longer yields an
+      // unpaid project or a double charge.
+      const project = await db.transaction(async (tx) => {
+        const [created] = await tx.insert(projectsTable).values(insertValues).returning();
+        await tx
+          .update(gameStates)
+          .set({
+            money: (gameState.money ?? 0) - projectCost,
+            creativeCapital: currentCreativeCapital - 1,
+            updatedAt: new Date(),
+          })
+          .where(eq(gameStates.id, gameId));
+        return created;
       });
 
       if (projectCost > 0) {
@@ -194,9 +297,32 @@ router.post("/api/budget-calculation", requireClerkUser, async (req, res) => {
 
   router.patch("/api/projects/:id", requireClerkUser, async (req, res) => {
     try {
-      const project = await storage.updateProject(req.params.id, req.body);
+      // B3: whitelist patchable fields; reject unknown keys (mass-assignment).
+      const updates = patchProjectInputSchema.parse(req.body);
+
+      // B1: entity-walk ownership (project -> gameId -> game.userId). 404 (not
+      // 403) so we don't leak the existence of other users' projects.
+      const existing = await storage.getProject(req.params.id);
+      if (!existing) {
+        return res.status(404).json({
+          error: 'PROJECT_NOT_FOUND',
+          message: 'Project not found or does not belong to this user'
+        });
+      }
+      const owner = existing.gameId ? await storage.getGameState(existing.gameId) : undefined;
+      if (!owner || owner.userId !== req.userId) {
+        return res.status(404).json({
+          error: 'PROJECT_NOT_FOUND',
+          message: 'Project not found or does not belong to this user'
+        });
+      }
+
+      const project = await storage.updateProject(req.params.id, updates);
       res.json(project);
     } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: "Invalid project data", errors: error.errors });
+      }
       res.status(500).json({ message: "Failed to update project" });
     }
   });

--- a/tests/endpoints/projects-create.characterization.test.ts
+++ b/tests/endpoints/projects-create.characterization.test.ts
@@ -197,24 +197,46 @@ describe('POST /api/game/:gameId/projects (characterization)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Pre-fix exploitable behavior. Commit 1 pins these GREEN on today's code;
-// Commit 2 FLIPS each of them (see the (post-fix) block below).
+// Post-fix hardening (B1-B4). These FLIP the pre-fix exploits and assert the
+// new ownership / entity-scoping / bounds checks. They only pass after the fix.
 // ---------------------------------------------------------------------------
-describe('POST /api/game/:gameId/projects (pre-fix exploits)', () => {
-  it('B2 PIN: totalCost:1 with a high budgetPerSong is charged only $1', async () => {
+describe('POST /api/game/:gameId/projects (post-fix hardening)', () => {
+  it('B2 FLIP: server-computed cost is charged; client totalCost:1 is ignored', async () => {
     const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
 
     const res = await request(app)
       .post(`/api/game/${gameId}/projects`)
+      // budgetPerSong 8000 (max in-bounds for Single 1-song) with totalCost:1.
       .send(clientPayload({ artistId, budgetPerSong: 8000, totalCost: 1 }));
 
     expect(res.status).toBe(200);
+    // Server recomputes: 8000 * 1 song * local(1.0) * standard(1.0) = 8000.
+    expect(res.body.totalCost).toBe(8000);
     const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
-    // Only $1 deducted despite budgetPerSong 8000 (drives quality) -> exploit.
-    expect(gs.money).toBe(500000 - 1);
+    expect(gs.money).toBe(500000 - 8000); // NOT 500000 - 1
   });
 
-  it("B3 PIN: client-supplied stage:'production' is accepted verbatim", async () => {
+  it('B2: producer/time multipliers are applied to the server cost', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      // regional(1.8) * extended(1.4) = 2.52; 5000 * 1 * 2.52 = 12600.
+      .send(clientPayload({
+        artistId,
+        budgetPerSong: 5000,
+        totalCost: 1,
+        producerTier: 'regional',
+        timeInvestment: 'extended',
+      }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalCost).toBe(12600);
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(500000 - 12600);
+  });
+
+  it("B3 FLIP: client-supplied stage:'production' is ignored; project is 'planning'", async () => {
     const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
 
     const res = await request(app)
@@ -222,10 +244,74 @@ describe('POST /api/game/:gameId/projects (pre-fix exploits)', () => {
       .send(clientPayload({ artistId, stage: 'production' }));
 
     expect(res.status).toBe(200);
-    expect(res.body.stage).toBe('production'); // skips the planning week -> exploit
+    expect(res.body.stage).toBe('planning'); // server-owned, not skippable
   });
 
-  it('B1 PIN: PATCH applies raw body to any project, even cross-tenant', async () => {
+  it('B3 FLIP: an unknown/forbidden field (quality) is rejected with 400', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      .send(clientPayload({ artistId, quality: 98 })); // mass-assignment attempt
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('Invalid project data');
+    const rows = await db.select().from(projects).where(eq(projects.gameId, gameId));
+    expect(rows.length).toBe(0);
+  });
+
+  it('B3: songCount out of bounds (EP with 10 songs) is rejected with 400', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      .send(clientPayload({
+        artistId,
+        type: 'EP',
+        songCount: 10, // legit range is 3-5
+        budgetPerSong: 5000,
+        totalCost: 1,
+      }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_SONG_COUNT');
+    const rows = await db.select().from(projects).where(eq(projects.gameId, gameId));
+    expect(rows.length).toBe(0);
+  });
+
+  it('B1: cross-tenant create returns 404 GAME_NOT_FOUND; victim game untouched', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: OTHER_USER_ID, money: 500000, creativeCapital: 5 });
+    currentUserId = TEST_USER_ID; // attacker != owner
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      .send(clientPayload({ artistId }));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(500000); // untouched
+    const rows = await db.select().from(projects).where(eq(projects.gameId, gameId));
+    expect(rows.length).toBe(0);
+  });
+
+  it('entity-scoping: artistId from a different game returns 400; no project created', async () => {
+    const mine = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+    const other = await seedGame({ ownerId: OTHER_USER_ID });
+
+    const res = await request(app)
+      .post(`/api/game/${mine.gameId}/projects`)
+      .send(clientPayload({ artistId: other.artistId })); // artist from another game
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('ARTIST_NOT_IN_GAME');
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, mine.gameId));
+    expect(gs.money).toBe(500000);
+    const rows = await db.select().from(projects).where(eq(projects.gameId, mine.gameId));
+    expect(rows.length).toBe(0);
+  });
+
+  it('B1 FLIP: PATCH cross-tenant returns 404 PROJECT_NOT_FOUND; project unchanged', async () => {
     // Victim owns the game/project; attacker (TEST_USER_ID) patches it.
     const { gameId, artistId } = await seedGame({ ownerId: OTHER_USER_ID, money: 500000, creativeCapital: 5 });
     const projectId = crypto.randomUUID();
@@ -241,10 +327,37 @@ describe('POST /api/game/:gameId/projects (pre-fix exploits)', () => {
     currentUserId = TEST_USER_ID; // attacker != owner
     const res = await request(app)
       .patch(`/api/projects/${projectId}`)
-      .send({ stage: 'recorded', quality: 98 });
+      .send({ stage: 'recorded' });
 
-    expect(res.status).toBe(200);
-    expect(res.body.stage).toBe('recorded');
-    expect(res.body.quality).toBe(98);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('PROJECT_NOT_FOUND');
+    const [proj] = await db.select().from(projects).where(eq(projects.id, projectId));
+    expect(proj.stage).toBe('planning'); // unchanged
+  });
+
+  it('B3: PATCH by the owner with a whitelisted field succeeds; unknown field 400s', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+    const projectId = crypto.randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      gameId,
+      artistId,
+      title: 'My Project',
+      type: 'Single',
+      stage: 'planning',
+    });
+
+    const ok = await request(app)
+      .patch(`/api/projects/${projectId}`)
+      .send({ stage: 'production' });
+    expect(ok.status).toBe(200);
+    expect(ok.body.stage).toBe('production');
+
+    const bad = await request(app)
+      .patch(`/api/projects/${projectId}`)
+      .send({ quality: 98 }); // mass-assignment attempt
+    expect(bad.status).toBe(400);
+    const [proj] = await db.select().from(projects).where(eq(projects.id, projectId));
+    expect(proj.quality).toBe(0); // unchanged
   });
 });

--- a/tests/endpoints/projects-create.characterization.test.ts
+++ b/tests/endpoints/projects-create.characterization.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment node
+/**
+ * Project-creation characterization test (B1-B4 hardening).
+ *
+ * POST /api/game/:gameId/projects (server/routes/projects.ts) had ZERO coverage
+ * and four confirmed vulnerabilities (RECORDING_SESSION_CODE_REVIEW_2026-07-02):
+ *   B1 no game/project ownership check anywhere in the router (cross-tenant);
+ *   B2 payment uses client-supplied totalCost, never recomputed server-side, so
+ *      an in-bounds budgetPerSong (drives quality) with totalCost:1 buys full
+ *      quality songs for $1;
+ *   B3 mass-assignment — the raw insertProjectSchema.parse lets a request set
+ *      stage/songsCreated/quality/unbounded songCount;
+ *   B4 create + deduct are two separate awaits (non-atomic).
+ * PATCH /api/projects/:id applied raw req.body to ANY project — no ownership,
+ * no whitelist.
+ *
+ * The "(characterization)" block pins the behavior that is IDENTICAL before and
+ * after the fix (honest happy path, insufficient funds). The "(pre-fix exploits)"
+ * block pins the CURRENT exploitable behavior so Commit 1 is green on today's
+ * code; Commit 2 FLIPS those pins. The "(post-fix)" block asserts the hardening
+ * and only passes after the fix lands.
+ *
+ * It drives the real projects router over supertest against the real test
+ * Postgres (Docker, localhost:5433). Clerk auth is mocked to a fixed test user
+ * (mutable so a second user can be impersonated for cross-tenant checks);
+ * server/db is mocked to a non-SSL pool pointed at the test DB (the production
+ * pool forces SSL, which the local test container rejects).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+// Must be set before any module that reads DATABASE_URL at import time.
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+// Fixed clerk id / resolved userId for the mocked authenticated user (owner).
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+// A second user, used for cross-tenant assertions.
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+// --- Mock server/db with a non-SSL pool at the test DB. storage.ts imports
+//     `db` from ./db, so this single mock reroutes storage + handlers.
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+// --- Mock server/auth so requireClerkUser injects the fixed test userId and
+//     everything else is a passthrough. The injected userId is mutable so
+//     individual tests can impersonate a second user for cross-tenant checks.
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import { gameStates, users, artists, projects } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import projectsRouter from '../../server/routes/projects';
+
+let app: Express;
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(projectsRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+/**
+ * Seed a game (owned by ownerId) + one artist, returning ids. No project — the
+ * create tests POST one. money/creativeCapital are configurable for the
+ * insufficient-funds path.
+ */
+async function seedGame(opts: {
+  ownerId: string;
+  money?: number;
+  creativeCapital?: number;
+}) {
+  const gameId = crypto.randomUUID();
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: opts.ownerId,
+    currentWeek: 3,
+    money: opts.money ?? 500000,
+    reputation: 100, // high rep so all producer tiers are conceptually available
+    creativeCapital: opts.creativeCapital ?? 5,
+  });
+
+  const artistId = crypto.randomUUID();
+  await db.insert(artists).values({
+    id: artistId,
+    gameId,
+    name: 'Test Artist',
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood: 50,
+    energy: 50,
+  });
+
+  return { gameId, artistId };
+}
+
+/**
+ * The REAL payload the live client sends (RecordingSessionPage.handleSubmit ->
+ * gameStore.createProject, which appends startWeek + stage:'planning').
+ */
+function clientPayload(over: Partial<Record<string, any>> = {}) {
+  return {
+    title: 'My Single',
+    type: 'Single',
+    budgetPerSong: 5000,
+    totalCost: 5000, // local x standard => 5000 * 1 * 1.0 * 1.0
+    songCount: 1,
+    producerTier: 'local',
+    timeInvestment: 'standard',
+    startWeek: 3,
+    stage: 'planning',
+    ...over,
+  };
+}
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+describe('POST /api/game/:gameId/projects (characterization)', () => {
+  it('happy path: creates a Single with the real client payload and deducts the correct cost + 1 creative capital', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      .send(clientPayload({ artistId }));
+
+    expect(res.status).toBe(200);
+    // Response is the created project row.
+    expect(res.body.id).toBeDefined();
+    expect(res.body.title).toBe('My Single');
+    expect(res.body.type).toBe('Single');
+    expect(res.body.artistId).toBe(artistId);
+    expect(res.body.gameId).toBe(gameId);
+    expect(res.body.stage).toBe('planning');
+    expect(res.body.songCount).toBe(1);
+    expect(res.body.budgetPerSong).toBe(5000);
+
+    // budgetPerSong 5000 x 1 song x local(1.0) x standard(1.0) = 5000 charged.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(500000 - 5000);
+    expect(gs.creativeCapital).toBe(4);
+  });
+
+  it('insufficient funds: rejects and moves no money', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 1000, creativeCapital: 5 });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      .send(clientPayload({ artistId, budgetPerSong: 5000, totalCost: 5000 }));
+
+    // Handler throws a plain Error -> 500 with the generic message (pinned).
+    expect(res.status).toBe(500);
+    expect(res.body.message).toBe('Failed to create project');
+
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(1000);
+    expect(gs.creativeCapital).toBe(5);
+    const rows = await db.select().from(projects).where(eq(projects.gameId, gameId));
+    expect(rows.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-fix exploitable behavior. Commit 1 pins these GREEN on today's code;
+// Commit 2 FLIPS each of them (see the (post-fix) block below).
+// ---------------------------------------------------------------------------
+describe('POST /api/game/:gameId/projects (pre-fix exploits)', () => {
+  it('B2 PIN: totalCost:1 with a high budgetPerSong is charged only $1', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      .send(clientPayload({ artistId, budgetPerSong: 8000, totalCost: 1 }));
+
+    expect(res.status).toBe(200);
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    // Only $1 deducted despite budgetPerSong 8000 (drives quality) -> exploit.
+    expect(gs.money).toBe(500000 - 1);
+  });
+
+  it("B3 PIN: client-supplied stage:'production' is accepted verbatim", async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: TEST_USER_ID, money: 500000, creativeCapital: 5 });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/projects`)
+      .send(clientPayload({ artistId, stage: 'production' }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.stage).toBe('production'); // skips the planning week -> exploit
+  });
+
+  it('B1 PIN: PATCH applies raw body to any project, even cross-tenant', async () => {
+    // Victim owns the game/project; attacker (TEST_USER_ID) patches it.
+    const { gameId, artistId } = await seedGame({ ownerId: OTHER_USER_ID, money: 500000, creativeCapital: 5 });
+    const projectId = crypto.randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      gameId,
+      artistId,
+      title: 'Victim Project',
+      type: 'Single',
+      stage: 'planning',
+    });
+
+    currentUserId = TEST_USER_ID; // attacker != owner
+    const res = await request(app)
+      .patch(`/api/projects/${projectId}`)
+      .send({ stage: 'recorded', quality: 98 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.stage).toBe('recorded');
+    expect(res.body.quality).toBe(98);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes findings B1–B4 of `docs/98-research/RECORDING_SESSION_CODE_REVIEW_2026-07-02.md` on `server/routes/projects.ts`:
- **B2 (exploit)**: recording-project cost is now recomputed server-side via the shared `FinancialSystem.calculatePerSongProjectCost` (same code the engine uses) — `totalCost: 1` + high `budgetPerSong` no longer buys full-quality songs for $1. Mini-Tour keeps its existing cost path verbatim (tour economy is C40 territory, already merged in #66)
- **B3**: `.strict()` creation whitelist (client-sent `stage`/`startWeek` tolerated but ignored — server sets authoritative values; genuinely forbidden fields like `quality` → 400); `songCount` bounded per type (Single 1–3, EP 3–5) so a huge count can't depress the per-song minimum; PATCH gets a stage/title-only whitelist
- **B1**: ownership on create (game-scoped, 404) and PATCH (entity-walk project→game→user, 404); `artistId` must belong to the same game (400 `ARTIST_NOT_IN_GAME`)
- **B4**: create + money/creative-capital deduction now one `db.transaction`

## Verification
- Characterization-first: commit 1 pins current behavior **including all three exploits** ($1 charge honored, client `stage: 'production'` honored, cross-tenant PATCH succeeds); commit 2 flips each pin and adds cross-tenant/entity-scoping/bounds tests
- 20/20 across projects-create (11) + projects-cancel (from #66) + route-manifest (unchanged — inline checks, no new middleware); `npm run check` clean

Out of scope, preserved: insufficient-funds still surfaces as the pre-existing 500 (pinned); recording review B5–B7 (engine RNG, no-op pass, client UX) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)