### PR TITLE
fix(ar-office): pure-read artists endpoint (Phase 2 PR-4)

### DIFF
--- a/server/routes/arOffice.ts
+++ b/server/routes/arOffice.ts
@@ -126,7 +126,27 @@ const router = Router();
     }
   });
 
-  // Get discovered artists for A&R (returns the persisted pick when operation is complete)
+  // Get discovered artists for A&R.
+  //
+  // PURE READ (Phase 2 PR-4): this endpoint reads the canonical
+  // `flags.ar_office_discovered_artists` array, enriches each entry from the
+  // game-data artist catalog, filters out artists already signed to this game
+  // by name, and returns the result. It performs NO storage writes and uses no
+  // RNG.
+  //
+  // Removed in PR-4 (were a GET with side effects, breaking save
+  // reproducibility): the in-GET migration write that copied the legacy
+  // singular flags into the array, the legacy singular-key response branch, and
+  // the `Math.random()` fallback that persisted a random artist back to flags.
+  //
+  // TODO(PR-12): the engine still writes the legacy singular keys
+  // (ar_office_discovered_artist_id / _info, game-engine.ts ~:748) and
+  // artistService still cleans them up on sign. They are now write-only cruft
+  // as far as this endpoint is concerned; the dead-code sweep removes the
+  // engine writes + the client fallback reader. Until then a legacy-only save
+  // (singular keys set, array absent) returns an empty list here — the client's
+  // own flag fallback (gameStore.loadDiscoveredArtists) still surfaces the
+  // singular artist locally, so no user-visible regression.
   router.get('/api/game/:gameId/ar-office/artists', requireClerkUser, requireGameOwner, async (req, res) => {
     try {
       const { gameId } = req.params;
@@ -163,233 +183,89 @@ const router = Router();
         });
       }
 
-      // Enhanced flags reading and validation
       const flags = (gameState.flags || {}) as any;
-      console.log('[A&R DEBUG] Backend: Full flags object:', JSON.stringify(flags, null, 2));
 
-      // Check for new discovered artists array (preferred method)
-      let discoveredArtistsArray = flags.ar_office_discovered_artists || [];
-      const legacyArtistId = flags.ar_office_discovered_artist_id; // backwards compatibility
-      const legacyArtistInfo = flags.ar_office_discovered_artist_info;
-
+      // Canonical source of truth: the discovered-artists array.
+      const discoveredArtistsArray = flags.ar_office_discovered_artists || [];
       console.log('[A&R DEBUG] Backend: Discovered artists array:', discoveredArtistsArray.length, 'artists');
-      console.log('[A&R DEBUG] Backend: Legacy artist ID:', legacyArtistId);
 
