### PR TITLE
refactor(engine): extract ProgressionProcessor + WeeklyFinancesProcessor (Phase 2 PR-6)

### DIFF
--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -20,6 +20,8 @@ import type { WeekSummary, ChartUpdate, GameChange, EventOccurrence, GameArtist 
 import { ArtistChangeHelpers } from '../types/gameTypes';
 import { getSeasonFromWeek, getSeasonalMultiplier } from '../utils/seasonalCalculations';
 import { AROfficeProcessor } from './processors/AROfficeProcessor';
+import { ProgressionProcessor } from './processors/ProgressionProcessor';
+import { WeeklyFinancesProcessor } from './processors/WeeklyFinancesProcessor';
 import type { WeekContext } from './processors/types';
 
 // Re-export WeekSummary for backward compatibility
@@ -563,6 +565,7 @@ export class GameEngine {
       summary,
       gameData: this.gameData,
       storage: this.storage,
+      financialSystem: this.financialSystem,
       getRandom: (min: number, max: number) => this.getRandom(min, max),
       dbTransaction
     };
@@ -1222,8 +1225,9 @@ export class GameEngine {
    * Calculates weekly operational costs including artist payments
    */
   private async calculateWeeklyBurn(): Promise<number> {
-    const result = await this.calculateWeeklyBurnWithBreakdown();
-    return result.total;
+    return new WeeklyFinancesProcessor().calculateWeeklyBurn(
+      this.weekContext({ changes: [] } as unknown as WeekSummary)
+    );
   }
 
   /**
@@ -1236,9 +1240,8 @@ export class GameEngine {
     artistCosts: number;
     artistDetails: Array<{name: string, weeklyCost: number}>;
   }> {
-    return this.financialSystem.calculateWeeklyBurnWithBreakdown(
-      this.gameState.id || '',
-      this.storage
+    return new WeeklyFinancesProcessor().calculateWeeklyBurnWithBreakdown(
+      this.weekContext({ changes: [] } as unknown as WeekSummary)
     );
   }
 
@@ -3201,167 +3204,25 @@ export class GameEngine {
    * Checks and applies progression gates
    */
   private async checkProgressionGates(summary: WeekSummary): Promise<void> {
-    const thresholds = this.gameData.getProgressionThresholdsSync();
-    
-    // Slot unlock functionality has been removed - these were non-functional placeholders
+    return new ProgressionProcessor().checkProgressionGates(this.weekContext(summary));
   }
 
   /**
    * Updates access tiers based on current reputation and returns tier upgrade notifications
    */
   private updateAccessTiers(): GameChange[] {
-    const tiers = this.gameData.getAccessTiersSync();
-    const reputation = this.gameState.reputation || 0;
-    const tierChanges: GameChange[] = [];
-
-    // Initialize tier unlock history if missing (Task 2.2)
-    const gs: any = this.gameState as any;
-    if (!gs.tierUnlockHistory) {
-      gs.tierUnlockHistory = {};
-    }
-    
-    // Store previous values to detect changes
-    const previousPlaylist = this.gameState.playlistAccess;
-    const previousPress = this.gameState.pressAccess;
-    const previousVenue = this.gameState.venueAccess;
-    
-    // Update playlist access
-    const playlistTiers = Object.entries(tiers.playlist_access)
-      .sort(([,a], [,b]) => b.threshold - a.threshold); // Sort by threshold descending
-    
-    for (const [tierName, config] of playlistTiers) {
-      if (reputation >= config.threshold) {
-        if (this.gameState.playlistAccess !== tierName) {
-          this.gameState.playlistAccess = tierName;
-        }
-        break;
-      }
-    }
-    
-    // Update press access
-    const pressTiers = Object.entries(tiers.press_access)
-      .sort(([,a], [,b]) => b.threshold - a.threshold);
-    
-    for (const [tierName, config] of pressTiers) {
-      if (reputation >= config.threshold) {
-        if (this.gameState.pressAccess !== tierName) {
-          this.gameState.pressAccess = tierName;
-        }
-        break;
-      }
-    }
-    
-    // Update venue access
-    const venueTiers = Object.entries(tiers.venue_access)
-      .sort(([,a], [,b]) => b.threshold - a.threshold);
-    
-    for (const [tierName, config] of venueTiers) {
-      if (reputation >= config.threshold) {
-        if (this.gameState.venueAccess !== tierName) {
-          this.gameState.venueAccess = tierName;
-        }
-        break;
-      }
-    }
-    
-    // Generate notifications for tier upgrades
-    if (previousPlaylist !== this.gameState.playlistAccess && this.gameState.playlistAccess !== 'none') {
-      const tierDisplay = this.gameState.playlistAccess === 'niche' ? 'Niche' :
-                         this.gameState.playlistAccess === 'mid' ? 'Mid-Tier' :
-                         this.gameState.playlistAccess === 'flagship' ? 'Flagship' : this.gameState.playlistAccess;
-      tierChanges.push({
-        type: 'unlock',
-        description: `🎵 Playlist Access Upgraded: ${tierDisplay} playlists unlocked! Your releases can now reach wider audiences.`,
-        amount: 0
-      });
-
-      // Task 2.3: Track unlock week in tierUnlockHistory for playlist
-      if (!gs.tierUnlockHistory.playlist) gs.tierUnlockHistory.playlist = {};
-      const tierKey = this.gameState.playlistAccess;
-      if (tierKey && !gs.tierUnlockHistory.playlist[tierKey]) {
-        gs.tierUnlockHistory.playlist[tierKey] = this.gameState.currentWeek || 0;
-      }
-    }
-    
-    if (previousPress !== this.gameState.pressAccess && this.gameState.pressAccess !== 'none') {
-      const tierDisplay = this.gameState.pressAccess === 'blogs' ? 'Music Blogs' :
-                         this.gameState.pressAccess === 'mid_tier' ? 'Mid-Tier Press' :
-                         this.gameState.pressAccess === 'national' ? 'National Media' : this.gameState.pressAccess;
-      tierChanges.push({
-        type: 'unlock',
-        description: `📰 Press Access Upgraded: ${tierDisplay} coverage unlocked! Your projects will get better media attention.`,
-        amount: 0
-      });
-
-      // Task 2.4: Track unlock week in tierUnlockHistory for press
-      if (!gs.tierUnlockHistory.press) gs.tierUnlockHistory.press = {};
-      const tierKey = this.gameState.pressAccess;
-      if (tierKey && !gs.tierUnlockHistory.press[tierKey]) {
-        gs.tierUnlockHistory.press[tierKey] = this.gameState.currentWeek || 0;
-      }
-    }
-    
-    if (previousVenue !== this.gameState.venueAccess && this.gameState.venueAccess !== 'none') {
-      const tierDisplay = this.gameState.venueAccess === 'clubs' ? 'Club Venues' :
-                         this.gameState.venueAccess === 'theaters' ? 'Theater Venues' :
-                         this.gameState.venueAccess === 'arenas' ? 'Arena Venues' : this.gameState.venueAccess;
-      tierChanges.push({
-        type: 'unlock',
-        description: `🎭 Venue Access Upgraded: ${tierDisplay} unlocked! Your artists can now perform at larger venues.`,
-        amount: 0
-      });
-
-      // Task 2.6: Track unlock week in tierUnlockHistory for venue
-      if (!gs.tierUnlockHistory.venue) gs.tierUnlockHistory.venue = {};
-      const tierKey = this.gameState.venueAccess;
-      if (tierKey && !gs.tierUnlockHistory.venue[tierKey]) {
-        gs.tierUnlockHistory.venue[tierKey] = this.gameState.currentWeek || 0;
-      }
-    }
-    
-    return tierChanges;
+    // updateAccessTiers returns its notifications (it does not read ctx.summary),
+    // so a throwaway summary is passed only to satisfy the WeekContext shape.
+    return new ProgressionProcessor().updateAccessTiers(
+      this.weekContext({ changes: [] } as unknown as WeekSummary)
+    );
   }
 
   /**
    * Checks for producer tier unlocks and adds progression notifications
    */
   private checkProducerTierUnlocks(summary: WeekSummary): void {
-    const reputation = this.gameState.reputation || 0;
-    const producerSystem = this.gameData.getProducerTierSystemSync();
-    
-    // Track which tiers were previously unlocked - properly handle flags
-    const flags = this.gameState.flags || {};
-    let unlockedTiers = (flags as any)['unlocked_producer_tiers'];
-    
-    // Initialize unlockedTiers if it doesn't exist yet
-    if (!unlockedTiers) {
-      unlockedTiers = ['local']; // Start with local tier
-      (flags as any)['unlocked_producer_tiers'] = unlockedTiers;
-      this.gameState.flags = flags;
-    }
-    
-    let newUnlocks = false;
-    const availableTiers = this.gameData.getAvailableProducerTiers(reputation);
-    
-    for (const tierName of availableTiers) {
-      if (!unlockedTiers.includes(tierName)) {
-        unlockedTiers.push(tierName);
-        newUnlocks = true;
-        
-        const tierData = producerSystem[tierName];
-        summary.changes.push({
-          type: 'unlock',
-          description: `🎛️ Producer Tier Unlocked: ${tierName.charAt(0).toUpperCase() + tierName.slice(1)} - ${tierData.description}`,
-          amount: 0
-        });
-        
-        console.log(`[PROGRESSION] Producer tier unlocked: ${tierName} (reputation: ${reputation})`);
-      }
-    }
-    
-    // Always update the flags to ensure persistence
-    (flags as any)['unlocked_producer_tiers'] = unlockedTiers;
-    this.gameState.flags = flags;
+    return new ProgressionProcessor().checkProducerTierUnlocks(this.weekContext(summary));
   }
 
   // REMOVED: processProjectStart method is redundant
@@ -3849,29 +3710,7 @@ export class GameEngine {
    * Check if the 52-week campaign has been completed and calculate final results
    */
   private async checkCampaignCompletion(summary: WeekSummary): Promise<CampaignResults | undefined> {
-    const currentWeek = this.gameState.currentWeek || 0;
-    const balanceConfig = await this.gameData.getBalanceConfig();
-    const campaignLength = balanceConfig.time_progression.campaign_length_weeks;
-    
-    // Only complete campaign if we've reached the final week
-    if (currentWeek < campaignLength) {
-      return undefined;
-    }
-
-    // Mark campaign as completed
-    this.gameState.campaignCompleted = true;
-
-    // Calculate complete campaign results
-    const campaignResults = AchievementsEngine.calculateCampaignResults(this.gameState);
-
-    // Add campaign completion to summary
-    summary.changes.push({
-      type: 'unlock',
-      description: `🎉 Campaign Completed! Final Score: ${campaignResults.finalScore}`,
-      amount: campaignResults.finalScore
-    });
-
-    return campaignResults;
+    return new ProgressionProcessor().checkCampaignCompletion(this.weekContext(summary));
   }
 
 
@@ -4112,38 +3951,7 @@ export class GameEngine {
    * Enhanced weekly summary generation with economic insights
    */
   private generateEconomicInsights(summary: WeekSummary): void {
-    // Track budget efficiency and strategic decisions for the week
-    const projectStartChanges = summary.changes.filter(change => 
-      change.type === 'project_complete' && change.description.includes('Started')
-    );
-    
-    if (projectStartChanges.length > 0) {
-      const totalProjectSpend = projectStartChanges.reduce((total, change) => 
-        total + Math.abs(change.amount || 0), 0
-      );
-      
-      summary.changes.push({
-        type: 'unlock',
-        description: `💰 Weekly project investment: $${totalProjectSpend.toLocaleString()} across ${projectStartChanges.length} project${projectStartChanges.length > 1 ? 's' : ''}`,
-        amount: 0
-      });
-    }
-    
-    // Add economic efficiency reporting for ongoing projects
-    const ongoingRevenue = summary.changes.filter(change => 
-      change.type === 'ongoing_revenue'
-    ).reduce((total, change) => total + (change.amount || 0), 0);
-    
-    if (ongoingRevenue > 0) {
-      summary.changes.push({
-        type: 'unlock',
-        description: `📈 Catalog revenue efficiency: $${ongoingRevenue.toLocaleString()} from released content`,
-        amount: 0
-      });
-    }
-    
-    // Note: Removed efficiency achievement as it serves no gameplay purpose
-    // Instead, track reputation gains per release/activity in their respective sections
+    return new WeeklyFinancesProcessor().generateEconomicInsights(this.weekContext(summary));
   }
 
   /**
@@ -4377,42 +4185,10 @@ export class GameEngine {
    * Generates human-readable financial breakdown string
    */
   private generateFinancialBreakdown(f: WeeklyFinancials): string {
-    const parts: string[] = [`$${f.startingBalance.toLocaleString()}`];
-    
-    if (f.operations.base > 0) {
-      parts.push(`- $${f.operations.base.toLocaleString()} (operations)`);
-    }
-    if (f.operations.artists > 0) {
-      parts.push(`- $${f.operations.artists.toLocaleString()} (artists)`);
-    }
-    if (f.operations.executives > 0) {
-      parts.push(`- $${f.operations.executives.toLocaleString()} (executives)`);
-    }
-    if (f.operations.signingBonuses > 0) {
-      parts.push(`- $${f.operations.signingBonuses.toLocaleString()} (signing bonuses)`);
-    }
-    if (f.projects.costs > 0) {
-      parts.push(`- $${f.projects.costs.toLocaleString()} (projects)`);
-    }
-    if (f.projects.revenue > 0) {
-      parts.push(`+ $${f.projects.revenue.toLocaleString()} (project revenue)`);
-    }
-    if (f.marketing.costs > 0) {
-      parts.push(`- $${f.marketing.costs.toLocaleString()} (marketing)`);
-    }
-    if (f.roleEffects.costs > 0) {
-      parts.push(`- $${f.roleEffects.costs.toLocaleString()} (role costs)`);
-    }
-    if (f.roleEffects.revenue > 0) {
-      parts.push(`+ $${f.roleEffects.revenue.toLocaleString()} (role benefits)`);
-    }
-    if (f.streamingRevenue > 0) {
-      parts.push(`+ $${f.streamingRevenue.toLocaleString()} (streaming)`);
-    }
-    
-    parts.push(`= $${f.endingBalance.toLocaleString()}`);
-    
-    return parts.join(' ');
+    return new WeeklyFinancesProcessor().generateFinancialBreakdown(
+      this.weekContext({ changes: [] } as unknown as WeekSummary),
+      f
+    );
   }
 
   /**
@@ -4421,9 +4197,9 @@ export class GameEngine {
    */
   // DELEGATED TO FinancialSystem (originally lines 3126-3172)
   async calculateWeeklyFinancials(summary: WeekSummary): Promise<WeeklyFinancials> {
-    return this.financialSystem.calculateWeeklyFinancials(
-      summary,
-      this.gameState.money || 0
+    return new WeeklyFinancesProcessor().calculateWeeklyFinancials(
+      this.weekContext(summary),
+      summary
     );
   }
 

--- a/shared/engine/processors/ProgressionProcessor.ts
+++ b/shared/engine/processors/ProgressionProcessor.ts
@@ -1,0 +1,213 @@
+/**
+ * ProgressionProcessor — weekly reputation-gated progression & campaign completion.
+ *
+ * Phase 2 engine-seams §2 row 2. VERBATIM move of four `GameEngine` methods:
+ * `checkProgressionGates`, `updateAccessTiers`, `checkProducerTierUnlocks`, and
+ * `checkCampaignCompletion`. Every branch, log line, emoji notification, and
+ * flag/gameState write is preserved character-for-character, with only `this.`
+ * rebound to the injected `WeekContext` (`this.gameState` → `ctx.gameState`,
+ * `this.gameData` → `ctx.gameData`). `AchievementsEngine` is still imported
+ * statically, exactly as the pre-extraction engine used it.
+ *
+ * The processor is stateless — all state flows through the `WeekContext`.
+ * See ./types.ts for the RNG-order invariant this move preserves (these methods
+ * draw no RNG, so order is unaffected).
+ */
+import type { WeekContext } from './types';
+import type { GameChange } from '../../types/gameTypes';
+import type { CampaignResults } from '../game-engine';
+import { AchievementsEngine } from '../AchievementsEngine';
+
+export class ProgressionProcessor {
+  async checkProgressionGates(ctx: WeekContext): Promise<void> {
+    const thresholds = ctx.gameData.getProgressionThresholdsSync();
+
+    // Slot unlock functionality has been removed - these were non-functional placeholders
+  }
+
+  /**
+   * Updates access tiers based on current reputation and returns tier upgrade notifications
+   */
+  updateAccessTiers(ctx: WeekContext): GameChange[] {
+    const tiers = ctx.gameData.getAccessTiersSync();
+    const reputation = ctx.gameState.reputation || 0;
+    const tierChanges: GameChange[] = [];
+
+    // Initialize tier unlock history if missing (Task 2.2)
+    const gs: any = ctx.gameState as any;
+    if (!gs.tierUnlockHistory) {
+      gs.tierUnlockHistory = {};
+    }
+
+    // Store previous values to detect changes
+    const previousPlaylist = ctx.gameState.playlistAccess;
+    const previousPress = ctx.gameState.pressAccess;
+    const previousVenue = ctx.gameState.venueAccess;
+
+    // Update playlist access
+    const playlistTiers = Object.entries(tiers.playlist_access)
+      .sort(([,a], [,b]) => b.threshold - a.threshold); // Sort by threshold descending
+
+    for (const [tierName, config] of playlistTiers) {
+      if (reputation >= config.threshold) {
+        if (ctx.gameState.playlistAccess !== tierName) {
+          ctx.gameState.playlistAccess = tierName;
+        }
+        break;
+      }
+    }
+
+    // Update press access
+    const pressTiers = Object.entries(tiers.press_access)
+      .sort(([,a], [,b]) => b.threshold - a.threshold);
+
+    for (const [tierName, config] of pressTiers) {
+      if (reputation >= config.threshold) {
+        if (ctx.gameState.pressAccess !== tierName) {
+          ctx.gameState.pressAccess = tierName;
+        }
+        break;
+      }
+    }
+
+    // Update venue access
+    const venueTiers = Object.entries(tiers.venue_access)
+      .sort(([,a], [,b]) => b.threshold - a.threshold);
+
+    for (const [tierName, config] of venueTiers) {
+      if (reputation >= config.threshold) {
+        if (ctx.gameState.venueAccess !== tierName) {
+          ctx.gameState.venueAccess = tierName;
+        }
+        break;
+      }
+    }
+
+    // Generate notifications for tier upgrades
+    if (previousPlaylist !== ctx.gameState.playlistAccess && ctx.gameState.playlistAccess !== 'none') {
+      const tierDisplay = ctx.gameState.playlistAccess === 'niche' ? 'Niche' :
+                         ctx.gameState.playlistAccess === 'mid' ? 'Mid-Tier' :
+                         ctx.gameState.playlistAccess === 'flagship' ? 'Flagship' : ctx.gameState.playlistAccess;
+      tierChanges.push({
+        type: 'unlock',
+        description: `🎵 Playlist Access Upgraded: ${tierDisplay} playlists unlocked! Your releases can now reach wider audiences.`,
+        amount: 0
+      });
+
+      // Task 2.3: Track unlock week in tierUnlockHistory for playlist
+      if (!gs.tierUnlockHistory.playlist) gs.tierUnlockHistory.playlist = {};
+      const tierKey = ctx.gameState.playlistAccess;
+      if (tierKey && !gs.tierUnlockHistory.playlist[tierKey]) {
+        gs.tierUnlockHistory.playlist[tierKey] = ctx.gameState.currentWeek || 0;
+      }
+    }
+
+    if (previousPress !== ctx.gameState.pressAccess && ctx.gameState.pressAccess !== 'none') {
+      const tierDisplay = ctx.gameState.pressAccess === 'blogs' ? 'Music Blogs' :
+                         ctx.gameState.pressAccess === 'mid_tier' ? 'Mid-Tier Press' :
+                         ctx.gameState.pressAccess === 'national' ? 'National Media' : ctx.gameState.pressAccess;
+      tierChanges.push({
+        type: 'unlock',
+        description: `📰 Press Access Upgraded: ${tierDisplay} coverage unlocked! Your projects will get better media attention.`,
+        amount: 0
+      });
+
+      // Task 2.4: Track unlock week in tierUnlockHistory for press
+      if (!gs.tierUnlockHistory.press) gs.tierUnlockHistory.press = {};
+      const tierKey = ctx.gameState.pressAccess;
+      if (tierKey && !gs.tierUnlockHistory.press[tierKey]) {
+        gs.tierUnlockHistory.press[tierKey] = ctx.gameState.currentWeek || 0;
+      }
+    }
+
+    if (previousVenue !== ctx.gameState.venueAccess && ctx.gameState.venueAccess !== 'none') {
+      const tierDisplay = ctx.gameState.venueAccess === 'clubs' ? 'Club Venues' :
+                         ctx.gameState.venueAccess === 'theaters' ? 'Theater Venues' :
+                         ctx.gameState.venueAccess === 'arenas' ? 'Arena Venues' : ctx.gameState.venueAccess;
+      tierChanges.push({
+        type: 'unlock',
+        description: `🎭 Venue Access Upgraded: ${tierDisplay} unlocked! Your artists can now perform at larger venues.`,
+        amount: 0
+      });
+
+      // Task 2.6: Track unlock week in tierUnlockHistory for venue
+      if (!gs.tierUnlockHistory.venue) gs.tierUnlockHistory.venue = {};
+      const tierKey = ctx.gameState.venueAccess;
+      if (tierKey && !gs.tierUnlockHistory.venue[tierKey]) {
+        gs.tierUnlockHistory.venue[tierKey] = ctx.gameState.currentWeek || 0;
+      }
+    }
+
+    return tierChanges;
+  }
+
+  /**
+   * Checks for producer tier unlocks and adds progression notifications
+   */
+  checkProducerTierUnlocks(ctx: WeekContext): void {
+    const { summary } = ctx;
+    const reputation = ctx.gameState.reputation || 0;
+    const producerSystem = ctx.gameData.getProducerTierSystemSync();
+
+    // Track which tiers were previously unlocked - properly handle flags
+    const flags = ctx.gameState.flags || {};
+    let unlockedTiers = (flags as any)['unlocked_producer_tiers'];
+
+    // Initialize unlockedTiers if it doesn't exist yet
+    if (!unlockedTiers) {
+      unlockedTiers = ['local']; // Start with local tier
+      (flags as any)['unlocked_producer_tiers'] = unlockedTiers;
+      ctx.gameState.flags = flags;
+    }
+
+    let newUnlocks = false;
+    const availableTiers = ctx.gameData.getAvailableProducerTiers(reputation);
+
+    for (const tierName of availableTiers) {
+      if (!unlockedTiers.includes(tierName)) {
+        unlockedTiers.push(tierName);
+        newUnlocks = true;
+
+        const tierData = producerSystem[tierName];
+        summary.changes.push({
+          type: 'unlock',
+          description: `🎛️ Producer Tier Unlocked: ${tierName.charAt(0).toUpperCase() + tierName.slice(1)} - ${tierData.description}`,
+          amount: 0
+        });
+
+        console.log(`[PROGRESSION] Producer tier unlocked: ${tierName} (reputation: ${reputation})`);
+      }
+    }
+
+    // Always update the flags to ensure persistence
+    (flags as any)['unlocked_producer_tiers'] = unlockedTiers;
+    ctx.gameState.flags = flags;
+  }
+
+  async checkCampaignCompletion(ctx: WeekContext): Promise<CampaignResults | undefined> {
+    const { summary } = ctx;
+    const currentWeek = ctx.gameState.currentWeek || 0;
+    const balanceConfig = await ctx.gameData.getBalanceConfig();
+    const campaignLength = balanceConfig.time_progression.campaign_length_weeks;
+
+    // Only complete campaign if we've reached the final week
+    if (currentWeek < campaignLength) {
+      return undefined;
+    }
+
+    // Mark campaign as completed
+    ctx.gameState.campaignCompleted = true;
+
+    // Calculate complete campaign results
+    const campaignResults = AchievementsEngine.calculateCampaignResults(ctx.gameState);
+
+    // Add campaign completion to summary
+    summary.changes.push({
+      type: 'unlock',
+      description: `🎉 Campaign Completed! Final Score: ${campaignResults.finalScore}`,
+      amount: campaignResults.finalScore
+    });
+
+    return campaignResults;
+  }
+}

--- a/shared/engine/processors/WeeklyFinancesProcessor.ts
+++ b/shared/engine/processors/WeeklyFinancesProcessor.ts
@@ -1,0 +1,140 @@
+/**
+ * WeeklyFinancesProcessor — weekly burn / financial-breakdown computation.
+ *
+ * Phase 2 engine-seams §2 row 3. VERBATIM move of five `GameEngine` methods:
+ * `calculateWeeklyBurn`, `calculateWeeklyBurnWithBreakdown`,
+ * `calculateWeeklyFinancials`, `generateFinancialBreakdown`, and
+ * `generateEconomicInsights`. Each body is preserved character-for-character,
+ * with only `this.` rebound to the injected `WeekContext`
+ * (`this.financialSystem` → `ctx.financialSystem`, `this.gameState` → `ctx.gameState`,
+ * `this.storage` → `ctx.storage`).
+ *
+ * CRITICAL INVARIANT (plan §2): the SINGLE money-update point stays in
+ * `GameEngine.advanceWeek` (the `[FINAL MONEY]` block). These methods only
+ * COMPUTE breakdowns; they never mutate `gameState.money`. Nothing here writes money.
+ *
+ * The processor is stateless — all state flows through the `WeekContext`.
+ * Note: `calculateExecutiveSalaries` was already owned by `FinancialSystem`
+ * (the engine only ever delegated to it), so it is not part of this move.
+ */
+import type { WeekContext } from './types';
+import type { WeeklyFinancials } from '../game-engine';
+
+export class WeeklyFinancesProcessor {
+  /**
+   * Calculates weekly operational costs including artist payments
+   */
+  async calculateWeeklyBurn(ctx: WeekContext): Promise<number> {
+    const result = await this.calculateWeeklyBurnWithBreakdown(ctx);
+    return result.total;
+  }
+
+  /**
+   * Calculates weekly operational costs with detailed breakdown for transparency
+   */
+  // DELEGATED TO FinancialSystem (originally lines 572-617)
+  async calculateWeeklyBurnWithBreakdown(ctx: WeekContext): Promise<{
+    total: number;
+    baseBurn: number;
+    artistCosts: number;
+    artistDetails: Array<{name: string, weeklyCost: number}>;
+  }> {
+    return ctx.financialSystem.calculateWeeklyBurnWithBreakdown(
+      ctx.gameState.id || '',
+      ctx.storage
+    );
+  }
+
+  /**
+   * Generates human-readable financial breakdown string
+   */
+  generateFinancialBreakdown(ctx: WeekContext, f: WeeklyFinancials): string {
+    const parts: string[] = [`$${f.startingBalance.toLocaleString()}`];
+
+    if (f.operations.base > 0) {
+      parts.push(`- $${f.operations.base.toLocaleString()} (operations)`);
+    }
+    if (f.operations.artists > 0) {
+      parts.push(`- $${f.operations.artists.toLocaleString()} (artists)`);
+    }
+    if (f.operations.executives > 0) {
+      parts.push(`- $${f.operations.executives.toLocaleString()} (executives)`);
+    }
+    if (f.operations.signingBonuses > 0) {
+      parts.push(`- $${f.operations.signingBonuses.toLocaleString()} (signing bonuses)`);
+    }
+    if (f.projects.costs > 0) {
+      parts.push(`- $${f.projects.costs.toLocaleString()} (projects)`);
+    }
+    if (f.projects.revenue > 0) {
+      parts.push(`+ $${f.projects.revenue.toLocaleString()} (project revenue)`);
+    }
+    if (f.marketing.costs > 0) {
+      parts.push(`- $${f.marketing.costs.toLocaleString()} (marketing)`);
+    }
+    if (f.roleEffects.costs > 0) {
+      parts.push(`- $${f.roleEffects.costs.toLocaleString()} (role costs)`);
+    }
+    if (f.roleEffects.revenue > 0) {
+      parts.push(`+ $${f.roleEffects.revenue.toLocaleString()} (role benefits)`);
+    }
+    if (f.streamingRevenue > 0) {
+      parts.push(`+ $${f.streamingRevenue.toLocaleString()} (streaming)`);
+    }
+
+    parts.push(`= $${f.endingBalance.toLocaleString()}`);
+
+    return parts.join(' ');
+  }
+
+  /**
+   * Generates financial breakdown for display purposes only
+   * Does NOT modify game state - that happens at the end of advanceWeek()
+   */
+  // DELEGATED TO FinancialSystem (originally lines 3126-3172)
+  async calculateWeeklyFinancials(ctx: WeekContext, summary: any): Promise<WeeklyFinancials> {
+    return ctx.financialSystem.calculateWeeklyFinancials(
+      summary,
+      ctx.gameState.money || 0
+    );
+  }
+
+  /**
+   * Enhanced weekly summary generation with economic insights
+   */
+  generateEconomicInsights(ctx: WeekContext): void {
+    const { summary } = ctx;
+    // Track budget efficiency and strategic decisions for the week
+    const projectStartChanges = summary.changes.filter(change =>
+      change.type === 'project_complete' && change.description.includes('Started')
+    );
+
+    if (projectStartChanges.length > 0) {
+      const totalProjectSpend = projectStartChanges.reduce((total, change) =>
+        total + Math.abs(change.amount || 0), 0
+      );
+
+      summary.changes.push({
+        type: 'unlock',
+        description: `💰 Weekly project investment: $${totalProjectSpend.toLocaleString()} across ${projectStartChanges.length} project${projectStartChanges.length > 1 ? 's' : ''}`,
+        amount: 0
+      });
+    }
+
+    // Add economic efficiency reporting for ongoing projects
+    const ongoingRevenue = summary.changes.filter(change =>
+      change.type === 'ongoing_revenue'
+    ).reduce((total, change) => total + (change.amount || 0), 0);
+
+    if (ongoingRevenue > 0) {
+      summary.changes.push({
+        type: 'unlock',
+        description: `📈 Catalog revenue efficiency: $${ongoingRevenue.toLocaleString()} from released content`,
+        amount: 0
+      });
+    }
+
+    // Note: Removed efficiency achievement as it serves no gameplay purpose
+    // Instead, track reputation gains per release/activity in their respective sections
+  }
+}

--- a/shared/engine/processors/types.ts
+++ b/shared/engine/processors/types.ts
@@ -25,6 +25,7 @@
 import type { GameState } from '../../schema';
 import type { WeekSummary } from '../../types/gameTypes';
 import type { ServerGameData } from '../../../server/data/gameData';
+import type { FinancialSystem } from '../FinancialSystem';
 
 export interface WeekContext {
   /** Live game state, mutated in place (flags, arOffice columns, money, etc.). */
@@ -35,6 +36,14 @@ export interface WeekContext {
   gameData: ServerGameData;
   /** Storage interface for DB reads/writes. Optional, mirroring GameEngine. */
   storage: any;
+  /**
+   * The engine's FinancialSystem instance (shares the engine's seeded RNG).
+   * WeeklyFinancesProcessor delegates burn/financials calculations to it exactly
+   * as the pre-extraction GameEngine methods did (`this.financialSystem.*`).
+   * Money is still mutated ONLY at the single `[FINAL MONEY]` point in
+   * `GameEngine.advanceWeek` — processors compute breakdowns, never mutate money.
+   */
+  financialSystem: FinancialSystem;
   /**
    * The engine's single seeded RNG draw — `min + rng() * (max - min)`.
    * MUST be bound from GameEngine so the one seeded stream and its draw order


### PR DESCRIPTION
## Summary
PR-6 of the Phase 2 plan — two more verbatim processor extractions following the PR-5 template:
- `ProgressionProcessor` (213 lines): progression gates, access-tier unlocks, producer-tier unlocks, campaign completion
- `WeeklyFinancesProcessor` (140 lines): weekly burn (+breakdown), financial breakdown/insights, weekly financials audit. `calculateExecutiveSalaries` was already wholly in FinancialSystem — nothing to move, documented
- `WeekContext` gains a `financialSystem` field (the finances methods were already thin delegates to it)
- **The single money-update point stays in `advanceWeek`** (`this.gameState.money = finalMoney`, game-engine.ts:366) — processors compute, the engine mutates
- Every moved method keeps a same-signature delegate; caller audit found two external users (a tier-unlock test and a debug script), both preserved. game-engine.ts 4,861 → 4,637

## Verification
- Golden master 8/8, zero snapshot updates, run twice; full suite 652/652; `npm run check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)