### PR TITLE
fix(security): enforce game ownership across remaining routers

### DIFF
--- a/server/middleware/requireGameOwner.ts
+++ b/server/middleware/requireGameOwner.ts
@@ -6,11 +6,18 @@
  * single reusable middleware, closing the broken-object-level-authorization
  * (IDOR) gap documented in OWNERSHIP_AUTHORIZATION_SWEEP_2026-07-02.md.
  *
- * Reads `req.params.gameId`, loads the game scoped by BOTH id AND
- * `req.userId`, and 404s (not 403) if no such row exists so we don't leak
- * whether a given gameId exists to a non-owner. On success it stashes the
- * loaded game row on `req.gameState` so downstream handlers can reuse it
- * without a second query.
+ * Resolves the gameId from `req.params.gameId ?? req.body?.gameId ?? req.query?.gameId`
+ * (URL param preferred; body/query fallbacks support routes that carry the id
+ * off-path, e.g. POST /api/advance-week and the analytics ROI reads), loads the
+ * game scoped by BOTH id AND `req.userId`, and 404s (not 403) if no such row
+ * exists so we don't leak whether a given gameId exists to a non-owner. On
+ * success it stashes the loaded game row on `req.gameState` so downstream
+ * handlers can reuse it without a second query.
+ *
+ * For routes whose param is NOT named `gameId` (games.ts uses `:id`), use
+ * `requireGameOwnerByParam('id')` which builds a wrapper that reads the given
+ * param name; the shared middleware deliberately does NOT add a generic `:id`
+ * fallback so the route paths in the manifest never change.
  *
  * MUST run after requireClerkUser (which populates req.userId).
  */
@@ -19,18 +26,28 @@ import { and, eq } from 'drizzle-orm';
 import { db } from '../db';
 import { gameStates, type GameState } from '@shared/schema';
 
