### PR TITLE
refactor(engine): extract AROfficeProcessor (Phase 2 PR-5)

### DIFF
--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -19,6 +19,8 @@ import { AchievementsEngine } from './AchievementsEngine';
 import type { WeekSummary, ChartUpdate, GameChange, EventOccurrence, GameArtist } from '../types/gameTypes';
 import { ArtistChangeHelpers } from '../types/gameTypes';
 import { getSeasonFromWeek, getSeasonalMultiplier } from '../utils/seasonalCalculations';
+import { AROfficeProcessor } from './processors/AROfficeProcessor';
+import type { WeekContext } from './processors/types';
 
 // Re-export WeekSummary for backward compatibility
 export type { WeekSummary } from '../types/gameTypes';
@@ -547,281 +549,27 @@ export class GameEngine {
    * and update the flags accordingly. Client code should check the response
    * metadata to detect when fallback artists are used.
    */
+  /**
+   * Builds the shared WeekContext passed to every extracted engine processor
+   * (Phase 2 engine seams). PRs 6-11 reuse this helper for their processors.
+   *
+   * `getRandom` is bound as an arrow over `this` so processors draw from the
+   * engine's single seeded RNG stream — preserving draw ORDER, which is behavior
+   * (see processors/types.ts). Do not hand processors a fresh RNG.
+   */
+  private weekContext(summary: WeekSummary, dbTransaction?: any): WeekContext {
+    return {
+      gameState: this.gameState,
+      summary,
+      gameData: this.gameData,
+      storage: this.storage,
+      getRandom: (min: number, max: number) => this.getRandom(min, max),
+      dbTransaction
+    };
+  }
+
   private async processAROfficeWeekly(summary: WeekSummary, dbTransaction?: any): Promise<void> {
-    try {
-      const slotUsed = (this.gameState as any).arOfficeSlotUsed;
-      const sourcingType = (this.gameState as any).arOfficeSourcingType;
-      const primaryGenre = (this.gameState as any).arOfficePrimaryGenre;
-      const secondaryGenre = (this.gameState as any).arOfficeSecondaryGenre;
-      console.log('[A&R DEBUG] Processing A&R operation:', {
-        slotUsed,
-        sourcingType,
-        primaryGenre,
-        secondaryGenre,
-        gameId: this.gameState.id,
-        currentWeek: this.gameState.currentWeek
-      });
-
-      if (slotUsed) {
-        // Complete the one-week operation: free the slot, clear start time and genre parameters
-        (this.gameState as any).arOfficeSlotUsed = false;
-        (this.gameState as any).arOfficeOperationStart = null;
-        (this.gameState as any).arOfficePrimaryGenre = null;
-        (this.gameState as any).arOfficeSecondaryGenre = null;
-
-        // Enhanced flags initialization and management
-        let flags = (this.gameState.flags || {}) as any;
-        if (!flags || typeof flags !== 'object') {
-          console.log('[A&R DEBUG] Initializing flags object');
-          flags = {};
-          this.gameState.flags = flags;
-        }
-
-        // Clear start-week flag used by server validation
-        if ('ar_office_start_week' in flags) {
-          delete flags.ar_office_start_week;
-        }
-
-        // Add discovery timestamp for tracking (sim-time week for save-restore reproducibility — Phase 2 PR-1 / D2)
-        flags.ar_office_discovery_time = this.gameState.currentWeek;
-        flags.ar_office_sourcing_type = sourcingType;
-
-        // Enhanced artist selection with better validation and error handling
-        try {
-          const allArtists = await this.gameData.getAllArtists();
-          console.log('[A&R DEBUG] All artists loaded:', allArtists?.length, 'artists');
-
-          if (!allArtists || allArtists.length === 0) {
-            console.error('[A&R DEBUG] No artists available in game data');
-            flags.ar_office_discovered_artist_id = null;
-            flags.ar_office_error = 'No artists available in game data';
-          } else {
-            let unsigned = [...allArtists];
-
-            // Enhanced signed and discovered artist filtering
-            try {
-              if (this.storage?.getArtistsByGame) {
-                const signed = await this.storage.getArtistsByGame(this.gameState.id);
-                console.log('[A&R DEBUG] Signed artists:', signed?.length, 'signed');
-
-                // BUGFIX: Match by name (case-insensitive) instead of ID
-                // JSON artist IDs (e.g., "art_4") don't match database UUIDs
-                const signedNames = new Set(
-                  (signed || []).map((a: any) => String(a.name || '').toLowerCase())
-                );
-
-                // Also exclude already discovered artists from selection
-                const discoveredNames = new Set();
-                if (flags.ar_office_discovered_artists && Array.isArray(flags.ar_office_discovered_artists)) {
-                  flags.ar_office_discovered_artists.forEach((discovered: any) => {
-                    if (discovered.name) {
-                      discoveredNames.add(String(discovered.name).toLowerCase());
-                    }
-                  });
-                }
-                console.log('[A&R DEBUG] Already discovered artists:', discoveredNames.size, 'discovered');
-
-                // Filter out both signed and already discovered artists by name
-                unsigned = allArtists.filter((a: any) => {
-                  const artistName = String(a.name || '').toLowerCase();
-                  return !signedNames.has(artistName) && !discoveredNames.has(artistName);
-                });
-                console.log('[A&R DEBUG] Available artists (unsigned + undiscovered):', unsigned?.length, 'available');
-              }
-            } catch (storageErr) {
-              console.warn('[A&R DEBUG] Failed to filter signed/discovered artists, using all artists:', storageErr);
-              // Continue with all artists if filtering fails
-            }
-
-            let picked: any | null = null;
-            let genreUsed: string | null = null;
-            const selectBestArtist = (artists: typeof unsigned) => {
-              let bestArtist: (typeof unsigned)[number] | undefined;
-              let bestScore = Number.NEGATIVE_INFINITY;
-
-              for (const artist of artists) {
-                if (!artist) {
-                  continue;
-                }
-
-                const talent = artist.talent ?? 0;
-                const popularity = artist.popularity ?? 0;
-                const score = talent + popularity;
-
-                if (score > bestScore) {
-                  bestArtist = artist;
-                  bestScore = score;
-                }
-              }
-
-              return bestArtist;
-            };
-
-            if (unsigned.length > 0) {
-              // SPECIALIZED mode: Apply genre filtering with fallback logic
-              if (sourcingType === 'specialized') {
-                let pool = [...unsigned];
-
-                // Try primary genre first
-                if (primaryGenre) {
-                  const primaryMatches = pool.filter(a => a.genre === primaryGenre);
-                  if (primaryMatches.length > 0) {
-                    pool = primaryMatches;
-                    genreUsed = primaryGenre;
-                    console.log(`[A&R DEBUG] Found ${primaryMatches.length} artists matching primary genre: ${primaryGenre}`);
-                  } else {
-                    console.log(`[A&R DEBUG] No artists found for primary genre: ${primaryGenre}, trying secondary...`);
-                    // Try secondary genre
-                    if (secondaryGenre) {
-                      const secondaryMatches = pool.filter(a => a.genre === secondaryGenre);
-                      if (secondaryMatches.length > 0) {
-                        pool = secondaryMatches;
-                        genreUsed = secondaryGenre;
-                        console.log(`[A&R DEBUG] Found ${secondaryMatches.length} artists matching secondary genre: ${secondaryGenre}`);
-                      } else {
-                        console.log(`[A&R DEBUG] No artists found for secondary genre: ${secondaryGenre}, using all available`);
-                        genreUsed = 'any';
-                      }
-                    } else {
-                      console.log(`[A&R DEBUG] No secondary genre specified, using all available`);
-                      genreUsed = 'any';
-                    }
-                  }
-                }
-
-                // Pick best artist from filtered pool
-                picked = selectBestArtist(pool);
-
-              } else if (sourcingType === 'active') {
-                // ACTIVE mode: Pick best artist overall (no genre filtering)
-                picked = selectBestArtist(unsigned);
-              } else {
-                // PASSIVE mode: Random selection
-                const idx = Math.floor(this.getRandom(0, unsigned.length));
-                picked = unsigned[idx];
-              }
-
-              // Validate the picked artist has required fields
-              if (picked) {
-                const requiredFields = ['id', 'name', 'archetype'];
-                const missingFields = requiredFields.filter(field => !picked[field]);
-
-                if (missingFields.length > 0) {
-                  console.warn('[A&R DEBUG] Selected artist missing required fields:', missingFields, 'Artist:', picked);
-                  // Add fallback values
-                  picked = {
-                    ...picked,
-                    name: picked.name || `Artist ${picked.id}`,
-                    archetype: picked.archetype || 'Unknown',
-                    talent: picked.talent || 50,
-                    popularity: picked.popularity || 0
-                  };
-                }
-              }
-            }
-
-            if (picked) {
-              console.log('[A&R DEBUG] Selected artist:', picked.name, 'ID:', picked.id, 'Talent:', picked.talent, 'Popularity:', picked.popularity);
-
-              // Initialize discovered artists array if it doesn't exist
-              if (!flags.ar_office_discovered_artists) {
-                flags.ar_office_discovered_artists = [];
-              }
-
-              // Add new discovered artist to the collection (no duplicate check needed since we pre-filtered)
-              flags.ar_office_discovered_artists.push({
-                id: picked.id,
-                name: picked.name,
-                archetype: picked.archetype,
-                talent: picked.talent || 0,
-                popularity: picked.popularity || 0,
-                genre: picked.genre || null,
-                discoveryTime: this.gameState.currentWeek, // sim-time week for save-restore reproducibility (Phase 2 PR-1 / D2)
-                sourcingType: sourcingType,
-                genreUsed: genreUsed || null // Track which genre filter was used
-              });
-              console.log('[A&R DEBUG] Added artist to discovered collection. Total discovered:', flags.ar_office_discovered_artists.length);
-              if (genreUsed) {
-                console.log('[A&R DEBUG] Genre filter result:', genreUsed);
-              }
-
-              // Keep legacy fields for backwards compatibility
-              flags.ar_office_discovered_artist_id = picked.id;
-              flags.ar_office_discovered_artist_info = {
-                name: picked.name,
-                archetype: picked.archetype,
-                talent: picked.talent || 0,
-                popularity: picked.popularity || 0,
-                genre: picked.genre || null
-              };
-
-              // Populate week summary A&R section with discovered artist id
-              // NOTE: This ID may differ from what /ar-office/artists returns if fallback logic is triggered
-              summary.arOffice = {
-                completed: true,
-                sourcingType: sourcingType ?? null,
-                discoveredArtistId: picked.id
-              };
-            } else {
-              console.log('[A&R DEBUG] No artist selected - no unsigned artists available');
-              flags.ar_office_discovered_artist_id = null;
-              flags.ar_office_error = 'No unsigned artists available';
-
-              // Create synthetic "no artists available" flag for better client handling
-              if (unsigned.length === 0) {
-                flags.ar_office_no_artists_reason = 'all_signed';
-              } else {
-                flags.ar_office_no_artists_reason = 'unknown';
-              }
-
-              summary.arOffice = {
-                completed: true,
-                sourcingType: sourcingType ?? null,
-                discoveredArtistId: null
-              };
-            }
-          }
-
-          // Ensure flags are properly set on gameState
-          this.gameState.flags = flags;
-          console.log('[A&R DEBUG] Final flags state:', JSON.stringify(flags, null, 2));
-
-        } catch (selectErr) {
-          console.error('[A&R] Failed to select/persist discovered artist:', selectErr);
-          flags.ar_office_discovered_artist_id = null;
-          flags.ar_office_error = selectErr instanceof Error ? selectErr.message : 'Artist selection failed';
-          this.gameState.flags = flags;
-        }
-
-        // Ensure WeekSummary A&R section is always properly populated
-        if (!summary.arOffice) {
-          summary.arOffice = {
-            completed: true,
-            sourcingType: sourcingType ?? null,
-            discoveredArtistId: flags.ar_office_discovered_artist_id || null
-          } as any;
-        }
-
-        // Add comprehensive change description
-        const discoveredArtistName = flags.ar_office_discovered_artist_info?.name;
-        let description;
-        if (discoveredArtistName) {
-          description = `A&R sourcing (${sourcingType || 'active'}) completed. Discovered ${discoveredArtistName}.`;
-        } else if (flags.ar_office_error) {
-          description = `A&R sourcing (${sourcingType || 'active'}) completed. ${flags.ar_office_error}`;
-        } else {
-          description = `A&R sourcing (${sourcingType || 'active'}) completed. Check discovered artists.`;
-        }
-
-        summary.changes.push({
-          type: 'unlock',
-          description,
-          amount: 0
-        });
-      }
-    } catch (e) {
-      console.warn('[A&R] Failed to process weekly A&R completion:', e);
-    }
+    return new AROfficeProcessor().processAROfficeWeekly(this.weekContext(summary, dbTransaction));
   }
 
   /**

--- a/shared/engine/processors/AROfficeProcessor.ts
+++ b/shared/engine/processors/AROfficeProcessor.ts
@@ -1,0 +1,297 @@
+/**
+ * AROfficeProcessor — weekly A&R Office sourcing completion.
+ *
+ * First extraction of the Phase 2 engine-seams plan (§2 row 1). The body below
+ * is a VERBATIM move of `GameEngine.processAROfficeWeekly`: every log line,
+ * branch, flag write (discovered-artists array + legacy singular keys), and the
+ * passive-mode `getRandom` draw are preserved character-for-character, with only
+ * `this.` rebound to the injected `WeekContext` (`this.gameState` → `ctx.gameState`,
+ * `this.gameData` → `ctx.gameData`, `this.storage` → `ctx.storage`,
+ * `this.getRandom` → `ctx.getRandom`). The `selectBestArtist` helper is a local
+ * closure inside the method (it was in the original), so it moves inline.
+ *
+ * The processor is stateless — construct it once and call, or reuse a shared
+ * instance; all state flows through the `WeekContext`. See ./types.ts for the
+ * RNG-order invariant this move preserves.
+ */
+import type { WeekContext } from './types';
+
+export class AROfficeProcessor {
+  async processAROfficeWeekly(ctx: WeekContext): Promise<void> {
+    const { gameState, summary } = ctx;
+    try {
+      const slotUsed = (gameState as any).arOfficeSlotUsed;
+      const sourcingType = (gameState as any).arOfficeSourcingType;
+      const primaryGenre = (gameState as any).arOfficePrimaryGenre;
+      const secondaryGenre = (gameState as any).arOfficeSecondaryGenre;
+      console.log('[A&R DEBUG] Processing A&R operation:', {
+        slotUsed,
+        sourcingType,
+        primaryGenre,
+        secondaryGenre,
+        gameId: gameState.id,
+        currentWeek: gameState.currentWeek
+      });
+
+      if (slotUsed) {
+        // Complete the one-week operation: free the slot, clear start time and genre parameters
+        (gameState as any).arOfficeSlotUsed = false;
+        (gameState as any).arOfficeOperationStart = null;
+        (gameState as any).arOfficePrimaryGenre = null;
+        (gameState as any).arOfficeSecondaryGenre = null;
+
+        // Enhanced flags initialization and management
+        let flags = (gameState.flags || {}) as any;
+        if (!flags || typeof flags !== 'object') {
+          console.log('[A&R DEBUG] Initializing flags object');
+          flags = {};
+          gameState.flags = flags;
+        }
+
+        // Clear start-week flag used by server validation
+        if ('ar_office_start_week' in flags) {
+          delete flags.ar_office_start_week;
+        }
+
+        // Add discovery timestamp for tracking (sim-time week for save-restore reproducibility — Phase 2 PR-1 / D2)
+        flags.ar_office_discovery_time = gameState.currentWeek;
+        flags.ar_office_sourcing_type = sourcingType;
+
+        // Enhanced artist selection with better validation and error handling
+        try {
+          const allArtists = await ctx.gameData.getAllArtists();
+          console.log('[A&R DEBUG] All artists loaded:', allArtists?.length, 'artists');
+
+          if (!allArtists || allArtists.length === 0) {
+            console.error('[A&R DEBUG] No artists available in game data');
+            flags.ar_office_discovered_artist_id = null;
+            flags.ar_office_error = 'No artists available in game data';
+          } else {
+            let unsigned = [...allArtists];
+
+            // Enhanced signed and discovered artist filtering
+            try {
+              if (ctx.storage?.getArtistsByGame) {
+                const signed = await ctx.storage.getArtistsByGame(gameState.id);
+                console.log('[A&R DEBUG] Signed artists:', signed?.length, 'signed');
+
+                // BUGFIX: Match by name (case-insensitive) instead of ID
+                // JSON artist IDs (e.g., "art_4") don't match database UUIDs
+                const signedNames = new Set(
+                  (signed || []).map((a: any) => String(a.name || '').toLowerCase())
+                );
+
+                // Also exclude already discovered artists from selection
+                const discoveredNames = new Set();
+                if (flags.ar_office_discovered_artists && Array.isArray(flags.ar_office_discovered_artists)) {
+                  flags.ar_office_discovered_artists.forEach((discovered: any) => {
+                    if (discovered.name) {
+                      discoveredNames.add(String(discovered.name).toLowerCase());
+                    }
+                  });
+                }
+                console.log('[A&R DEBUG] Already discovered artists:', discoveredNames.size, 'discovered');
+
+                // Filter out both signed and already discovered artists by name
+                unsigned = allArtists.filter((a: any) => {
+                  const artistName = String(a.name || '').toLowerCase();
+                  return !signedNames.has(artistName) && !discoveredNames.has(artistName);
+                });
+                console.log('[A&R DEBUG] Available artists (unsigned + undiscovered):', unsigned?.length, 'available');
+              }
+            } catch (storageErr) {
+              console.warn('[A&R DEBUG] Failed to filter signed/discovered artists, using all artists:', storageErr);
+              // Continue with all artists if filtering fails
+            }
+
+            let picked: any | null = null;
+            let genreUsed: string | null = null;
+            const selectBestArtist = (artists: typeof unsigned) => {
+              let bestArtist: (typeof unsigned)[number] | undefined;
+              let bestScore = Number.NEGATIVE_INFINITY;
+
+              for (const artist of artists) {
+                if (!artist) {
+                  continue;
+                }
+
+                const talent = artist.talent ?? 0;
+                const popularity = artist.popularity ?? 0;
+                const score = talent + popularity;
+
+                if (score > bestScore) {
+                  bestArtist = artist;
+                  bestScore = score;
+                }
+              }
+
+              return bestArtist;
+            };
+
+            if (unsigned.length > 0) {
+              // SPECIALIZED mode: Apply genre filtering with fallback logic
+              if (sourcingType === 'specialized') {
+                let pool = [...unsigned];
+
+                // Try primary genre first
+                if (primaryGenre) {
+                  const primaryMatches = pool.filter(a => a.genre === primaryGenre);
+                  if (primaryMatches.length > 0) {
+                    pool = primaryMatches;
+                    genreUsed = primaryGenre;
+                    console.log(`[A&R DEBUG] Found ${primaryMatches.length} artists matching primary genre: ${primaryGenre}`);
+                  } else {
+                    console.log(`[A&R DEBUG] No artists found for primary genre: ${primaryGenre}, trying secondary...`);
+                    // Try secondary genre
+                    if (secondaryGenre) {
+                      const secondaryMatches = pool.filter(a => a.genre === secondaryGenre);
+                      if (secondaryMatches.length > 0) {
+                        pool = secondaryMatches;
+                        genreUsed = secondaryGenre;
+                        console.log(`[A&R DEBUG] Found ${secondaryMatches.length} artists matching secondary genre: ${secondaryGenre}`);
+                      } else {
+                        console.log(`[A&R DEBUG] No artists found for secondary genre: ${secondaryGenre}, using all available`);
+                        genreUsed = 'any';
+                      }
+                    } else {
+                      console.log(`[A&R DEBUG] No secondary genre specified, using all available`);
+                      genreUsed = 'any';
+                    }
+                  }
+                }
+
+                // Pick best artist from filtered pool
+                picked = selectBestArtist(pool);
+
+              } else if (sourcingType === 'active') {
+                // ACTIVE mode: Pick best artist overall (no genre filtering)
+                picked = selectBestArtist(unsigned);
+              } else {
+                // PASSIVE mode: Random selection
+                const idx = Math.floor(ctx.getRandom(0, unsigned.length));
+                picked = unsigned[idx];
+              }
+
+              // Validate the picked artist has required fields
+              if (picked) {
+                const requiredFields = ['id', 'name', 'archetype'];
+                const missingFields = requiredFields.filter(field => !picked[field]);
+
+                if (missingFields.length > 0) {
+                  console.warn('[A&R DEBUG] Selected artist missing required fields:', missingFields, 'Artist:', picked);
+                  // Add fallback values
+                  picked = {
+                    ...picked,
+                    name: picked.name || `Artist ${picked.id}`,
+                    archetype: picked.archetype || 'Unknown',
+                    talent: picked.talent || 50,
+                    popularity: picked.popularity || 0
+                  };
+                }
+              }
+            }
+
+            if (picked) {
+              console.log('[A&R DEBUG] Selected artist:', picked.name, 'ID:', picked.id, 'Talent:', picked.talent, 'Popularity:', picked.popularity);
+
+              // Initialize discovered artists array if it doesn't exist
+              if (!flags.ar_office_discovered_artists) {
+                flags.ar_office_discovered_artists = [];
+              }
+
+              // Add new discovered artist to the collection (no duplicate check needed since we pre-filtered)
+              flags.ar_office_discovered_artists.push({
+                id: picked.id,
+                name: picked.name,
+                archetype: picked.archetype,
+                talent: picked.talent || 0,
+                popularity: picked.popularity || 0,
+                genre: picked.genre || null,
+                discoveryTime: gameState.currentWeek, // sim-time week for save-restore reproducibility (Phase 2 PR-1 / D2)
+                sourcingType: sourcingType,
+                genreUsed: genreUsed || null // Track which genre filter was used
+              });
+              console.log('[A&R DEBUG] Added artist to discovered collection. Total discovered:', flags.ar_office_discovered_artists.length);
+              if (genreUsed) {
+                console.log('[A&R DEBUG] Genre filter result:', genreUsed);
+              }
+
+              // Keep legacy fields for backwards compatibility
+              flags.ar_office_discovered_artist_id = picked.id;
+              flags.ar_office_discovered_artist_info = {
+                name: picked.name,
+                archetype: picked.archetype,
+                talent: picked.talent || 0,
+                popularity: picked.popularity || 0,
+                genre: picked.genre || null
+              };
+
+              // Populate week summary A&R section with discovered artist id
+              // NOTE: This ID may differ from what /ar-office/artists returns if fallback logic is triggered
+              summary.arOffice = {
+                completed: true,
+                sourcingType: sourcingType ?? null,
+                discoveredArtistId: picked.id
+              };
+            } else {
+              console.log('[A&R DEBUG] No artist selected - no unsigned artists available');
+              flags.ar_office_discovered_artist_id = null;
+              flags.ar_office_error = 'No unsigned artists available';
+
+              // Create synthetic "no artists available" flag for better client handling
+              if (unsigned.length === 0) {
+                flags.ar_office_no_artists_reason = 'all_signed';
+              } else {
+                flags.ar_office_no_artists_reason = 'unknown';
+              }
+
+              summary.arOffice = {
+                completed: true,
+                sourcingType: sourcingType ?? null,
+                discoveredArtistId: null
+              };
+            }
+          }
+
+          // Ensure flags are properly set on gameState
+          gameState.flags = flags;
+          console.log('[A&R DEBUG] Final flags state:', JSON.stringify(flags, null, 2));
+
+        } catch (selectErr) {
+          console.error('[A&R] Failed to select/persist discovered artist:', selectErr);
+          flags.ar_office_discovered_artist_id = null;
+          flags.ar_office_error = selectErr instanceof Error ? selectErr.message : 'Artist selection failed';
+          gameState.flags = flags;
+        }
+
+        // Ensure WeekSummary A&R section is always properly populated
+        if (!summary.arOffice) {
+          summary.arOffice = {
+            completed: true,
+            sourcingType: sourcingType ?? null,
+            discoveredArtistId: flags.ar_office_discovered_artist_id || null
+          } as any;
+        }
+
+        // Add comprehensive change description
+        const discoveredArtistName = flags.ar_office_discovered_artist_info?.name;
+        let description;
+        if (discoveredArtistName) {
+          description = `A&R sourcing (${sourcingType || 'active'}) completed. Discovered ${discoveredArtistName}.`;
+        } else if (flags.ar_office_error) {
+          description = `A&R sourcing (${sourcingType || 'active'}) completed. ${flags.ar_office_error}`;
+        } else {
+          description = `A&R sourcing (${sourcingType || 'active'}) completed. Check discovered artists.`;
+        }
+
+        summary.changes.push({
+          type: 'unlock',
+          description,
+          amount: 0
+        });
+      }
+    } catch (e) {
+      console.warn('[A&R] Failed to process weekly A&R completion:', e);
+    }
+  }
+}

--- a/shared/engine/processors/types.ts
+++ b/shared/engine/processors/types.ts
@@ -1,0 +1,46 @@
+/**
+ * WeekContext — the shared dependency bundle passed to every engine processor.
+ *
+ * Phase 2 (engine seams) decomposes `GameEngine.advanceWeek` into a fixed-order
+ * sequence of domain processors (AROfficeProcessor, ProgressionProcessor, ...).
+ * Each processor receives a `WeekContext` instead of reaching into `GameEngine`
+ * internals, so processors never construct their own dependencies and the call
+ * sites in `advanceWeek` stay thin and uniform.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * RNG INVARIANT (see phase-2-engine-seams-plan §6 "RNG stream order = behavior"):
+ *   `getRandom` MUST be the GameEngine's own bound seeded function
+ *   (`this.getRandom.bind(this)` — or an arrow closing over `this`). The whole
+ *   game shares a SINGLE seeded RNG stream, and outcomes for a given seed depend
+ *   on the exact ORDER of draws from it. Processors must therefore draw only
+ *   through this `getRandom`, and the engine must call processors in the exact
+ *   pipeline order. Never hand a processor a fresh/unseeded RNG — that would fork
+ *   the stream and change behavior (and break the golden master).
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * `gameState` and `summary` are the engine's live objects — processors mutate
+ * them in place (flags, arOffice columns, summary.changes, summary.arOffice),
+ * exactly as the pre-extraction methods did.
+ */
+import type { GameState } from '../../schema';
+import type { WeekSummary } from '../../types/gameTypes';
+import type { ServerGameData } from '../../../server/data/gameData';
+
+export interface WeekContext {
+  /** Live game state, mutated in place (flags, arOffice columns, money, etc.). */
+  gameState: GameState;
+  /** The week's accumulating summary; processors push changes / set sections. */
+  summary: WeekSummary;
+  /** Content + persistence-backed game data (getAllArtists, etc.). */
+  gameData: ServerGameData;
+  /** Storage interface for DB reads/writes. Optional, mirroring GameEngine. */
+  storage: any;
+  /**
+   * The engine's single seeded RNG draw — `min + rng() * (max - min)`.
+   * MUST be bound from GameEngine so the one seeded stream and its draw order
+   * are preserved. See the RNG INVARIANT note above.
+   */
+  getRandom: (min: number, max: number) => number;
+  /** Optional per-step DB transaction handle, threaded verbatim (D6). */
+  dbTransaction?: any;
+}


### PR DESCRIPTION
## Summary
PR-5 of the Phase 2 plan — the first engine processor, establishing the pattern PRs 6–11 copy:
- New `shared/engine/processors/types.ts`: the `WeekContext` interface (gameState, summary, gameData, storage, seeded `getRandom`, per-step `dbTransaction`) with the RNG stream-order invariant documented
- New `shared/engine/processors/AROfficeProcessor.ts` (297 lines): `processAROfficeWeekly` moved verbatim — every log line, sourcing mode, flag write, and the seeded passive-pick draw are character-identical; the `selectBestArtist` closure moved with it (caller audit: zero external users)
- GameEngine keeps a thin delegate at the same pipeline position plus a reusable `weekContext()` helper; public surface unchanged. game-engine.ts 5,113 → 4,861

## Verification
- Golden master 8/8 with **zero snapshot updates, run twice**; full suite 652/652; `npm run check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)