### PR TITLE
docs: mark Phase 1 complete, close out security-wave backlog entries

### DIFF
--- a/DEVELOPMENT_STATUS.md
+++ b/DEVELOPMENT_STATUS.md
@@ -6,23 +6,29 @@
 
 ## 📅 Session Log — July 2, 2026 Evening (PR-16..18 services + security hardening wave)
 
-**Continued the Phase 1 service-extraction sequence (PR-16, PR-17, PR-18) and, in parallel, ran a security-focused wave off this morning's three `docs/98-research` reviews (RECORDING_SESSION, OWNERSHIP_AUTHORIZATION_SWEEP, AR_OFFICE).** Same orchestrator pattern as the day session: parallel scout subagents plus one mutating agent per checkout, worktree-isolated, characterization-test-first for every behavior-touching PR. **PRs open/green at time of writing, merges pending** — nothing below is claimed as merged.
+**Continued the Phase 1 service-extraction sequence (PR-16, PR-17, PR-18) and, in parallel, ran a security-focused wave off this morning's three `docs/98-research` reviews (RECORDING_SESSION, OWNERSHIP_AUTHORIZATION_SWEEP, AR_OFFICE).** Same orchestrator pattern as the day session: parallel scout subagents plus one mutating agent per checkout, worktree-isolated, characterization-test-first for every behavior-touching PR. **Everything below is merged to `main`** — PR-16 (#61), PR-17 (#63), PR-18 (#64), and the full security wave.
 
 **Done this session:**
 - **PR-16 saveService extraction (#61)**: `server/routes/saves.ts` **629 → 139 lines**. New `server/services/saveService.ts` (`createSave`/`restoreOverwrite`/`restoreFork`/`deleteSave`) follows the `AnalyticsService` convention. Characterization-first: `tests/endpoints/save-restore.characterization.test.ts` (11 tests, committed green against the old handler before the swap).
 - **Security wave, PR #62**: deleted the two zero-auth routes found by the reviews — `GET /api/debug/game/:gameId/revenue` and `POST /api/select-actions` (the latter already flagged as orphaned/dead in a July 1 follow-up note) — and admin-gated `POST /api/dev/markets-config`.
 - **PR-17 releasePlanningService extraction (#63)**: new `server/services/releasePlanningService.ts`; introduced a shared `server/middleware/requireGameOwner.ts` applied to all 12 `:gameId` releases routes; fixed a **live negative-marketing-budget money-credit exploit** in the release-plan handler; added a field whitelist on release create. `server/routes/releases.ts` **908 → 685 lines**.
 - **PR-18 artistService extraction (#64, stacked on #63)**: new `server/services/artistService.ts`. `sign-artist` now derives `signingCost`/stats server-side from `data/artists.json` + the discovered pool instead of trusting client-supplied values (closes A&R review finding **B1**); the sign flow is now one atomic transaction (**B2**); roster cap is enforced server-side (**B5**); the dead `signed_artists_count` flags write was deleted (**B6**); ownership checks added on sign/dialogue/mood-events/PATCH artist routes. `server/routes/artists.ts` **317 → 233 lines**.
-- **C40 fix in flight**: server-side tour-refund recompute underway on `fix/c40-tour-refund-server-side` (not part of this session's merges).
+- **C40 fixed (#66)**: server-side tour-refund recompute landed — refund is now computed from `totalCost`/`plannedCities`/`remainingCities` server-side, client-supplied `refundAmount` is ignored.
+
+**Post-merge additions (later same day):**
+- **#67**: deleted ~2000 lines of dead client components.
+- **#68**: projects create hardening (B1-B4) — server-side cost recompute, field whitelist, ownership check, atomic transaction; closed the `totalCost: $1` exploit.
+- **#69**: ownership sweep across every remaining game-scoped router (gameLoop, games, executives, arOffice, analytics, tour, devTools) — all game-scoped routes now enforce ownership via the shared `requireGameOwner` middleware; `execId` validation added; `PATCH /api/game/:id` now field-whitelisted.
+- Phase 1 plan doc moved to `COMPLETED/[COMPLETE] phase-1-server-routes-refactor-plan.md`.
 
 **Decisions made:**
 - Orchestration: parallel subagents — read-only scouts for each research review plus one mutating agent per checkout/worktree — feeding a single orchestrator that reviews before merge, same as the day-session pattern.
 - Every behavior-touching PR (16, 17, 18) gets a characterization test committed green against the OLD code first, matching the PR-15 precedent.
 
 **Open threads / next steps:**
-- Confirm PR-16/#61, PR #62 (security deletions), PR-17/#63, and PR-18/#64 all go green in CI and merge; none are merged as of this entry.
-- Land `fix/c40-tour-refund-server-side` (Comment 40) as its own PR once the stacked PR-17/PR-18 chain clears.
-- After PR-18 merges: move the Phase 1 plan doc to COMPLETED per its own next-steps note, then start Phase 2 (engine seams) planning.
+- **Manual authenticated smoke pass still owed**: new game → sign artist → create project → plan release → A&R op → advance week → save/restore.
+- **Recording review remaining items**: B5-B7 + E-items (engine RNG determinism, no-op recorded pass, silent creation-failure UX).
+- **Phase 2 (engine seams) planning can start.**
 
 ## 📅 Session Log — July 2, 2026 (Phase 1 executed: PRs 2–15, orchestrator + Opus subagent factory)
 

--- a/docs/01-planning/implementation-specs/COMPLETED/[COMPLETE] phase-1-server-routes-refactor-plan.md
+++ b/docs/01-planning/implementation-specs/COMPLETED/[COMPLETE] phase-1-server-routes-refactor-plan.md
@@ -1,12 +1,12 @@
-# [READY] Phase 1: Split `server/routes.ts` into Feature Routers + Service Layer
+# [COMPLETE] Phase 1: Split `server/routes.ts` into Feature Routers + Service Layer
 
 *Created: July 1, 2026 — planned by a code-reading architect pass against the live tree.*
-*Status: READY — execution gated on merge order: PR #38 (vitest CI) → #36 → #37 → start Phase 1.*
+*Status: COMPLETE — all 18 PRs merged to `main`.*
 *Part of the four-phase scaling arc (Phase 0: CI safety net · Phase 1: server seams · Phase 2: engine seams · Phase 3: client state ownership · Phase 4: game feel).*
 
 ## Execution status
 
-*Updated July 2, 2026. All pure-move PRs merged to `main`; `server/routes.ts` went 5,341 → 121 lines. Every PR was a pure move: byte-identical route-manifest snapshot, tsc clean, 545/545 vitest. (GitHub PR #49 was an unrelated docs PR, not part of this plan.)*
+*Completed 2026-07-02. `server/routes.ts` went 5,341 → 121 lines across 18 PRs; services extracted: `gameCreationService`, `saveService`, `releasePlanningService`, `artistService`. All pure-move PRs were byte-identical route-manifest snapshots, tsc clean, 545/545 vitest. Same day, a parallel security-hardening wave (triggered by the `docs/98-research` reviews) also merged: #62 (zero-auth deletions + admin-gate), #66 (C40 tour-refund server-side recompute), #68 (projects create hardening B1-B4), #69 (ownership sweep across every game-scoped router). (GitHub PR #49 was an unrelated docs PR, not part of this plan.)*
 
 - ✅ PR-1 — route-manifest characterization test (#39, prior session)
 - ✅ PR-2 — `bugReports.ts` router (#42)
@@ -23,9 +23,9 @@
 - ✅ PR-13 — `games.ts` router (#54)
 - ✅ PR-14 — `saves.ts` + `gameLoop.ts` routers (#55)
 - ✅ PR-15 — `gameCreationService` extraction (#57, merged)
-- ⏳ PR-16 — `saveService` extraction (#61, complete — pending merge)
-- ⏳ PR-17 — `releasePlanningService` extraction (#63, complete — pending merge)
-- ⏳ PR-18 — `artistService` extraction (#64, stacked on #63, complete — pending merge)
+- ✅ PR-16 — `saveService` extraction (#61, merged)
+- ✅ PR-17 — `releasePlanningService` extraction (#63, merged)
+- ✅ PR-18 — `artistService` extraction (#64, merged)
 
 ## 0. Ground truth (verified against the working tree)
 

--- a/docs/09-troubleshooting/technical-debt-backlog.md
+++ b/docs/09-troubleshooting/technical-debt-backlog.md
@@ -643,7 +643,7 @@ The `"{label} - Week {n}"` format is constructed independently in `client/src/st
 ---
 
 ### Comment 40: Tour cancellation trusts client-supplied refundAmount 🟡
-**Status**: 📋 **PENDING** (fix in flight)
+**Status**: ✅ **FIXED** — merged in PR #66 (2026-07-02); create-side costs additionally hardened in PR #68.
 
 The 60% tour-cancellation refund is computed entirely client-side (`client/src/components/ActiveTours.tsx`, `refundPercentage = 0.6`) and sent in the request body of `DELETE /api/projects/:id/cancel`. The server (`server/routes/projects.ts:205` since the Phase 1 route moves) applies the client's `refundAmount` to the player's money without recomputing or capping it — any refund amount can be submitted.
 
@@ -735,14 +735,14 @@ Two small leftovers from the release trace: (1) `data/balance/markets.json` `str
 
 ### By Priority
 - 🔴 Critical: 0 items (all completed! 🎉)
-- 🟡 High: 2 items (C40, C44)
+- 🟡 High: 1 item (C44)
 - 🟢 Medium: 3 items (C41, C42, C43)
 - 🔵 Low: 3 items (C26, C32, C45)
 
 ### By Status
-- ✅ Completed: 37 items (82.2%)
+- ✅ Completed: 38 items (84.4%)
 - 🚧 In Progress: 0 items (0%)
-- 📋 Pending: 8 items (17.8%)
+- 📋 Pending: 7 items (15.6%)
 
 ---
 

--- a/docs/98-research/OWNERSHIP_AUTHORIZATION_SWEEP_2026-07-02.md
+++ b/docs/98-research/OWNERSHIP_AUTHORIZATION_SWEEP_2026-07-02.md
@@ -2,6 +2,9 @@
 **Date**: July 2, 2026 · **Reviewer**: Claude (read-only session) · **Branch reviewed**: `claude/onboarding-jira33`
 **Scope**: Every HTTP route across all 16 feature routers + the `server/routes.ts` registry (84 handlers total). Verdict per route on whether it enforces that the caller owns the game/entity it touches. Prompted by finding B1 of the recording-session review (projects router had zero ownership checks). Findings below were located by audit agents and the high-severity ones independently re-verified in source.
 
+## Resolution status (2026-07-02, same day)
+All buckets below closed same day: CRITICAL (no-auth routes) → fixed in **#62**. HIGH mutations → releases in **#63**, artists in **#64**, projects in **#66**/**#68**, all remaining routers (gameLoop/games/executives/arOffice/analytics/tour/devTools) in **#69**. MEDIUM unowned reads → **#63**/**#69**. The two "correctly owned" reference patterns cited below are now unified behind the shared `requireGameOwner` middleware rather than ad hoc per-router checks.
+
 ## Executive summary
 This is a **systemic broken-object-level-authorization (IDOR) problem, not an isolated bug.** `requireClerkUser` proves the caller is *a* logged-in user but performs **no game-ownership check**; there is **no shared ownership helper**; each router re-implements the check inline, and roughly half forget it. **~35 of 84 routes that touch game-scoped data do not verify ownership.** An authenticated attacker who knows (or guesses — they're UUIDs, but they leak via the client, saves, and error messages) another player's `gameId` can read and mutate that player's entire game: money, reputation, artists, projects, releases, executives, focus slots. Two routes need no authentication at all.
 


### PR DESCRIPTION
## Summary
- Phase 1 plan doc moved to `COMPLETED/[COMPLETE] phase-1-server-routes-refactor-plan.md` with all 18 PRs marked merged and a completion note (routes.ts 5,341 → 121; four services extracted)
- DEVELOPMENT_STATUS evening entry updated: everything merged, post-merge additions (#67, #68, #69), open threads narrowed to the smoke pass, recording B5-B7/E-items, and Phase 2 planning
- Backlog: C40 marked fixed (#66, hardened further in #68), summary stats updated
- Ownership sweep doc gets a same-day resolution-status section mapping every severity bucket to its fixing PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)