### PR TITLE
fix(engine): seed all gameplay randomness (Phase 2 PR-1)

### DIFF
--- a/shared/engine/FinancialSystem.ts
+++ b/shared/engine/FinancialSystem.ts
@@ -951,7 +951,8 @@ export class FinancialSystem {
 
         if (weeksSinceRelease <= streamGrowthDuration) {
           // Stream growth phase: 20-40% increase instead of decay
-          const growthRate = 1.2 + (Math.random() * 0.2); // 1.2x to 1.4x growth
+          // Seeded RNG: getRandom(0, 1) is uniform [0,1), equivalent to Math.random() (Phase 2 PR-1)
+          const growthRate = 1.2 + (this.getRandom(0, 1) * 0.2); // 1.2x to 1.4x growth
           const growthDecay = Math.pow(growthRate, weeksSinceRelease - 1);
           weeklyStreams = initialStreams * growthDecay * reputationBonus * accessBonus * ongoingFactor;
         } else {

--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -582,8 +582,8 @@ export class GameEngine {
           delete flags.ar_office_start_week;
         }
 
-        // Add discovery timestamp for tracking
-        flags.ar_office_discovery_time = new Date().toISOString();
+        // Add discovery timestamp for tracking (sim-time week for save-restore reproducibility — Phase 2 PR-1 / D2)
+        flags.ar_office_discovery_time = this.gameState.currentWeek;
         flags.ar_office_sourcing_type = sourcingType;
 
         // Enhanced artist selection with better validation and error handling
@@ -736,7 +736,7 @@ export class GameEngine {
                 talent: picked.talent || 0,
                 popularity: picked.popularity || 0,
                 genre: picked.genre || null,
-                discoveryTime: new Date().toISOString(),
+                discoveryTime: this.gameState.currentWeek, // sim-time week for save-restore reproducibility (Phase 2 PR-1 / D2)
                 sourcingType: sourcingType,
                 genreUsed: genreUsed || null // Track which genre filter was used
               });
@@ -2490,11 +2490,6 @@ export class GameEngine {
       throw new Error(`Cannot create song: missing gameId (${gameId}) or artistId (${artistId})`);
     }
 
-    // Enhanced metadata with economic factors
-    const baseQuality = 40 + Math.floor(this.getRandom(0, 20));
-    const producerBonus = this.gameData.getProducerTierSystemSync()[producerTier]?.quality_bonus || 0;
-    const timeBonus = this.gameData.getTimeInvestmentSystemSync()[timeInvestment]?.quality_bonus || 0;
-    
     // Don't include 'id' field - let database generate it
     return {
       title: randomName,
@@ -2625,7 +2620,8 @@ export class GameEngine {
     const baseVarianceRange = 35 - (30 * (combinedSkill / 100)); // 35% down to 5%
     
     // Check for outlier events (10% chance)
-    const outlierRoll = Math.random();
+    // Seeded RNG: getRandom(0, 1) is uniform [0,1), equivalent to Math.random() (Phase 2 PR-1)
+    const outlierRoll = this.getRandom(0, 1);
     let variance: number;
     let outlierType = '';
     
@@ -3693,7 +3689,8 @@ export class GameEngine {
       // Store pre-calculated cities - NO MANUAL CALCULATIONS
       const preCalculatedCities = detailedBreakdown.cities.map((city: any, index: number) => {
         // Add variance to actual tour performance (±20% attendance variance)
-        const varianceFactor = 0.8 + (Math.random() * 0.4);
+        // Seeded RNG: getRandom(0, 1) is uniform [0,1), equivalent to Math.random() (Phase 2 PR-1)
+        const varianceFactor = 0.8 + (this.getRandom(0, 1) * 0.4);
         const actualSellThrough = city.sellThroughRate * varianceFactor;
         const actualRevenue = Math.round(city.totalRevenue * varianceFactor);
 


### PR DESCRIPTION
## Summary
PR-1 of the Phase 2 engine-seams plan — every gameplay-affecting random draw now flows through the seeded RNG:
- Song-quality outlier roll (`game-engine.ts:2628`) and tour attendance variance (`:3696`): `Math.random()` → `this.getRandom(0, 1)` (verified equivalent — uniform [0,1))
- **Plus one violation the plan missed**: breakthrough stream-growth in `FinancialSystem.ts:954` (reachable from `advanceWeek` via `calculateStreamingOutcome`)
- Deleted the dead block at `:2494–2496` that consumed a seeded draw for nothing (sanctioned RNG-stream shift, review finding E2)
- A&R `discoveryTime` flags switched from wall-clock ISO strings to the sim week number (D2) — full reader audit found no client rendering and only pass-through server readers
- ChartService: engine path already seeded (`:4071`); the unseeded `Math.random()` in the releases.ts GET-preview path is out of `advanceWeek` and intentionally left (flagged for PR-7/10)

## Verification
- `npm run check` clean; full suite 640/640 (no test pinned RNG-dependent values, so the sanctioned stream shift broke nothing)
- Distribution sanity (N=200,000, seeded engine): breakout 5.06% / critical 5.03% (targets 5/5), tour variance exactly bounded [0.8, 1.2), same seed ⇒ byte-identical sequences, different seeds differ
- This unblocks PR-2 (golden-master advanceWeek harness), which guards all subsequent extractions

🤖 Generated with [Claude Code](https://claude.com/claude-code)