-      // Migrate legacy format to new array format if needed
-      if (legacyArtistId && legacyArtistInfo && discoveredArtistsArray.length === 0) {
-        console.log('[A&R DEBUG] Backend: Migrating legacy artist to array format');
-        discoveredArtistsArray = [{
-          id: legacyArtistId,
-          name: legacyArtistInfo.name,
-          archetype: legacyArtistInfo.archetype,
-          talent: legacyArtistInfo.talent,
-          popularity: legacyArtistInfo.popularity,
-          genre: legacyArtistInfo.genre,
-          discoveryTime: flags.ar_office_discovery_time,
-          sourcingType: flags.ar_office_sourcing_type
-        }];
-
-        // Update flags with migrated data
-        flags.ar_office_discovered_artists = discoveredArtistsArray;
-        await storage.updateGameState(gameId, { flags });
-        console.log('[A&R DEBUG] Backend: Migration complete, saved to database');
-      }
-
-      if (discoveredArtistsArray.length > 0) {
-        // Return all discovered artists
-        let allGameArtists;
-        try {
-          allGameArtists = await serverGameData.getAllArtists();
-          console.log('[A&R DEBUG] Backend: Loaded', allGameArtists?.length, 'total game artists');
-        } catch (artistLoadError) {
-          console.error('[A&R] Failed to load game artists:', artistLoadError);
-          // Return the discovered artist data we have in flags without enrichment
-          return res.json({
-            artists: discoveredArtistsArray.map((a: any) => ({
-              ...a,
-              isFallback: true,
-              loadError: 'Could not enrich with full artist data'
-            })),
-            metadata: {
-              totalDiscovered: discoveredArtistsArray.length,
-              isDiscoveredCollection: true,
-              enrichmentFailed: true,
-              discoveryTime: flags.ar_office_discovery_time,
-              sourcingType: flags.ar_office_sourcing_type
-            }
-          });
-        }
-
-        // Filter out artists already signed to this game by name
-        const signedForGame = await storage.getArtistsByGame(gameId);
-        const signedNames = new Set((signedForGame || []).map(a => String(a.name || '').toLowerCase()))
-        const filteredDiscovered = discoveredArtistsArray.filter((a: any) => !signedNames.has(String(a?.name || '').toLowerCase()));
-
-        const discoveredArtists = filteredDiscovered.map((discoveredArtist: any) => {
-          // First try to find the full artist data
-          const fullArtist = allGameArtists.find((a: any) => a.id === discoveredArtist.id);
-
-          if (fullArtist) {
-            // Return full artist data with discovery metadata
-            return {
-              ...fullArtist,
-              discoveryTime: discoveredArtist.discoveryTime,
-              discoveredVia: discoveredArtist.sourcingType
-            };
-          } else {
-            // Fallback to stored artist info if full data not found
-            return {
-              id: discoveredArtist.id,
-              name: discoveredArtist.name || 'Unknown Artist',
-              archetype: discoveredArtist.archetype || 'Unknown',
-              talent: discoveredArtist.talent || 0,
-              popularity: discoveredArtist.popularity || 0,
-              genre: discoveredArtist.genre || null,
-              discoveryTime: discoveredArtist.discoveryTime,
-              discoveredVia: discoveredArtist.sourcingType,
-              isFallback: true
-            };
+      // No discovered artists -> empty list (no legacy branch, no random write).
+      if (discoveredArtistsArray.length === 0) {
+        console.log('[A&R DEBUG] Backend: No discovered artists, returning empty list');
+        return res.json({
+          artists: [],
+          metadata: {
+            noPersistedResult: true,
+            hasFlags: Object.keys(flags).length > 0
           }
         });
+      }
 
-        console.log('[A&R DEBUG] Backend: Returning', discoveredArtists.length, 'discovered artists');
-
+      // Enrich each discovered record from the game-data catalog.
+      let allGameArtists;
+      try {
+        allGameArtists = await serverGameData.getAllArtists();
+        console.log('[A&R DEBUG] Backend: Loaded', allGameArtists?.length, 'total game artists');
+      } catch (artistLoadError) {
+        console.error('[A&R] Failed to load game artists:', artistLoadError);
+        // Return the discovered artist data we have in flags without enrichment
         return res.json({
-          artists: discoveredArtists,
+          artists: discoveredArtistsArray.map((a: any) => ({
+            ...a,
+            isFallback: true,
+            loadError: 'Could not enrich with full artist data'
+          })),
           metadata: {
-            totalDiscovered: discoveredArtists.length,
+            totalDiscovered: discoveredArtistsArray.length,
             isDiscoveredCollection: true,
+            enrichmentFailed: true,
             discoveryTime: flags.ar_office_discovery_time,
             sourcingType: flags.ar_office_sourcing_type
           }
         });
-      } else if (legacyArtistId) {
-        // Backwards compatibility: handle single legacy artist
-        let allArtists;
-        try {
-          allArtists = await serverGameData.getAllArtists();
-          console.log('[A&R DEBUG] Backend: Loaded', allArtists?.length, 'total artists for legacy mode');
-        } catch (artistLoadError) {
-          console.error('[A&R] Failed to load game artists for legacy mode:', artistLoadError);
-          // Return fallback artist info if we can't load full data
-          if (legacyArtistInfo) {
-            return res.json({
-              artists: [{
-                id: legacyArtistId,
-                name: legacyArtistInfo.name || 'Unknown Artist',
-                archetype: legacyArtistInfo.archetype || 'Unknown',
-                talent: legacyArtistInfo.talent || 50,
-                popularity: legacyArtistInfo.popularity || 0,
-                genre: legacyArtistInfo.genre || null,
-                isFallback: true,
-                loadError: 'Could not load full artist data'
-              }],
-              metadata: {
-                isLegacyFallback: true,
-                enrichmentFailed: true,
-                discoveryTime: flags.ar_office_discovery_time,
-                sourcingType: flags.ar_office_sourcing_type
-              }
-            });
-          }
-          // If no legacy info available, return empty
-          return res.json({
-            artists: [],
-            metadata: {
-              error: 'Could not load artist data',
-              enrichmentFailed: true
-            }
-          });
-        }
-
-        const artist = (allArtists || []).find((a: any) => a.id === legacyArtistId);
-        console.log('[A&R DEBUG] Backend: Found legacy artist for ID:', artist?.name || 'none');
-
-        if (artist) {
-          // Validate artist has all required fields
-          const requiredFields = ['id', 'name', 'archetype', 'talent', 'popularity'];
-          const missingFields = requiredFields.filter(field => (artist as any)[field] === undefined || (artist as any)[field] === null);
-
-          if (missingFields.length > 0) {
-            console.warn('[A&R DEBUG] Backend: Artist missing required fields:', missingFields);
-            // Add fallback values for missing fields
-            const enrichedArtist = {
-              ...artist,
-              talent: artist.talent ?? 50,
-              popularity: artist.popularity ?? 0,
-              archetype: artist.archetype ?? 'Unknown'
-            };
-            return res.json({
-              artists: [enrichedArtist],
-              metadata: {
-                missingFields,
-                enriched: true,
-                discoveryTime: flags.ar_office_discovery_time
-              }
-            });
-          }
-
-          return res.json({
-            artists: [artist],
-            metadata: {
-              discoveryTime: flags.ar_office_discovery_time,
-              sourcingType: flags.ar_office_sourcing_type,
-              isOriginalDiscovery: true,
-              discoveredArtistId: legacyArtistId
-            }
-          });
-        } else {
-          // Artist ID not found in current data - fallback mechanism
-          console.warn('[A&R DEBUG] Backend: Artist ID not found in current data, generating fallback');
-
-          // Select a new random artist as fallback
-          const unsignedArtists = (allArtists || []).filter((a: any) => !a.signed);
-          if (unsignedArtists.length > 0) {
-            const fallbackArtist = unsignedArtists[Math.floor(Math.random() * unsignedArtists.length)];
-
-            // Update flags with new artist ID
-            const updatedFlags = { ...flags, ar_office_discovered_artist_id: fallbackArtist.id };
-            await storage.updateGameState(gameId, { flags: updatedFlags });
-
-            console.log('[A&R DEBUG] Backend: Updated flags with fallback artist:', fallbackArtist.id);
-
-            return res.json({
-              artists: [fallbackArtist],
-              metadata: {
-                isFallback: true,
-                isOriginalDiscovery: false,
-                originalDiscoveredArtistId: legacyArtistId,
-                discoveredArtistId: fallbackArtist.id,
-                fallbackReason: 'Original artist not found in current data',
-                discoveryTime: flags.ar_office_discovery_time,
-                sourcingType: flags.ar_office_sourcing_type,
-                warning: 'The artist shown differs from the one in the weekly summary due to data changes'
-              }
-            });
-          }
-
-          console.warn('[A&R DEBUG] Backend: No unsigned artists available for fallback');
-          return res.json({
-            artists: [],
-            metadata: {
-              error: 'Artist not found and no fallback available',
-              isOriginalDiscovery: false,
-              originalDiscoveredArtistId: legacyArtistId,
-              discoveredArtistId: null,
-              fallbackReason: 'Original artist not found and no unsigned artists available',
-              warning: 'No artist available - the weekly summary may show a different result'
-            }
-          });
-        }
       }
 
-      // No persisted result yet (operation not completed properly) - return empty list
-      console.log('[A&R DEBUG] Backend: No persisted artist, returning empty list');
+      // Filter out artists already signed to this game by name
+      const signedForGame = await storage.getArtistsByGame(gameId);
+      const signedNames = new Set((signedForGame || []).map(a => String(a.name || '').toLowerCase()))
+      const filteredDiscovered = discoveredArtistsArray.filter((a: any) => !signedNames.has(String(a?.name || '').toLowerCase()));
+
+      const discoveredArtists = filteredDiscovered.map((discoveredArtist: any) => {
+        // First try to find the full artist data
+        const fullArtist = allGameArtists.find((a: any) => a.id === discoveredArtist.id);
+
+        if (fullArtist) {
+          // Return full artist data with discovery metadata
+          return {
+            ...fullArtist,
+            discoveryTime: discoveredArtist.discoveryTime,
+            discoveredVia: discoveredArtist.sourcingType
+          };
+        } else {
+          // Fallback to stored artist info if full data not found
+          return {
+            id: discoveredArtist.id,
+            name: discoveredArtist.name || 'Unknown Artist',
+            archetype: discoveredArtist.archetype || 'Unknown',
+            talent: discoveredArtist.talent || 0,
+            popularity: discoveredArtist.popularity || 0,
+            genre: discoveredArtist.genre || null,
+            discoveryTime: discoveredArtist.discoveryTime,
+            discoveredVia: discoveredArtist.sourcingType,
+            isFallback: true
+          };
+        }
+      });
+
+      console.log('[A&R DEBUG] Backend: Returning', discoveredArtists.length, 'discovered artists');
+
       return res.json({
-        artists: [],
+        artists: discoveredArtists,
         metadata: {
-          noPersistedResult: true,
-          hasFlags: Object.keys(flags).length > 0
+          totalDiscovered: discoveredArtists.length,
+          isDiscoveredCollection: true,
+          discoveryTime: flags.ar_office_discovery_time,
+          sourcingType: flags.ar_office_sourcing_type
         }
       });
     } catch (error) {

--- a/tests/endpoints/ar-office-artists.characterization.test.ts
+++ b/tests/endpoints/ar-office-artists.characterization.test.ts
@@ -250,7 +250,7 @@ describe('GET /api/game/:gameId/ar-office/artists — stable behavior', () => {
 // "(post-pure-read)" block below. Kept commented (not deleted) so the
 // sanctioned behavior change is explicit in the diff.
 // ===========================================================================
-describe('LEGACY paths — CURRENT behavior (pre-pure-read; flipped by Commit 2)', () => {
+describe.skip('LEGACY paths — CURRENT behavior (pre-pure-read; flipped by Commit 2)', () => {
   it('(c) legacy-only flags: migrates singular keys into the array, persists, and returns the enriched artist', async () => {
     const gameId = await seedGame({
       ownerId: TEST_USER_ID,
@@ -313,7 +313,7 @@ describe('LEGACY paths — CURRENT behavior (pre-pure-read; flipped by Commit 2)
 // handler: legacy singular keys are IGNORED (no migration, no random write),
 // and a GET never mutates flags.
 // ===========================================================================
-describe.skip('LEGACY paths — pure-read behavior (post-pure-read)', () => {
+describe('LEGACY paths — pure-read behavior (post-pure-read)', () => {
   it('(c) legacy-only flags: singular keys are IGNORED → empty list, flags UNCHANGED', async () => {
     const legacyFlags = {
       ar_office_discovered_artist_id: KNOWN_JSON_ID,

--- a/tests/endpoints/ar-office-artists.characterization.test.ts
+++ b/tests/endpoints/ar-office-artists.characterization.test.ts
@@ -1,0 +1,359 @@
+// @vitest-environment node
+/**
+ * A&R discovered-artists GET characterization test (Phase 2, PR-4).
+ *
+ * The GET /api/game/:gameId/ar-office/artists handler had no HTTP-layer
+ * coverage. It currently carries three response paths plus a state-mutating
+ * fallback:
+ *   - the canonical `flags.ar_office_discovered_artists` array (enriched from
+ *     data/artists.json, filtered by signed-name),
+ *   - an in-GET MIGRATION WRITE that copies the legacy singular keys
+ *     (ar_office_discovered_artist_id/_info) into the array and persists it,
+ *   - a legacy singular-key branch, and
+ *   - a `Math.random()` FALLBACK that picks a random artist and WRITES it back
+ *     to flags (a GET with side effects + unseeded RNG).
+ *
+ * This file pins the observable behavior of the CURRENT handler BEFORE it is
+ * collapsed into a pure read over the canonical array (PR-4 Commit 2). The
+ * blocks tagged "(post-pure-read)" only pass AFTER Commit 2 lands; they assert
+ * the new pure-read behavior (legacy-only → empty, no-flags → empty + NO
+ * write). Both the pre- and post- pins live in this one file per the PR-17/18
+ * pattern; the pre-pins for the migration/legacy/random paths are commented out
+ * (not deleted) after the flip so the sanctioned behavior change is explicit.
+ *
+ * It drives the real arOffice router over supertest against the real test
+ * Postgres (Docker, localhost:5433). Clerk auth is mocked to a fixed test user;
+ * server/db is mocked to a non-SSL pool pointed at the test DB (the production
+ * pool forces SSL, which the local test container rejects).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+// Must be set before any module that reads DATABASE_URL at import time.
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+// Fixed clerk id / resolved userId for the mocked authenticated user (owner).
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+// A second user, used for cross-tenant assertions.
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+// --- Mock server/db with a non-SSL pool at the test DB. storage.ts imports
+//     `db` from ./db, and requireGameOwner imports `db` from ./db too, so this
+//     single mock reroutes storage + middleware + handler.
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+// --- Mock server/auth so requireClerkUser injects the fixed test userId and
+//     everything else is a passthrough. The injected userId is mutable so
+//     individual tests can impersonate a second user for cross-tenant checks.
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import { gameStates, users, artists } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import arOfficeRouter from '../../server/routes/arOffice';
+
+let app: Express;
+
+// A known JSON artist (data/artists.json → art_1 Nova Sterling), used to assert
+// the enrichment shape of the canonical branch.
+const KNOWN_JSON_ID = 'art_1';
+
+/** A canonical discovered record, as the engine appends it to the array. */
+const DISCOVERED_ART_1 = {
+  id: KNOWN_JSON_ID,
+  name: 'Nova Sterling',
+  archetype: 'Visionary',
+  talent: 85,
+  popularity: 10,
+  genre: 'Pop',
+  discoveryTime: 3,
+  sourcingType: 'active',
+  genreUsed: null,
+};
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(arOfficeRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+/** Seed a game owned by ownerId with the given flags. Returns the gameId. */
+async function seedGame(opts: {
+  ownerId: string;
+  flags?: Record<string, any>;
+  arOfficeSlotUsed?: boolean;
+}) {
+  const gameId = crypto.randomUUID();
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: opts.ownerId,
+    currentWeek: 5,
+    money: 100000,
+    reputation: 0,
+    creativeCapital: 5,
+    arOfficeSlotUsed: opts.arOfficeSlotUsed ?? false,
+    flags: opts.flags ?? {},
+  });
+  return gameId;
+}
+
+/** Insert a signed artist row (used to exercise signed-name exclusion). */
+async function seedSignedArtist(gameId: string, name: string) {
+  const artistId = crypto.randomUUID();
+  await db.insert(artists).values({
+    id: artistId,
+    gameId,
+    name,
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood: 50,
+    energy: 50,
+  });
+  return artistId;
+}
+
+async function readFlags(gameId: string) {
+  const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+  return (gs?.flags ?? {}) as any;
+}
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+// ===========================================================================
+// Behavior stable across the flip (pins hold pre- AND post-pure-read).
+// ===========================================================================
+describe('GET /api/game/:gameId/ar-office/artists — stable behavior', () => {
+  it('(a) canonical array: enriches from data/artists.json with discovery metadata', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      flags: {
+        ar_office_discovered_artists: [DISCOVERED_ART_1],
+        ar_office_discovery_time: 3,
+        ar_office_sourcing_type: 'active',
+      },
+    });
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.artists)).toBe(true);
+    expect(res.body.artists).toHaveLength(1);
+
+    const a = res.body.artists[0];
+    // Enriched from the full JSON record (talent 85, weeklyCost 1200, bio, etc.)
+    expect(a.id).toBe(KNOWN_JSON_ID);
+    expect(a.name).toBe('Nova Sterling');
+    expect(a.talent).toBe(85);
+    expect(a.weeklyCost).toBe(1200);
+    expect(a.signingCost).toBe(8000);
+    // Discovery metadata merged in from the discovered record.
+    expect(a.discoveryTime).toBe(3);
+    expect(a.discoveredVia).toBe('active');
+
+    expect(res.body.metadata.isDiscoveredCollection).toBe(true);
+    expect(res.body.metadata.totalDiscovered).toBe(1);
+  });
+
+  it('(a2) canonical array: excludes artists already signed to this game by name', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      flags: { ar_office_discovered_artists: [DISCOVERED_ART_1] },
+    });
+    // Sign an artist with the same (case-insensitive) name as the discovered one.
+    await seedSignedArtist(gameId, 'nova sterling');
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.artists).toHaveLength(0);
+  });
+
+  it('(b) empty pool: no discovered flags → empty list', async () => {
+    const gameId = await seedGame({ ownerId: TEST_USER_ID, flags: {} });
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.artists).toEqual([]);
+  });
+
+  it('operation active: returns empty list with operationActive metadata', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      arOfficeSlotUsed: true,
+      flags: { arOfficeSourcingType: 'active' },
+    });
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.artists).toEqual([]);
+    expect(res.body.metadata.operationActive).toBe(true);
+  });
+
+  it('(e) cross-tenant: 404 GAME_NOT_FOUND when the game belongs to another user', async () => {
+    const gameId = await seedGame({
+      ownerId: OTHER_USER_ID,
+      flags: { ar_office_discovered_artists: [DISCOVERED_ART_1] },
+    });
+    currentUserId = TEST_USER_ID; // impersonate non-owner
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('GAME_NOT_FOUND');
+  });
+});
+
+// ===========================================================================
+// CURRENT (pre-pure-read) behavior for the legacy paths. These pins document
+// the migration write, the legacy singular branch, and the random-write
+// fallback. Commit 2 FLIPS them — after the flip they are replaced by the
+// "(post-pure-read)" block below. Kept commented (not deleted) so the
+// sanctioned behavior change is explicit in the diff.
+// ===========================================================================
+describe('LEGACY paths — CURRENT behavior (pre-pure-read; flipped by Commit 2)', () => {
+  it('(c) legacy-only flags: migrates singular keys into the array, persists, and returns the enriched artist', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      flags: {
+        ar_office_discovered_artist_id: KNOWN_JSON_ID,
+        ar_office_discovered_artist_info: {
+          name: 'Nova Sterling',
+          archetype: 'Visionary',
+          talent: 85,
+          popularity: 10,
+          genre: 'Pop',
+        },
+        ar_office_discovery_time: 3,
+        ar_office_sourcing_type: 'active',
+      },
+    });
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.artists).toHaveLength(1);
+    expect(res.body.artists[0].name).toBe('Nova Sterling');
+
+    // MIGRATION WRITE: the singular keys were copied into the array and persisted.
+    const flags = await readFlags(gameId);
+    expect(Array.isArray(flags.ar_office_discovered_artists)).toBe(true);
+    expect(flags.ar_office_discovered_artists).toHaveLength(1);
+    expect(flags.ar_office_discovered_artists[0].id).toBe(KNOWN_JSON_ID);
+  });
+
+  it('(d) unknown legacy id, NO info: Math.random() fallback picks an artist AND writes it back to flags', async () => {
+    // A legacy id that does NOT exist in data/artists.json, with NO _info blob
+    // (so the migration branch is skipped), falls through to the legacy branch
+    // and then the Math.random() fallback, which WRITES a new random id back to
+    // flags — a GET with a side effect. Pinned loosely: status + that a write
+    // occurred (the artist itself is random and not asserted).
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      flags: {
+        ar_office_discovered_artist_id: 'art_does_not_exist',
+      },
+    });
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    // A random artist was returned (pinned loosely: exactly one, and it is a fallback).
+    expect(res.body.artists).toHaveLength(1);
+    expect(res.body.metadata.isFallback).toBe(true);
+
+    // SIDE EFFECT: the fallback wrote a (random) artist id back to flags.
+    const flags = await readFlags(gameId);
+    expect(flags.ar_office_discovered_artist_id).toBeTruthy();
+    expect(flags.ar_office_discovered_artist_id).not.toBe('art_does_not_exist');
+  });
+});
+
+// ===========================================================================
+// Post-pure-read behavior (Commit 2). These assert the collapsed pure-read
+// handler: legacy singular keys are IGNORED (no migration, no random write),
+// and a GET never mutates flags.
+// ===========================================================================
+describe.skip('LEGACY paths — pure-read behavior (post-pure-read)', () => {
+  it('(c) legacy-only flags: singular keys are IGNORED → empty list, flags UNCHANGED', async () => {
+    const legacyFlags = {
+      ar_office_discovered_artist_id: KNOWN_JSON_ID,
+      ar_office_discovered_artist_info: {
+        name: 'Nova Sterling',
+        archetype: 'Visionary',
+        talent: 85,
+        popularity: 10,
+        genre: 'Pop',
+      },
+      ar_office_discovery_time: 3,
+      ar_office_sourcing_type: 'active',
+    };
+    const gameId = await seedGame({ ownerId: TEST_USER_ID, flags: legacyFlags });
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.artists).toEqual([]);
+
+    // NO migration write: flags are byte-identical to what was seeded.
+    const flags = await readFlags(gameId);
+    expect(flags).toEqual(legacyFlags);
+    expect(flags.ar_office_discovered_artists).toBeUndefined();
+  });
+
+  it('(d) unknown legacy id, NO info: no random write → empty list, flags UNCHANGED', async () => {
+    const legacyFlags = {
+      ar_office_discovered_artist_id: 'art_does_not_exist',
+    };
+    const gameId = await seedGame({ ownerId: TEST_USER_ID, flags: legacyFlags });
+
+    const res = await request(app).get(`/api/game/${gameId}/ar-office/artists`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.artists).toEqual([]);
+
+    // NO random write: the singular id is untouched.
+    const flags = await readFlags(gameId);
+    expect(flags).toEqual(legacyFlags);
+    expect(flags.ar_office_discovered_artist_id).toBe('art_does_not_exist');
+  });
+});


### PR DESCRIPTION
## Summary
PR-4 of the Phase 2 plan — `GET /api/game/:gameId/ar-office/artists` is now a pure read over the canonical `ar_office_discovered_artists` array (arOffice.ts 408 → 284):
- Deleted: the in-GET migration write, the legacy singular-key branch, and the `Math.random()` fallback that **wrote a random artist to flags on a GET** (review findings B3/E4)
- Legacy singular keys: option (a) — endpoint ignores them; the engine still writes them and the client keeps its local fallback reader (a legacy-only save still displays its artist via the client fallback, so no user-visible regression). Removing the writes end-to-end is PR-12's job (would flip the golden master + require client edits, both out of scope here) — TODO left on the handler
- Sanctioned behavior change: legacy-only flags now → empty list with **flags untouched in DB** (previously migrated + persisted); unknown-id-no-info now → empty list, **no write** (previously random artist written)

## Verification
- Characterization-first: 5 stable pins + 2 legacy pins committed green against old code, then flipped; pre-flip pins kept as an explicit `describe.skip` block documenting the change
- Golden master 8/8 **byte-identical**; route-manifest unchanged; artist-signing characterization green (legacy cleanup path unaffected); `npm run check` clean; gate run 32 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)