-export async function requireGameOwner(req: Request, res: Response, next: NextFunction) {
+/**
+ * Core ownership check. `resolveGameId` extracts the candidate gameId from the
+ * request; the default reads params.gameId, then body.gameId, then query.gameId.
+ */
+async function enforceGameOwnership(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  resolveGameId: (req: Request) => unknown,
+) {
   try {
     const userId = req.userId;
     if (!userId) {
       return res.status(401).json({ message: 'Authentication required' });
     }
 
-    const gameId = req.params.gameId;
+    const rawGameId = resolveGameId(req);
+    const gameId = typeof rawGameId === 'string' ? rawGameId : undefined;
     if (!gameId) {
       return res.status(400).json({
         error: 'MISSING_GAME_ID',
-        message: 'gameId route parameter is required',
+        message: 'gameId is required',
       });
     }
 
@@ -55,6 +72,30 @@ export async function requireGameOwner(req: Request, res: Response, next: NextFu
     console.error('[requireGameOwner] Failed to verify game ownership', error);
     res.status(500).json({ message: 'Failed to verify game ownership' });
   }
+}
+
+export async function requireGameOwner(req: Request, res: Response, next: NextFunction) {
+  return enforceGameOwnership(
+    req,
+    res,
+    next,
+    (r) => r.params.gameId ?? r.body?.gameId ?? r.query?.gameId,
+  );
+}
+
+/**
+ * Ownership middleware for routes whose route parameter is NOT named `gameId`
+ * (e.g. games.ts's GET/PATCH /api/game/:id). Reads only the named param so the
+ * route path in the manifest stays `:id` and we never introduce a generic
+ * `:id` fallback into the shared middleware.
+ */
+export function requireGameOwnerByParam(paramName: string) {
+  // Distinct inner name (no collision with the factory binding) so the
+  // route-manifest snapshot reads `requireGameOwnerForParam`, not a
+  // V8-suffixed `requireGameOwnerByParam2`.
+  return function requireGameOwnerForParam(req: Request, res: Response, next: NextFunction) {
+    return enforceGameOwnership(req, res, next, (r) => r.params[paramName]);
+  };
 }
 
 declare global {

--- a/server/routes/analytics.ts
+++ b/server/routes/analytics.ts
@@ -7,13 +7,20 @@
 
 import { Router } from 'express';
 import { analyticsService } from '../services/AnalyticsService';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 
 const router = Router();
+
+// NOTE: this router is mounted in server/routes.ts with requireClerkUser at the
+// mount point, so callers are already authenticated. requireGameOwner (added
+// per-route below, resolving gameId from the ?gameId query param) closes the
+// remaining cross-tenant read gap: previously any authenticated user could read
+// another player's ROI by passing their gameId. Non-owner => 404 GAME_NOT_FOUND.
 
 /**
  * Get ROI metrics for a specific artist
  */
-router.get('/artist/:artistId/roi', async (req, res) => {
+router.get('/artist/:artistId/roi', requireGameOwner, async (req, res) => {
   try {
     const { artistId } = req.params;
     const { gameId } = req.query;
@@ -37,7 +44,7 @@ router.get('/artist/:artistId/roi', async (req, res) => {
 /**
  * Get ROI metrics for a specific project
  */
-router.get('/project/:projectId/roi', async (req, res) => {
+router.get('/project/:projectId/roi', requireGameOwner, async (req, res) => {
   try {
     const { projectId } = req.params;
     const { gameId } = req.query;
@@ -61,7 +68,7 @@ router.get('/project/:projectId/roi', async (req, res) => {
 /**
  * Get ROI metrics for a specific release
  */
-router.get('/release/:releaseId/roi', async (req, res) => {
+router.get('/release/:releaseId/roi', requireGameOwner, async (req, res) => {
   try {
     const { releaseId } = req.params;
     const { gameId } = req.query;
@@ -85,7 +92,7 @@ router.get('/release/:releaseId/roi', async (req, res) => {
 /**
  * Get portfolio-wide ROI metrics
  */
-router.get('/portfolio/roi', async (req, res) => {
+router.get('/portfolio/roi', requireGameOwner, async (req, res) => {
   try {
     const { gameId } = req.query;
     

--- a/server/routes/arOffice.ts
+++ b/server/routes/arOffice.ts
@@ -2,15 +2,17 @@ import { Router } from 'express';
 import { storage } from '../storage';
 import { serverGameData } from '../data/gameData';
 import { requireClerkUser } from '../auth';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 
 const router = Router();
 
-  router.post('/api/game/:gameId/ar-office/start', requireClerkUser, async (req, res) => {
+  router.post('/api/game/:gameId/ar-office/start', requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
       const { sourcingType, primaryGenre, secondaryGenre } = req.body || {};
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) return res.status(404).json({ message: 'Game not found' });
+      // Ownership + existence verified by requireGameOwner (404 GAME_NOT_FOUND
+      // replaces the previous inline 'Game not found' 404).
+      const gameState = req.gameState!;
 
       // Validate sourcingType
       const validSourcingTypes = ['active', 'passive', 'specialized'];
@@ -71,11 +73,11 @@ const router = Router();
 
 
   // Cancel an A&R sourcing operation
-  router.post('/api/game/:gameId/ar-office/cancel', requireClerkUser, async (req, res) => {
+  router.post('/api/game/:gameId/ar-office/cancel', requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) return res.status(404).json({ message: 'Game not found' });
+      // Ownership + existence verified by requireGameOwner.
+      const gameState = req.gameState!;
 
       const used = gameState.usedFocusSlots || 0;
       const newUsed = gameState.arOfficeSlotUsed ? Math.max(0, used - 1) : used;
@@ -108,11 +110,10 @@ const router = Router();
   });
 
   // Get current A&R status
-  router.get('/api/game/:gameId/ar-office/status', requireClerkUser, async (req, res) => {
+  router.get('/api/game/:gameId/ar-office/status', requireClerkUser, requireGameOwner, async (req, res) => {
     try {
-      const { gameId } = req.params;
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) return res.status(404).json({ message: 'Game not found' });
+      // Ownership + existence verified by requireGameOwner.
+      const gameState = req.gameState!;
 
       return res.json({
         arOfficeSlotUsed: gameState.arOfficeSlotUsed || false,
@@ -126,15 +127,12 @@ const router = Router();
   });
 
   // Get discovered artists for A&R (returns the persisted pick when operation is complete)
-  router.get('/api/game/:gameId/ar-office/artists', requireClerkUser, async (req, res) => {
+  router.get('/api/game/:gameId/ar-office/artists', requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
       console.log('[A&R DEBUG] Backend: Getting discovered artists for game:', gameId);
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) {
-        console.log('[A&R DEBUG] Backend: Game not found');
-        return res.status(404).json({ message: 'Game not found' });
-      }
+      // Ownership + existence verified by requireGameOwner.
+      const gameState = req.gameState!;
 
       // Initialize game data - if this fails, return empty list instead of 500 error
       try {

--- a/server/routes/devTools.ts
+++ b/server/routes/devTools.ts
@@ -7,6 +7,7 @@ import { db } from '../db';
 import { gameStates } from '@shared/schema';
 import { eq } from 'drizzle-orm';
 import { requireClerkUser, requireAdmin } from '../auth';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 
 const router = Router();
 
@@ -204,7 +205,7 @@ router.get("/api/validate-types", requireClerkUser, async (req, res) => {
   });
 
   // Streaming decay testing endpoint
-  router.post('/api/game/:gameId/test/streaming-decay', requireClerkUser, async (req, res) => {
+  router.post('/api/game/:gameId/test/streaming-decay', requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const gameId = req.params.gameId;
       const {
@@ -218,11 +219,10 @@ router.get("/api/validate-types", requireClerkUser, async (req, res) => {
         awarenessConfig
       } = req.body;
 
-      // Get game state for current week
-      const [gameState] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
-      if (!gameState) {
-        return res.status(404).json({ error: 'Game not found' });
-      }
+      // Ownership + existence verified by requireGameOwner (404 GAME_NOT_FOUND
+      // replaces the previous inline 'Game not found' 404). Only currentWeek is
+      // read from the game below.
+      const gameState = req.gameState!;
 
       // Create mock song and release data for testing
       const mockSong = {

--- a/server/routes/executives.ts
+++ b/server/routes/executives.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { serverGameData } from '../data/gameData';
 import { storage } from '../storage';
 import { requireClerkUser } from '../auth';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 import { seededRandomPick, generateMeetingSeed } from '@shared/utils/seededRandom';
 import { gameDataLoader } from '@shared/utils/dataLoader';
 
@@ -101,7 +102,7 @@ router.get("/api/roles/:roleId", requireClerkUser, async (req, res) => {
   });
 
   // Get executives for a game
-  router.get("/api/game/:gameId/executives", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:gameId/executives", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
       console.log('[ROUTES] Fetching executives for game:', gameId);
@@ -117,15 +118,23 @@ router.get("/api/roles/:roleId", requireClerkUser, async (req, res) => {
   });
 
   // Process executive action/decision (Week 2 Task)
-  router.post("/api/game/:gameId/executive/:execId/action", requireClerkUser, async (req, res) => {
+  router.post("/api/game/:gameId/executive/:execId/action", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId, execId } = req.params;
       const { actionId, meetingId, choiceId, metadata } = req.body;
 
-      // Get the game state
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) {
-        return res.status(404).json({ message: "Game not found" });
+      // Ownership + existence verified by requireGameOwner; reuse its row.
+      const gameState = req.gameState!;
+
+      // HARDENING: validate the executive belongs to THIS game. Previously
+      // execId was used raw as targetId with no check, so any authenticated
+      // owner could pass an arbitrary/other-game execId.
+      const executive = await storage.getExecutive(execId);
+      if (!executive || executive.gameId !== gameId) {
+        return res.status(404).json({
+          error: 'EXECUTIVE_NOT_FOUND',
+          message: 'Executive not found for this game',
+        });
       }
 
       // Store the executive action as a selected action for the week

--- a/server/routes/gameLoop.ts
+++ b/server/routes/gameLoop.ts
@@ -4,6 +4,7 @@ import { storage } from '../storage';
 import { db } from '../db';
 import { eq, and } from 'drizzle-orm';
 import { requireClerkUser } from '../auth';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 import { serverGameData } from '../data/gameData';
 import { GameEngine } from '../../shared/engine/game-engine';
 import {
@@ -16,7 +17,7 @@ import { insertWeeklyActionSchema, gameStates, weeklyActions, projects, songs, a
 const router = Router();
 
   // Weekly action routes
-  router.post("/api/game/:gameId/actions", requireClerkUser, async (req, res) => {
+  router.post("/api/game/:gameId/actions", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const validatedData = insertWeeklyActionSchema.parse({
         ...req.body,
@@ -34,7 +35,10 @@ const router = Router();
   });
 
   // Week advancement with action processing using GameEngine and transactions
-  router.post("/api/advance-week", requireClerkUser, async (req, res) => {
+  // gameId arrives in the request body; requireGameOwner resolves it via its
+  // body fallback and 404s a non-owner before any transaction runs. The
+  // in-transaction re-read below is kept intentionally for freshness/locking.
+  router.post("/api/advance-week", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       // Validate request using shared contract
       const request = validateRequest(AdvanceWeekRequest, req.body);

--- a/server/routes/games.ts
+++ b/server/routes/games.ts
@@ -4,19 +4,34 @@ import { storage } from '../storage';
 import { db } from '../db';
 import { eq, desc, sql } from 'drizzle-orm';
 import { requireClerkUser } from '../auth';
+import { requireGameOwner, requireGameOwnerByParam } from '../middleware/requireGameOwner';
 import { serverGameData } from '../data/gameData';
 import { labelRequestSchema, gameStates, gameSaves } from '@shared/schema';
 import { gameCreationService } from '../services/gameCreationService';
 
 const router = Router();
 
+// HARDENING: whitelist the fields the client is actually allowed to PATCH on a
+// game. The only live PATCH /api/game/:id callers are syncSlotsPatch()
+// (client/src/store/gameStore.ts) and syncAROfficeSlots()
+// (client/src/services/arOfficeService.ts) — both send exactly
+// { usedFocusSlots, arOfficeSlotUsed, arOfficeSourcingType }. .strict() rejects
+// any other key so server-computed fields (money, reputation, access tiers,
+// flags, ...) can never be mass-assigned by the client.
+const patchGameStateSchema = z
+  .object({
+    usedFocusSlots: z.number().int().optional(),
+    arOfficeSlotUsed: z.boolean().optional(),
+    arOfficeSourcingType: z.string().nullable().optional(),
+  })
+  .strict();
+
   // Game state routes
-  router.get("/api/game/:id", requireClerkUser, async (req, res) => {
+  router.get("/api/game/:id", requireClerkUser, requireGameOwnerByParam('id'), async (req, res) => {
     try {
-      const gameState = await storage.getGameState(req.params.id);
-      if (!gameState) {
-        return res.status(404).json({ message: "Game not found" });
-      }
+      // Ownership verified by requireGameOwner; req.gameState is the owner's row.
+      // Its 404 GAME_NOT_FOUND replaces the previous inline "Game not found" 404.
+      const gameState = req.gameState!;
 
       // Get related data
       const musicLabel = await storage.getMusicLabel(gameState.id);
@@ -53,12 +68,24 @@ const router = Router();
     }
   });
 
-  router.patch("/api/game/:id", requireClerkUser, async (req, res) => {
+  router.patch("/api/game/:id", requireClerkUser, requireGameOwnerByParam('id'), async (req, res) => {
     try {
       console.log('[PATCH /api/game/:id] Request params:', req.params.id);
       console.log('[PATCH /api/game/:id] Request body:', req.body);
 
-      const gameState = await storage.updateGameState(req.params.id, req.body);
+      // HARDENING: reject unknown / server-computed fields (mass-assignment).
+      const parsed = patchGameStateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'INVALID_GAME_FIELDS',
+          message: 'Game update payload contains unexpected fields',
+          details: parsed.error.errors,
+        });
+      }
+
+      // Ownership verified by requireGameOwner (its 404 GAME_NOT_FOUND replaces
+      // the previous "Game not found or update failed" 404 for missing games).
+      const gameState = await storage.updateGameState(req.params.id, parsed.data);
 
       console.log('[PATCH /api/game/:id] Updated game state:', gameState);
 
@@ -191,17 +218,14 @@ const router = Router();
   });
 
 // Create/update music label for existing game
-  router.post("/api/game/:gameId/label", requireClerkUser, async (req, res) => {
+  router.post("/api/game/:gameId/label", requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
       console.log('[POST /api/game/:gameId/label] Creating/updating label for game:', gameId);
       console.log('[POST /api/game/:gameId/label] Label data:', req.body);
 
-      // Validate the game exists and belongs to the user
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) {
-        return res.status(404).json({ message: "Game not found" });
-      }
+      // Ownership + existence verified by requireGameOwner (404 GAME_NOT_FOUND
+      // replaces the previous inline "Game not found" 404).
 
       // Validate label data
       const validatedLabelData = labelRequestSchema.parse(req.body);

--- a/server/routes/tour.ts
+++ b/server/routes/tour.ts
@@ -1,13 +1,17 @@
 import { Router } from 'express';
 import { storage } from '../storage';
 import { requireClerkUser } from '../auth';
+import { requireGameOwner } from '../middleware/requireGameOwner';
 import { serverGameData } from '../data/gameData';
 import { FinancialSystem, VenueCapacityManager } from '@shared/engine/FinancialSystem';
 
 const router = Router();
 
   // Tour estimation endpoint - Phase 3: API Bridge
-  router.post('/api/tour/estimate', requireClerkUser, async (req, res) => {
+  // gameId arrives in the request body; requireGameOwner resolves it via its
+  // body fallback and 404s a non-owner (a missing gameId now yields the
+  // middleware's 400 MISSING_GAME_ID before this handler's combined 400).
+  router.post('/api/tour/estimate', requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { artistId, cities, budgetPerCity, gameId, venueCapacity } = req.body;
 
@@ -27,11 +31,9 @@ const router = Router();
         }
       }
 
-      // Get game state - CRASH IF MISSING
-      const gameState = await storage.getGameState(gameId);
-      if (!gameState) {
-        return res.status(404).json({ error: `Game not found: ${gameId}` });
-      }
+      // Ownership + existence verified by requireGameOwner (404 GAME_NOT_FOUND
+      // replaces the previous `Game not found: <id>` 404 body).
+      const gameState = req.gameState!;
 
       // Get artist - CRASH IF MISSING
       const artist = await storage.getArtist(artistId);

--- a/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
+++ b/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
@@ -53,27 +53,36 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/advance-week",
   },
   {
     "method": "GET",
-    "middleware": [],
+    "middleware": [
+      "requireGameOwner",
+    ],
     "path": "/api/analytics/artist/:artistId/roi",
   },
   {
     "method": "GET",
-    "middleware": [],
+    "middleware": [
+      "requireGameOwner",
+    ],
     "path": "/api/analytics/portfolio/roi",
   },
   {
     "method": "GET",
-    "middleware": [],
+    "middleware": [
+      "requireGameOwner",
+    ],
     "path": "/api/analytics/project/:projectId/roi",
   },
   {
     "method": "GET",
-    "middleware": [],
+    "middleware": [
+      "requireGameOwner",
+    ],
     "path": "/api/analytics/release/:releaseId/roi",
   },
   {
@@ -209,6 +218,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/actions",
   },
@@ -216,6 +226,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/ar-office/artists",
   },
@@ -223,6 +234,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/ar-office/cancel",
   },
@@ -230,6 +242,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/ar-office/start",
   },
@@ -237,6 +250,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/ar-office/status",
   },
@@ -333,6 +347,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/executive/:execId/action",
   },
@@ -340,6 +355,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/executives",
   },
@@ -347,6 +363,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/label",
   },
@@ -441,6 +458,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/game/:gameId/test/streaming-decay",
   },
@@ -448,6 +466,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "GET",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwnerForParam",
     ],
     "path": "/api/game/:id",
   },
@@ -455,6 +474,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "PATCH",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwnerForParam",
     ],
     "path": "/api/game/:id",
   },
@@ -563,6 +583,7 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "method": "POST",
     "middleware": [
       "requireClerkUser",
+      "requireGameOwner",
     ],
     "path": "/api/tour/estimate",
   },

--- a/tests/endpoints/sweep-migrations.characterization.test.ts
+++ b/tests/endpoints/sweep-migrations.characterization.test.ts
@@ -1,0 +1,451 @@
+// @vitest-environment node
+/**
+ * Ownership-sweep characterization test (Phase 1, ownership-sweep-migration).
+ *
+ * Pins the observable behavior of the remaining game-scoped routers BEFORE and
+ * AFTER the requireGameOwner sweep so the migration can be proven
+ * behavior-preserving for the OWNER path (green before AND after) while the
+ * non-owner path flips from "leaks/mutates victim data" to 404 GAME_NOT_FOUND.
+ *
+ * Routers covered: games (GET/PATCH /api/game/:id, POST /api/game/:gameId/label),
+ * gameLoop (POST /api/game/:gameId/actions, POST /api/advance-week body gameId),
+ * executives (GET .../executives, POST .../executive/:execId/action),
+ * arOffice (start/cancel/status/artists), analytics (4 ROI reads, query gameId),
+ * tour (POST /api/tour/estimate, body gameId), devTools (streaming-decay).
+ *
+ * Drives the real routers over supertest against the real test Postgres
+ * (Docker, localhost:5433). Clerk auth is mocked to a fixed test user; server/db
+ * is mocked to a non-SSL pool pointed at the test DB. Harness copied from
+ * tests/endpoints/releases.characterization.test.ts.
+ *
+ * The blocks tagged "(post-hardening)" only pass AFTER the migration commit
+ * lands (requireGameOwner + PATCH whitelist + execId validation).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import { gameStates, users, artists, executives, musicLabels } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import { requireClerkUser } from '../../server/auth';
+import gamesRouter from '../../server/routes/games';
+import gameLoopRouter from '../../server/routes/gameLoop';
+import executivesRouter from '../../server/routes/executives';
+import arOfficeRouter from '../../server/routes/arOffice';
+import tourRouter from '../../server/routes/tour';
+import devToolsRouter from '../../server/routes/devTools';
+import analyticsRouter from '../../server/routes/analytics';
+
+let app: Express;
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(gamesRouter);
+  app.use(gameLoopRouter);
+  app.use(executivesRouter);
+  app.use(arOfficeRouter);
+  app.use(tourRouter);
+  app.use(devToolsRouter);
+  // Analytics is mounted under /api/analytics with requireClerkUser at the mount
+  // point in production (server/routes.ts:117); mirror that here.
+  app.use('/api/analytics', requireClerkUser, analyticsRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+/** Seed a game owned by ownerId with sensible defaults. Returns ids. */
+async function seedGame(opts: {
+  ownerId: string;
+  money?: number;
+  reputation?: number;
+  creativeCapital?: number;
+  currentWeek?: number;
+  focusSlots?: number;
+  usedFocusSlots?: number;
+  venueAccess?: string;
+  withArtist?: boolean;
+  withExecutive?: boolean;
+}) {
+  const gameId = crypto.randomUUID();
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: opts.ownerId,
+    currentWeek: opts.currentWeek ?? 1,
+    money: opts.money ?? 100000,
+    reputation: opts.reputation ?? 10,
+    creativeCapital: opts.creativeCapital ?? 5,
+    focusSlots: opts.focusSlots ?? 3,
+    usedFocusSlots: opts.usedFocusSlots ?? 0,
+    venueAccess: opts.venueAccess ?? 'clubs',
+  });
+
+  let artistId: string | undefined;
+  if (opts.withArtist) {
+    artistId = crypto.randomUUID();
+    await db.insert(artists).values({
+      id: artistId,
+      gameId,
+      name: 'Test Artist',
+      archetype: 'Workhorse',
+      genre: 'pop',
+      mood: 50,
+      energy: 50,
+      popularity: 40,
+    });
+  }
+
+  let execId: string | undefined;
+  if (opts.withExecutive) {
+    execId = crypto.randomUUID();
+    await db.insert(executives).values({
+      id: execId,
+      gameId,
+      role: 'head_ar',
+      level: 1,
+      mood: 50,
+      loyalty: 50,
+    });
+  }
+
+  return { gameId, artistId, execId };
+}
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+// ===========================================================================
+// COMMIT 1: current OWNER-path behavior (green before AND after migration)
+// ===========================================================================
+describe('games router (owner path)', () => {
+  it('GET /api/game/:id returns the full game graph', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app).get(`/api/game/${gameId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.gameState.id).toBe(gameId);
+    expect(Array.isArray(res.body.artists)).toBe(true);
+    expect(Array.isArray(res.body.projects)).toBe(true);
+    expect(Array.isArray(res.body.releases)).toBe(true);
+  });
+
+  it('PATCH /api/game/:id updates focus-slot fields', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID, usedFocusSlots: 0 });
+    const res = await request(app)
+      .patch(`/api/game/${gameId}`)
+      .send({ usedFocusSlots: 2, arOfficeSlotUsed: true, arOfficeSourcingType: 'active' });
+    expect(res.status).toBe(200);
+    expect(res.body.usedFocusSlots).toBe(2);
+    expect(res.body.arOfficeSlotUsed).toBe(true);
+    expect(res.body.arOfficeSourcingType).toBe('active');
+  });
+
+  it('POST /api/game/:gameId/label creates a label', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/label`)
+      .send({ name: 'My Label' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('My Label');
+    expect(res.body.gameId).toBe(gameId);
+  });
+});
+
+describe('gameLoop router (owner path)', () => {
+  it('POST /api/game/:gameId/actions creates a weekly action', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/actions`)
+      .send({ actionType: 'role_meeting', week: 1, details: {} });
+    expect(res.status).toBe(200);
+    expect(res.body.gameId).toBe(gameId);
+  });
+});
+
+describe('executives router (owner path)', () => {
+  it('GET /api/game/:gameId/executives returns executives', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID, withExecutive: true });
+    const res = await request(app).get(`/api/game/${gameId}/executives`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
+  });
+
+  it('POST /api/game/:gameId/executive/:execId/action consumes a focus slot', async () => {
+    const { gameId, execId } = await seedGame({ ownerId: TEST_USER_ID, withExecutive: true, usedFocusSlots: 0 });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/executive/${execId}/action`)
+      .send({ actionId: 'a1', choiceId: 'c1', metadata: { roleId: 'head_ar' } });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.usedSlots).toBe(1);
+  });
+});
+
+describe('arOffice router (owner path)', () => {
+  it('GET /api/game/:gameId/ar-office/status returns status', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/status`);
+    expect(res.status).toBe(200);
+    expect(res.body.arOfficeSlotUsed).toBe(false);
+  });
+
+  it('POST /api/game/:gameId/ar-office/start starts an operation', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID, usedFocusSlots: 0 });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/ar-office/start`)
+      .send({ sourcingType: 'active' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.status.arOfficeSlotUsed).toBe(true);
+  });
+
+  it('GET /api/game/:gameId/ar-office/artists returns a list', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.artists)).toBe(true);
+  });
+});
+
+describe('tour router (owner path)', () => {
+  it('POST /api/tour/estimate returns an estimate', async () => {
+    const { gameId, artistId } = await seedGame({
+      ownerId: TEST_USER_ID,
+      venueAccess: 'clubs',
+      withArtist: true,
+    });
+    const res = await request(app)
+      .post('/api/tour/estimate')
+      .send({ artistId, cities: 3, budgetPerCity: 1000, gameId });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('estimatedRevenue');
+    expect(res.body).toHaveProperty('totalCosts');
+  });
+});
+
+describe('devTools router (owner path)', () => {
+  it('POST /api/game/:gameId/test/streaming-decay returns a simulation', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/test/streaming-decay`)
+      .send({
+        songQuality: 80,
+        artistPopularity: 40,
+        playlistAccess: 'none',
+        reputation: 10,
+        marketingBudget: { radio: 1000 },
+        weeksToSimulate: 4,
+      });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('analytics router (owner path)', () => {
+  it('GET /api/analytics/portfolio/roi returns metrics', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app).get(`/api/analytics/portfolio/roi?gameId=${gameId}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ===========================================================================
+// COMMIT 2: ownership hardening (post-hardening). Non-owner => 404, whitelist
+// rejects unknown PATCH fields, invalid execId => 404.
+// ===========================================================================
+describe('ownership hardening (post-hardening)', () => {
+  it('GET /api/game/:id 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app).get(`/api/game/${gameId}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('PATCH /api/game/:id 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app)
+      .patch(`/api/game/${gameId}`)
+      .send({ usedFocusSlots: 2, arOfficeSlotUsed: false, arOfficeSourcingType: null });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+    // Victim untouched.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.usedFocusSlots).toBe(0);
+  });
+
+  it('PATCH /api/game/:id 400 INVALID_GAME_FIELDS on unknown/server-computed field', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app)
+      .patch(`/api/game/${gameId}`)
+      .send({ money: 999999999 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_GAME_FIELDS');
+    // Money untouched.
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.money).toBe(100000);
+  });
+
+  it('POST /api/game/:gameId/label 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app).post(`/api/game/${gameId}/label`).send({ name: 'Hax' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+    const labels = await db.select().from(musicLabels).where(eq(musicLabels.gameId, gameId));
+    expect(labels).toHaveLength(0);
+  });
+
+  it('POST /api/game/:gameId/actions 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app)
+      .post(`/api/game/${gameId}/actions`)
+      .send({ actionType: 'role_meeting', week: 1, details: {} });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('POST /api/advance-week 404 GAME_NOT_FOUND for another user (body gameId)', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app)
+      .post('/api/advance-week')
+      .send({ gameId, selectedActions: [] });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('GET /api/game/:gameId/executives 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID, withExecutive: true });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app).get(`/api/game/${gameId}/executives`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('POST executive action 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId, execId } = await seedGame({ ownerId: OTHER_USER_ID, withExecutive: true });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app)
+      .post(`/api/game/${gameId}/executive/${execId}/action`)
+      .send({ actionId: 'a1', choiceId: 'c1', metadata: {} });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('POST executive action 404 EXECUTIVE_NOT_FOUND when execId not in game', async () => {
+    const { gameId } = await seedGame({ ownerId: TEST_USER_ID });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/executive/${crypto.randomUUID()}/action`)
+      .send({ actionId: 'a1', choiceId: 'c1', metadata: {} });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('EXECUTIVE_NOT_FOUND');
+  });
+
+  it('arOffice start 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app)
+      .post(`/api/game/${gameId}/ar-office/start`)
+      .send({ sourcingType: 'active' });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('arOffice status 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/status`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('arOffice cancel 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app).post(`/api/game/${gameId}/ar-office/cancel`).send({});
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('arOffice artists 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('POST /api/tour/estimate 404 GAME_NOT_FOUND for another user (body gameId)', async () => {
+    const { gameId, artistId } = await seedGame({ ownerId: OTHER_USER_ID, withArtist: true });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app)
+      .post('/api/tour/estimate')
+      .send({ artistId, cities: 3, budgetPerCity: 1000, gameId });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('devTools streaming-decay 404 GAME_NOT_FOUND for another user', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app)
+      .post(`/api/game/${gameId}/test/streaming-decay`)
+      .send({ songQuality: 80, artistPopularity: 40, playlistAccess: 'none', reputation: 10, marketingBudget: {}, weeksToSimulate: 2 });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+
+  it('analytics portfolio ROI 404 GAME_NOT_FOUND for another user (query gameId)', async () => {
+    const { gameId } = await seedGame({ ownerId: OTHER_USER_ID });
+    currentUserId = TEST_USER_ID;
+    const res = await request(app).get(`/api/analytics/portfolio/roi?gameId=${gameId}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+});


### PR DESCRIPTION
## Summary
Completes the migration recommended by `docs/98-research/OWNERSHIP_AUTHORIZATION_SWEEP_2026-07-02.md` — after this, every game-scoped route in the API enforces ownership:
- `requireGameOwner` extended to resolve gameId from param → body → query (covers `POST /api/advance-week`, `POST /api/tour/estimate`, and the 4 analytics ROI reads); new `requireGameOwnerByParam('id')` factory for games.ts's `:id` routes so no route paths change
- 15 routes migrated across gameLoop, games, executives, arOffice, analytics, tour, devTools; redundant in-handler `getGameState` loads swapped to the middleware's `req.gameState` (byte-identical rows), advance-week keeps its in-transaction re-read
- **New checks beyond ownership**: `execId`-belongs-to-game validation on executive actions (previously any UUID accepted); `.strict()` whitelist on `PATCH /api/game/:id` limited to the 3 fields live clients actually send (`usedFocusSlots`, `arOfficeSlotUsed`, `arOfficeSourcingType`) — money/reputation/tiers/flags no longer client-settable
- Analytics auth discrepancy resolved: routes were authenticated via mount-level `requireClerkUser` (MEDIUM unowned reads, not zero-auth); now owner-scoped

## Behavior changes (owner paths byte-identical)
Non-owner/missing-game responses unify on 404 `GAME_NOT_FOUND` (previously a mix of `{message:"Game not found"}` bodies, a 500 on advance-week, or serving the victim's data); executive action adds 404 `EXECUTIVE_NOT_FOUND`; `PATCH /api/game/:id` adds 400 `INVALID_GAME_FIELDS`; tour estimate's missing-gameId 400 body changed to `MISSING_GAME_ID`.

## Verification
- Characterization-first: commit 1 pins 12 owner-path behaviors green pre-migration; commit 2 adds 16 hardening tests — 28/28, full gate (sweep + releases + artist-signing + route-manifest) 60/60; `npm run check` clean
- Route-manifest diff: middleware arrays only, zero path changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)