### PR TITLE
refactor(engine): extract SongGenerationProcessor + quality unit tests (Phase 2 PR-8)

### DIFF
--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -23,6 +23,7 @@ import { AROfficeProcessor } from './processors/AROfficeProcessor';
 import { ProgressionProcessor } from './processors/ProgressionProcessor';
 import { WeeklyFinancesProcessor } from './processors/WeeklyFinancesProcessor';
 import { TourProcessor } from './processors/TourProcessor';
+import { SongGenerationProcessor } from './processors/SongGenerationProcessor';
 import type { WeekContext } from './processors/types';
 
 // Re-export WeekSummary for backward compatibility
@@ -2033,402 +2034,36 @@ export class GameEngine {
    * Processes song generation for recording projects
    * This is called during weekly processing to create songs for active recording projects
    */
+  // DELEGATED TO SongGenerationProcessor (Phase 2 engine-seams PR-8). Same-signature
+  // wrapper; still called from advanceWeek (stays in engine until later PRs).
   private async processRecordingProjects(summary: WeekSummary, dbTransaction?: any): Promise<void> {
-    
-    try {
-      // Get recording projects from database via ServerGameData
-      const recordingProjects = await this.gameData.getActiveRecordingProjects(this.gameState.id || '', dbTransaction);
-
-      if (!recordingProjects || recordingProjects.length === 0) {
-        return;
-      }
-
-      for (const project of recordingProjects) {
-        if (this.shouldGenerateProjectSongs(project)) {
-          await this.generateWeeklyProjectSongs(project, summary, dbTransaction);
-        }
-      }
-    } catch (error) {
-      console.error('[SONG GENERATION] Error processing recording projects:', error);
-    }
-  }
-
-  /**
-   * Determines if a project should generate songs this week
-   */
-  private shouldGenerateProjectSongs(project: any): boolean {
-    // Only generate songs for recording projects (Singles, EPs) in production stage
-    if (!['Single', 'EP'].includes(project.type) || project.stage !== 'production') {
-      return false;
-    }
-
-    // Check if project still needs to create songs
-    const songCount = project.songCount || 1;
-    const songsCreated = project.songsCreated || 0;
-    
-    return songsCreated < songCount;
-  }
-
-  /**
-   * Generates songs for a recording project during weekly processing
-   */
-  private async generateWeeklyProjectSongs(project: any, summary: WeekSummary, dbTransaction?: any): Promise<void> {
-    
-    try {
-      const artist = await this.gameData.getArtistById(project.artistId);
-      if (!artist) {
-        console.error(`[SONG GENERATION] Artist not found for project ${project.id}`);
-        return;
-      }
-
-      // Determine how many songs to generate this week
-      const remainingSongs = (project.songCount || 1) - (project.songsCreated || 0);
-      const songsPerWeek = this.getSongsPerWeek(project.type);
-      const songsToGenerate = Math.min(remainingSongs, songsPerWeek);
-
-
-      for (let i = 0; i < songsToGenerate; i++) {
-        const song = this.generateSong(project, artist);
-        
-        // Store song via ServerGameData (if available)
-        if (this.gameData.createSong) {
-          try {
-            const savedSong = await this.gameData.createSong(song, dbTransaction);
-          } catch (songError) {
-            console.error(`[SONG GENERATION] Failed to save song:`, songError);
-            continue;
-          }
-        } else {
-          console.warn(`[SONG GENERATION] createSong method not available on gameData`);
-        }
-
-        // Update project progress
-        project.songsCreated = (project.songsCreated || 0) + 1;
-        
-        // Enhanced summary with economic insights
-        const economicInsight = this.generateSongEconomicInsight(song, project);
-        
-        summary.changes.push({
-          type: 'project_complete', // Using existing type for now
-          description: `Created song: "${song.title}" for ${project.title} - ${economicInsight}`,
-          projectId: project.id,
-          amount: 0
-        });
-      }
-
-      // Update project in database
-      if (this.gameData.updateProject) {
-        await this.gameData.updateProject(project.id, {
-          songsCreated: project.songsCreated
-        }, dbTransaction);
-      }
-
-      // Check if project completed all songs
-      if (project.songsCreated >= project.songCount) {
-        // Calculate project completion economic summary
-        const completionSummary = this.generateProjectCompletionSummary(project);
-        
-        summary.changes.push({
-          type: 'project_complete',
-          description: `Recording completed for ${project.title} (${project.songsCreated}/${project.songCount} songs) - ${completionSummary}`,
-          projectId: project.id,
-          amount: 0
-        });
-      }
-
-    } catch (error) {
-      console.error(`[SONG GENERATION] Error generating songs for project ${project.id}:`, error);
-    }
-  }
-
-  /**
-   * Determines how many songs to generate per week based on project type
-   */
-  private getSongsPerWeek(projectType: string): number {
-    switch (projectType) {
-      case 'Single': return 2; // Singles can generate up to 2 songs per week
-      case 'EP': return 3;     // EPs can generate up to 3 songs per week  
-      default: return 2;
-    }
-  }
-
-  /**
-   * Generates a single song for a recording project with enhanced quality calculation
-   */
-  private generateSong(project: any, artist: any): any {
-    const currentWeek = this.gameState.currentWeek || 1;
-    
-    // Get song names from data layer
-    const songNamePools = this.gameData.getBalanceConfigSync()?.song_generation?.name_pools;
-    const defaultSongNames = songNamePools?.default || [
-      // Fallback if data not available
-      'Midnight Dreams', 'City Lights', 'Hearts on Fire', 'Thunder Road'
-    ];
-    
-    // Could use genre-specific names in future based on artist.genre
-    const songNames = defaultSongNames;
-    
-    const randomName = songNames[Math.floor(this.getRandom(0, songNames.length))];
-    
-    // Get producer tier and time investment from project metadata (with defaults)
-    const metadata = project.metadata || {};
-    const producerTier = project.producerTier || metadata.producerTier || 'local';
-    const timeInvestment = project.timeInvestment || metadata.timeInvestment || 'standard';
-    
-    console.log('[GENERATE SONG] Project budget data analysis:', {
-      projectId: project.id,
-      projectTitle: project.title,
-      directBudgetPerSong: project.budgetPerSong,
-      directTotalCost: project.totalCost,
-      projectBudget: project.budget,
-      projectSongCount: project.songCount,
-      producerTier,
-      timeInvestment,
-      hasMetadata: !!metadata,
-      metadataKeys: Object.keys(metadata)
-    });
-    
-    // Extract economic decision data if available
-    const economicDecisions = metadata.economicDecisions || {};
-    const projectBudget = project.budgetPerSong ? (project.budgetPerSong * (project.songCount || 1)) : 
-                          (project.totalCost || project.budget || economicDecisions.finalBudget || 0);
-    
-    console.log('[GENERATE SONG] Budget calculation resolved:', {
-      finalProjectBudget: projectBudget,
-      calculationMethod: project.budgetPerSong ? 'budgetPerSong * songCount' : 
-                          (project.totalCost ? 'totalCost' :
-                          (project.budget ? 'budget' : 
-                          (economicDecisions.finalBudget ? 'economicDecisions.finalBudget' : 'default 0')))
-    });
-    
-    // Calculate enhanced song quality using new stacking formula with budget and song count
-    const finalQuality = this.calculateEnhancedSongQuality(
-      artist, 
-      project, 
-      producerTier, 
-      timeInvestment,
-      projectBudget,
-      project.songCount
+    return new SongGenerationProcessor().processRecordingProjects(
+      this.weekContext(summary, dbTransaction),
+      dbTransaction
     );
-
-    // CRITICAL FIX: Ensure gameId and artistId are properly set
-    // Use project.artistId consistently (this is the ID used in the UI)
-    const gameId = project.gameId || this.gameState.id;
-    const artistId = project.artistId; // Always use project's artistId, not the fetched artist.id
-    
-    // Calculate per-song budget allocation for tracking
-    const perSongBudget = project.songCount > 1 ? Math.round(projectBudget / project.songCount) : projectBudget;
-    
-    console.log('[SONG GENERATION] Creating enhanced song with multiplicative quality:', { 
-      gameId, 
-      artistId, 
-      projectId: project.id,
-      projectTitle: project.title,
-      artistName: artist?.name || 'Unknown',
-      artistTalent: artist?.talent || 50,
-      artistWorkEthic: artist?.workEthic || 50,
-      artistPopularity: artist?.popularity || 0,
-      artistMood: artist?.mood || 50,
-      producerTier,
-      timeInvestment,
-      finalQuality,
-      projectBudget,
-      perSongBudget,
-      songCount: project.songCount
-    });
-    
-    if (!gameId || !artistId) {
-      console.error('[SONG GENERATION] MISSING REQUIRED FIELDS:', { gameId, artistId });
-      throw new Error(`Cannot create song: missing gameId (${gameId}) or artistId (${artistId})`);
-    }
-
-    // Don't include 'id' field - let database generate it
-    return {
-      title: randomName,
-      artistId: artistId,
-      gameId: gameId,
-      quality: Math.round(finalQuality),
-      genre: artist.genre || 'pop', // Would come from artist data
-      mood: this.generateSongMood(),
-      createdWeek: currentWeek,
-      producerTier: producerTier,
-      timeInvestment: timeInvestment,
-      isRecorded: true,
-      isReleased: false,
-      releaseId: null,
-      // Direct foreign key and investment tracking
-      projectId: project.id,
-      productionBudget: Math.round(perSongBudget),
-      marketingAllocation: 0, // Will be set when release is planned
-      // Simplified metadata - only quality calculation details
-      metadata: {
-        artistAttributes: {
-          talent: artist.talent || 50,
-          workEthic: artist.workEthic || 50,
-          popularity: artist.popularity || 0,
-          mood: artist.mood || 50
-        },
-        qualityCalculation: {
-          formula: 'multiplicative_v2',
-          baseQuality: Math.round((artist.talent || 50) * 0.65 + (producerTier === 'legendary' ? 95 : producerTier === 'national' ? 75 : producerTier === 'regional' ? 55 : 40) * 0.35),
-          factors: {
-            time: timeInvestment,
-            producer: producerTier,
-            songCount: project.songCount || 1,
-            budgetPerSong: perSongBudget
-          },
-          final: finalQuality
-        },
-        generatedAt: new Date().toISOString()
-      }
-    };
   }
 
-  /**
-   * Calculates enhanced song quality using multiplicative formula with artist attributes
-   * New formula incorporates talent, work ethic, and popularity
-   */
+  // DELEGATED TO SongGenerationProcessor (Phase 2 engine-seams PR-8). Same-signature
+  // wrapper preserved because the engine's diagnostics path (getSystemStatus, ~:3667)
+  // and scripts/verification/test-song-quality-scenarios.ts still call it on the
+  // engine instance. Draws from the engine's single seeded RNG via weekContext().
   private calculateEnhancedSongQuality(
-    artist: any, 
-    project: any, 
-    producerTier: string, 
+    artist: any,
+    project: any,
+    producerTier: string,
     timeInvestment: string,
     budgetAmount?: number,
     songCount?: number
   ): number {
-    // 1. BASE QUALITY (Talent + Producer Skill hybrid)
-    const producerSkillMap: Record<string, number> = {
-      'local': 40,
-      'regional': 55,
-      'national': 75,
-      'legendary': 95
-    };
-    const producerSkill = producerSkillMap[producerTier] || 40;
-    
-    // Weighted average: talent matters more than producer
-    const artistTalent = artist.talent || 50;
-    const baseQuality = (artistTalent * 0.65 + producerSkill * 0.35);
-    
-    // 2. WORK ETHIC & TIME SYNERGY
-    // Work ethic amplifies time investment effectiveness
-    const timeMultipliers: Record<string, number> = {
-      'rushed': 0.7,      // 70% efficiency
-      'standard': 1.0,    // 100% efficiency (baseline)
-      'extended': 1.1,    // 110% efficiency
-      'perfectionist': 1.2 // 120% efficiency
-    };
-    
-    const artistWorkEthic = artist.workEthic || 50;
-    const workEthicBonus = (artistWorkEthic / 100) * 0.3; // up to 30% bonus
-    const timeFactor = (timeMultipliers[timeInvestment] || 1.0) * (1 + workEthicBonus);
-    
-    // 3. POPULARITY IMPACT
-    // Popularity attracts better session musicians, engineers, features
-    const artistPopularity = artist.popularity || 0;
-    const popularityFactor = 0.95 + 0.1 * Math.sqrt(artistPopularity / 100);
-    // Results in 0.95x to 1.05x multiplier (10% total swing, more balanced)
-    
-    // 4. SESSION FATIGUE
-    // Quality drops 3% per song after 3rd song
-    const actualSongCount = songCount || project.songCount || 1;
-    const focusFactor = Math.pow(0.97, Math.max(0, actualSongCount - 3));
-    
-    // 5. BUDGET IMPACT (using new multiplier method)
-    const totalBudget = budgetAmount || project.totalCost || project.budgetPerSong || 0;
-    const perSongBudget = totalBudget / actualSongCount;
-    const budgetFactor = this.financialSystem.calculateBudgetQualityMultiplier(
-      perSongBudget,
-      project.type || 'single',
+    return new SongGenerationProcessor().calculateEnhancedSongQuality(
+      this.weekContext({ changes: [] } as unknown as WeekSummary),
+      artist,
+      project,
       producerTier,
       timeInvestment,
-      actualSongCount
+      budgetAmount,
+      songCount
     );
-    
-    // 6. MOOD IMPACT (reduced influence)
-    // Mood is temporary, shouldn't dominate permanent attributes
-    const artistMood = artist.mood || 50;
-    const moodFactor = 0.9 + 0.2 * (artistMood / 100); // 0.9x to 1.1x
-    
-    // 7. COMBINE WITH MULTIPLICATIVE APPROACH
-    let quality = baseQuality;
-    
-    // Apply multiplicative factors
-    quality *= timeFactor;        // 0.7x to 1.43x (with work ethic)
-    quality *= popularityFactor;  // 0.8x to 1.1x  
-    quality *= focusFactor;       // 0.85x to 1.0x (for typical 1-5 songs)
-    quality *= budgetFactor;      // 0.7x to 1.3x
-    quality *= moodFactor;        // 0.9x to 1.1x
-    
-    // 8. SKILL-BASED VARIANCE WITH OUTLIER SYSTEM
-    // Higher skill = more consistent results, Lower skill = more random
-    // Combine artist talent and producer skill to determine consistency
-    const combinedSkill = (artistTalent + producerSkill) / 2; // 0-100 scale
-    
-    // Calculate base variance range based on skill level
-    // Low skill (25): ±35% base variance (was 20%)
-    // Medium skill (50): ±20% base variance (was 10%)
-    // High skill (75): ±10% base variance (was 5%)
-    // Max skill (100): ±5% base variance (was 2%)
-    const baseVarianceRange = 35 - (30 * (combinedSkill / 100)); // 35% down to 5%
-    
-    // Check for outlier events (10% chance)
-    // Seeded RNG: getRandom(0, 1) is uniform [0,1), equivalent to Math.random() (Phase 2 PR-1)
-    const outlierRoll = this.getRandom(0, 1);
-    let variance: number;
-    let outlierType = '';
-    
-    if (outlierRoll < 0.05) {
-      // 5% chance of breakout hit (massive positive outlier)
-      // Skill still matters: low skill gets bigger boost potential
-      const outlierBoost = 1.5 + (0.5 * (1 - combinedSkill / 100)); // 1.5x to 2.0x for breakout
-      variance = outlierBoost;
-      outlierType = 'BREAKOUT HIT';
-    } else if (outlierRoll < 0.10) {
-      // 5% chance of critical failure (massive negative outlier)
-      // Skill protects: high skill has less severe failures
-      const outlierPenalty = 0.5 + (0.2 * (combinedSkill / 100)); // 0.5x to 0.7x for failure
-      variance = outlierPenalty;
-      outlierType = 'CRITICAL FAILURE';
-    } else {
-      // 90% normal variance within calculated range
-      variance = 1 + (this.getRandom(-baseVarianceRange, baseVarianceRange) / 100);
-    }
-    
-    quality *= variance;
-    
-    // Log the variance for debugging
-    console.log(`[QUALITY VARIANCE] Skill-based variance:`, {
-      artistTalent,
-      producerSkill,
-      combinedSkill: combinedSkill.toFixed(1),
-      baseVarianceRange: `±${baseVarianceRange.toFixed(1)}%`,
-      actualVariance: ((variance - 1) * 100).toFixed(1) + '%',
-      outlierType: outlierType || 'NORMAL'
-    });
-    
-    // 9. FLOOR AND CEILING
-    // Ensure minimum quality even with bad inputs
-    const QUALITY_FLOOR = 25;   // No song is completely worthless
-    const QUALITY_CEILING = 98;  // Leave room for legendary moments
-    
-    const finalQuality = Math.round(Math.min(QUALITY_CEILING, Math.max(QUALITY_FLOOR, quality)));
-    
-    console.log(`[QUALITY CALC] New multiplicative song quality calculation:`, {
-      baseQuality: baseQuality.toFixed(1),
-      artistTalent,
-      producerSkill,
-      artistWorkEthic,
-      timeFactor: timeFactor.toFixed(3),
-      popularityFactor: popularityFactor.toFixed(3),
-      focusFactor: focusFactor.toFixed(3),
-      budgetFactor: budgetFactor.toFixed(3),
-      moodFactor: moodFactor.toFixed(3),
-      variance: variance.toFixed(3),
-      rawQuality: quality.toFixed(1),
-      finalQuality
-    });
-    
-    return finalQuality;
   }
 
   /**
@@ -2460,30 +2095,11 @@ export class GameEngine {
     return this.financialSystem.calculateSongCountQualityImpact(songCount);
   }
 
-  /**
-   * Generates a random mood for a song
-   */
-  private generateSongMood(): string {
-    const moodTypes = this.gameData.getBalanceConfigSync()?.song_generation?.mood_types;
-    const moods = moodTypes || ['upbeat', 'melancholic', 'aggressive', 'chill'];
-    return moods[Math.floor(this.getRandom(0, moods.length))];
-  }
-  
-  /**
-   * Generates economic insight summary for song creation
-   */
-  // DELEGATED TO FinancialSystem
-  private generateSongEconomicInsight(song: any, project: any): string {
-    return FinancialSystem.generateSongEconomicInsight(song, project);
-  }
-  
-  /**
-   * Generates economic summary for project completion
-   */
-  // DELEGATED TO FinancialSystem
-  private generateProjectCompletionSummary(project: any): string {
-    return FinancialSystem.generateProjectCompletionSummary(project);
-  }
+  // MOVED TO SongGenerationProcessor (Phase 2 engine-seams PR-8):
+  //   generateSong, generateWeeklyProjectSongs, shouldGenerateProjectSongs,
+  //   getSongsPerWeek, generateSongMood, generateSongEconomicInsight,
+  //   generateProjectCompletionSummary. These had no callers outside the moved
+  //   song-generation set, so no engine delegates are kept for them.
 
   /**
    * Calculates ongoing revenue for an individual released song using streaming decay formula

--- a/shared/engine/processors/SongGenerationProcessor.ts
+++ b/shared/engine/processors/SongGenerationProcessor.ts
@@ -1,0 +1,468 @@
+/**
+ * SongGenerationProcessor — weekly recording-project song generation + the
+ * enhanced (multiplicative) song-quality formula.
+ *
+ * Phase 2 engine-seams §2 row 5. VERBATIM move of nine `GameEngine` methods:
+ * `processRecordingProjects`, `shouldGenerateProjectSongs`,
+ * `generateWeeklyProjectSongs`, `getSongsPerWeek`, `generateSong`,
+ * `calculateEnhancedSongQuality`, `generateSongMood`,
+ * `generateSongEconomicInsight`, and `generateProjectCompletionSummary`.
+ * Every log line, branch, RNG draw, budget calculation, summary mutation, and
+ * storage/gameData call is preserved character-for-character. Only `this.` is
+ * rebound: dependency access (`this.gameData` → `ctx.gameData`, `this.gameState`
+ * → `ctx.gameState`, `this.getRandom` → `ctx.getRandom`, `this.financialSystem`
+ * → `ctx.financialSystem`) flows through the injected `WeekContext`, while the
+ * intra-processor method calls stay `this.*` (they now resolve within the class).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * RNG INVARIANT (see ./types.ts) — HIGHEST-RISK PROCESSOR:
+ *   `generateSong` and `calculateEnhancedSongQuality` make MANY sequential
+ *   `ctx.getRandom(...)` draws (song-name pick, mood pick, the outlier roll at
+ *   `:2376`, and the normal-variance draw at `:2394`). The outcome for a given
+ *   seed depends on the EXACT ORDER of these draws — the quality formula is the
+ *   game's "crown jewel". Bodies are moved wholesale with ZERO reordering so the
+ *   golden master stays byte-identical.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * The processor is stateless — all state flows through the `WeekContext`.
+ * `processRecordingProjects` is still called from `GameEngine.advanceWeek`, and
+ * `calculateEnhancedSongQuality` is still reached by the engine's
+ * `getSystemStatus`-style diagnostics and `scripts/verification/
+ * test-song-quality-scenarios.ts`; the engine's same-signature delegates keep
+ * those call sites working.
+ *
+ * `FinancialSystem` is imported for its two static flavor-text helpers
+ * (`generateSongEconomicInsight` / `generateProjectCompletionSummary`), exactly
+ * as the pre-extraction engine methods called them.
+ */
+import type { WeekContext } from './types';
+import type { WeekSummary } from '../../types/gameTypes';
+import { FinancialSystem } from '../FinancialSystem';
+
+export class SongGenerationProcessor {
+  async processRecordingProjects(ctx: WeekContext, dbTransaction?: any): Promise<void> {
+    const { summary } = ctx;
+
+    try {
+      // Get recording projects from database via ServerGameData
+      const recordingProjects = await ctx.gameData.getActiveRecordingProjects(ctx.gameState.id || '', dbTransaction);
+
+      if (!recordingProjects || recordingProjects.length === 0) {
+        return;
+      }
+
+      for (const project of recordingProjects) {
+        if (this.shouldGenerateProjectSongs(project)) {
+          await this.generateWeeklyProjectSongs(ctx, project, summary, dbTransaction);
+        }
+      }
+    } catch (error) {
+      console.error('[SONG GENERATION] Error processing recording projects:', error);
+    }
+  }
+
+  /**
+   * Determines if a project should generate songs this week
+   */
+  shouldGenerateProjectSongs(project: any): boolean {
+    // Only generate songs for recording projects (Singles, EPs) in production stage
+    if (!['Single', 'EP'].includes(project.type) || project.stage !== 'production') {
+      return false;
+    }
+
+    // Check if project still needs to create songs
+    const songCount = project.songCount || 1;
+    const songsCreated = project.songsCreated || 0;
+
+    return songsCreated < songCount;
+  }
+
+  /**
+   * Generates songs for a recording project during weekly processing
+   */
+  async generateWeeklyProjectSongs(ctx: WeekContext, project: any, summary: WeekSummary, dbTransaction?: any): Promise<void> {
+
+    try {
+      const artist = await ctx.gameData.getArtistById(project.artistId);
+      if (!artist) {
+        console.error(`[SONG GENERATION] Artist not found for project ${project.id}`);
+        return;
+      }
+
+      // Determine how many songs to generate this week
+      const remainingSongs = (project.songCount || 1) - (project.songsCreated || 0);
+      const songsPerWeek = this.getSongsPerWeek(project.type);
+      const songsToGenerate = Math.min(remainingSongs, songsPerWeek);
+
+
+      for (let i = 0; i < songsToGenerate; i++) {
+        const song = this.generateSong(ctx, project, artist);
+
+        // Store song via ServerGameData (if available)
+        if (ctx.gameData.createSong) {
+          try {
+            const savedSong = await ctx.gameData.createSong(song, dbTransaction);
+          } catch (songError) {
+            console.error(`[SONG GENERATION] Failed to save song:`, songError);
+            continue;
+          }
+        } else {
+          console.warn(`[SONG GENERATION] createSong method not available on gameData`);
+        }
+
+        // Update project progress
+        project.songsCreated = (project.songsCreated || 0) + 1;
+
+        // Enhanced summary with economic insights
+        const economicInsight = this.generateSongEconomicInsight(song, project);
+
+        summary.changes.push({
+          type: 'project_complete', // Using existing type for now
+          description: `Created song: "${song.title}" for ${project.title} - ${economicInsight}`,
+          projectId: project.id,
+          amount: 0
+        });
+      }
+
+      // Update project in database
+      if (ctx.gameData.updateProject) {
+        await ctx.gameData.updateProject(project.id, {
+          songsCreated: project.songsCreated
+        }, dbTransaction);
+      }
+
+      // Check if project completed all songs
+      if (project.songsCreated >= project.songCount) {
+        // Calculate project completion economic summary
+        const completionSummary = this.generateProjectCompletionSummary(project);
+
+        summary.changes.push({
+          type: 'project_complete',
+          description: `Recording completed for ${project.title} (${project.songsCreated}/${project.songCount} songs) - ${completionSummary}`,
+          projectId: project.id,
+          amount: 0
+        });
+      }
+
+    } catch (error) {
+      console.error(`[SONG GENERATION] Error generating songs for project ${project.id}:`, error);
+    }
+  }
+
+  /**
+   * Determines how many songs to generate per week based on project type
+   */
+  getSongsPerWeek(projectType: string): number {
+    switch (projectType) {
+      case 'Single': return 2; // Singles can generate up to 2 songs per week
+      case 'EP': return 3;     // EPs can generate up to 3 songs per week
+      default: return 2;
+    }
+  }
+
+  /**
+   * Generates a single song for a recording project with enhanced quality calculation
+   */
+  generateSong(ctx: WeekContext, project: any, artist: any): any {
+    const currentWeek = ctx.gameState.currentWeek || 1;
+
+    // Get song names from data layer
+    const songNamePools = ctx.gameData.getBalanceConfigSync()?.song_generation?.name_pools;
+    const defaultSongNames = songNamePools?.default || [
+      // Fallback if data not available
+      'Midnight Dreams', 'City Lights', 'Hearts on Fire', 'Thunder Road'
+    ];
+
+    // Could use genre-specific names in future based on artist.genre
+    const songNames = defaultSongNames;
+
+    const randomName = songNames[Math.floor(ctx.getRandom(0, songNames.length))];
+
+    // Get producer tier and time investment from project metadata (with defaults)
+    const metadata = project.metadata || {};
+    const producerTier = project.producerTier || metadata.producerTier || 'local';
+    const timeInvestment = project.timeInvestment || metadata.timeInvestment || 'standard';
+
+    console.log('[GENERATE SONG] Project budget data analysis:', {
+      projectId: project.id,
+      projectTitle: project.title,
+      directBudgetPerSong: project.budgetPerSong,
+      directTotalCost: project.totalCost,
+      projectBudget: project.budget,
+      projectSongCount: project.songCount,
+      producerTier,
+      timeInvestment,
+      hasMetadata: !!metadata,
+      metadataKeys: Object.keys(metadata)
+    });
+
+    // Extract economic decision data if available
+    const economicDecisions = metadata.economicDecisions || {};
+    const projectBudget = project.budgetPerSong ? (project.budgetPerSong * (project.songCount || 1)) :
+                          (project.totalCost || project.budget || economicDecisions.finalBudget || 0);
+
+    console.log('[GENERATE SONG] Budget calculation resolved:', {
+      finalProjectBudget: projectBudget,
+      calculationMethod: project.budgetPerSong ? 'budgetPerSong * songCount' :
+                          (project.totalCost ? 'totalCost' :
+                          (project.budget ? 'budget' :
+                          (economicDecisions.finalBudget ? 'economicDecisions.finalBudget' : 'default 0')))
+    });
+
+    // Calculate enhanced song quality using new stacking formula with budget and song count
+    const finalQuality = this.calculateEnhancedSongQuality(
+      ctx,
+      artist,
+      project,
+      producerTier,
+      timeInvestment,
+      projectBudget,
+      project.songCount
+    );
+
+    // CRITICAL FIX: Ensure gameId and artistId are properly set
+    // Use project.artistId consistently (this is the ID used in the UI)
+    const gameId = project.gameId || ctx.gameState.id;
+    const artistId = project.artistId; // Always use project's artistId, not the fetched artist.id
+
+    // Calculate per-song budget allocation for tracking
+    const perSongBudget = project.songCount > 1 ? Math.round(projectBudget / project.songCount) : projectBudget;
+
+    console.log('[SONG GENERATION] Creating enhanced song with multiplicative quality:', {
+      gameId,
+      artistId,
+      projectId: project.id,
+      projectTitle: project.title,
+      artistName: artist?.name || 'Unknown',
+      artistTalent: artist?.talent || 50,
+      artistWorkEthic: artist?.workEthic || 50,
+      artistPopularity: artist?.popularity || 0,
+      artistMood: artist?.mood || 50,
+      producerTier,
+      timeInvestment,
+      finalQuality,
+      projectBudget,
+      perSongBudget,
+      songCount: project.songCount
+    });
+
+    if (!gameId || !artistId) {
+      console.error('[SONG GENERATION] MISSING REQUIRED FIELDS:', { gameId, artistId });
+      throw new Error(`Cannot create song: missing gameId (${gameId}) or artistId (${artistId})`);
+    }
+
+    // Don't include 'id' field - let database generate it
+    return {
+      title: randomName,
+      artistId: artistId,
+      gameId: gameId,
+      quality: Math.round(finalQuality),
+      genre: artist.genre || 'pop', // Would come from artist data
+      mood: this.generateSongMood(ctx),
+      createdWeek: currentWeek,
+      producerTier: producerTier,
+      timeInvestment: timeInvestment,
+      isRecorded: true,
+      isReleased: false,
+      releaseId: null,
+      // Direct foreign key and investment tracking
+      projectId: project.id,
+      productionBudget: Math.round(perSongBudget),
+      marketingAllocation: 0, // Will be set when release is planned
+      // Simplified metadata - only quality calculation details
+      metadata: {
+        artistAttributes: {
+          talent: artist.talent || 50,
+          workEthic: artist.workEthic || 50,
+          popularity: artist.popularity || 0,
+          mood: artist.mood || 50
+        },
+        qualityCalculation: {
+          formula: 'multiplicative_v2',
+          baseQuality: Math.round((artist.talent || 50) * 0.65 + (producerTier === 'legendary' ? 95 : producerTier === 'national' ? 75 : producerTier === 'regional' ? 55 : 40) * 0.35),
+          factors: {
+            time: timeInvestment,
+            producer: producerTier,
+            songCount: project.songCount || 1,
+            budgetPerSong: perSongBudget
+          },
+          final: finalQuality
+        },
+        generatedAt: new Date().toISOString()
+      }
+    };
+  }
+
+  /**
+   * Calculates enhanced song quality using multiplicative formula with artist attributes
+   * New formula incorporates talent, work ethic, and popularity
+   */
+  calculateEnhancedSongQuality(
+    ctx: WeekContext,
+    artist: any,
+    project: any,
+    producerTier: string,
+    timeInvestment: string,
+    budgetAmount?: number,
+    songCount?: number
+  ): number {
+    // 1. BASE QUALITY (Talent + Producer Skill hybrid)
+    const producerSkillMap: Record<string, number> = {
+      'local': 40,
+      'regional': 55,
+      'national': 75,
+      'legendary': 95
+    };
+    const producerSkill = producerSkillMap[producerTier] || 40;
+
+    // Weighted average: talent matters more than producer
+    const artistTalent = artist.talent || 50;
+    const baseQuality = (artistTalent * 0.65 + producerSkill * 0.35);
+
+    // 2. WORK ETHIC & TIME SYNERGY
+    // Work ethic amplifies time investment effectiveness
+    const timeMultipliers: Record<string, number> = {
+      'rushed': 0.7,      // 70% efficiency
+      'standard': 1.0,    // 100% efficiency (baseline)
+      'extended': 1.1,    // 110% efficiency
+      'perfectionist': 1.2 // 120% efficiency
+    };
+
+    const artistWorkEthic = artist.workEthic || 50;
+    const workEthicBonus = (artistWorkEthic / 100) * 0.3; // up to 30% bonus
+    const timeFactor = (timeMultipliers[timeInvestment] || 1.0) * (1 + workEthicBonus);
+
+    // 3. POPULARITY IMPACT
+    // Popularity attracts better session musicians, engineers, features
+    const artistPopularity = artist.popularity || 0;
+    const popularityFactor = 0.95 + 0.1 * Math.sqrt(artistPopularity / 100);
+    // Results in 0.95x to 1.05x multiplier (10% total swing, more balanced)
+
+    // 4. SESSION FATIGUE
+    // Quality drops 3% per song after 3rd song
+    const actualSongCount = songCount || project.songCount || 1;
+    const focusFactor = Math.pow(0.97, Math.max(0, actualSongCount - 3));
+
+    // 5. BUDGET IMPACT (using new multiplier method)
+    const totalBudget = budgetAmount || project.totalCost || project.budgetPerSong || 0;
+    const perSongBudget = totalBudget / actualSongCount;
+    const budgetFactor = ctx.financialSystem.calculateBudgetQualityMultiplier(
+      perSongBudget,
+      project.type || 'single',
+      producerTier,
+      timeInvestment,
+      actualSongCount
+    );
+
+    // 6. MOOD IMPACT (reduced influence)
+    // Mood is temporary, shouldn't dominate permanent attributes
+    const artistMood = artist.mood || 50;
+    const moodFactor = 0.9 + 0.2 * (artistMood / 100); // 0.9x to 1.1x
+
+    // 7. COMBINE WITH MULTIPLICATIVE APPROACH
+    let quality = baseQuality;
+
+    // Apply multiplicative factors
+    quality *= timeFactor;        // 0.7x to 1.43x (with work ethic)
+    quality *= popularityFactor;  // 0.8x to 1.1x
+    quality *= focusFactor;       // 0.85x to 1.0x (for typical 1-5 songs)
+    quality *= budgetFactor;      // 0.7x to 1.3x
+    quality *= moodFactor;        // 0.9x to 1.1x
+
+    // 8. SKILL-BASED VARIANCE WITH OUTLIER SYSTEM
+    // Higher skill = more consistent results, Lower skill = more random
+    // Combine artist talent and producer skill to determine consistency
+    const combinedSkill = (artistTalent + producerSkill) / 2; // 0-100 scale
+
+    // Calculate base variance range based on skill level
+    // Low skill (25): ±35% base variance (was 20%)
+    // Medium skill (50): ±20% base variance (was 10%)
+    // High skill (75): ±10% base variance (was 5%)
+    // Max skill (100): ±5% base variance (was 2%)
+    const baseVarianceRange = 35 - (30 * (combinedSkill / 100)); // 35% down to 5%
+
+    // Check for outlier events (10% chance)
+    // Seeded RNG: getRandom(0, 1) is uniform [0,1), equivalent to Math.random() (Phase 2 PR-1)
+    const outlierRoll = ctx.getRandom(0, 1);
+    let variance: number;
+    let outlierType = '';
+
+    if (outlierRoll < 0.05) {
+      // 5% chance of breakout hit (massive positive outlier)
+      // Skill still matters: low skill gets bigger boost potential
+      const outlierBoost = 1.5 + (0.5 * (1 - combinedSkill / 100)); // 1.5x to 2.0x for breakout
+      variance = outlierBoost;
+      outlierType = 'BREAKOUT HIT';
+    } else if (outlierRoll < 0.10) {
+      // 5% chance of critical failure (massive negative outlier)
+      // Skill protects: high skill has less severe failures
+      const outlierPenalty = 0.5 + (0.2 * (combinedSkill / 100)); // 0.5x to 0.7x for failure
+      variance = outlierPenalty;
+      outlierType = 'CRITICAL FAILURE';
+    } else {
+      // 90% normal variance within calculated range
+      variance = 1 + (ctx.getRandom(-baseVarianceRange, baseVarianceRange) / 100);
+    }
+
+    quality *= variance;
+
+    // Log the variance for debugging
+    console.log(`[QUALITY VARIANCE] Skill-based variance:`, {
+      artistTalent,
+      producerSkill,
+      combinedSkill: combinedSkill.toFixed(1),
+      baseVarianceRange: `±${baseVarianceRange.toFixed(1)}%`,
+      actualVariance: ((variance - 1) * 100).toFixed(1) + '%',
+      outlierType: outlierType || 'NORMAL'
+    });
+
+    // 9. FLOOR AND CEILING
+    // Ensure minimum quality even with bad inputs
+    const QUALITY_FLOOR = 25;   // No song is completely worthless
+    const QUALITY_CEILING = 98;  // Leave room for legendary moments
+
+    const finalQuality = Math.round(Math.min(QUALITY_CEILING, Math.max(QUALITY_FLOOR, quality)));
+
+    console.log(`[QUALITY CALC] New multiplicative song quality calculation:`, {
+      baseQuality: baseQuality.toFixed(1),
+      artistTalent,
+      producerSkill,
+      artistWorkEthic,
+      timeFactor: timeFactor.toFixed(3),
+      popularityFactor: popularityFactor.toFixed(3),
+      focusFactor: focusFactor.toFixed(3),
+      budgetFactor: budgetFactor.toFixed(3),
+      moodFactor: moodFactor.toFixed(3),
+      variance: variance.toFixed(3),
+      rawQuality: quality.toFixed(1),
+      finalQuality
+    });
+
+    return finalQuality;
+  }
+
+  /**
+   * Generates a random mood for a song
+   */
+  generateSongMood(ctx: WeekContext): string {
+    const moodTypes = ctx.gameData.getBalanceConfigSync()?.song_generation?.mood_types;
+    const moods = moodTypes || ['upbeat', 'melancholic', 'aggressive', 'chill'];
+    return moods[Math.floor(ctx.getRandom(0, moods.length))];
+  }
+
+  /**
+   * Generates economic insight summary for song creation
+   */
+  // DELEGATED TO FinancialSystem
+  generateSongEconomicInsight(song: any, project: any): string {
+    return FinancialSystem.generateSongEconomicInsight(song, project);
+  }
+
+  /**
+   * Generates economic summary for project completion
+   */
+  // DELEGATED TO FinancialSystem
+  generateProjectCompletionSummary(project: any): string {
+    return FinancialSystem.generateProjectCompletionSummary(project);
+  }
+}

--- a/tests/engine/song-quality.test.ts
+++ b/tests/engine/song-quality.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Song-quality formula unit tests — Phase 2 engine-seams PR-8.
+ *
+ * Closes review-gap W3 (quality) by testing the "crown jewel" multiplicative
+ * quality formula DIRECTLY against the extracted SongGenerationProcessor
+ * (`calculateEnhancedSongQuality`), NOT over HTTP. Every expectation below was
+ * PINNED against the live code (not the review docs, whose numbers had drifted):
+ * the formula lives in shared/engine/processors/SongGenerationProcessor.ts and
+ * its budget factor is computed by the real FinancialSystem against the real
+ * quality.json config.
+ *
+ * ── RNG model ────────────────────────────────────────────────────────────────
+ * `calculateEnhancedSongQuality` draws from `ctx.getRandom` in a FIXED order:
+ *   draw #1  outlierRoll = getRandom(0, 1)
+ *   draw #2  (ONLY on the normal branch) variance = getRandom(-r, r)
+ * `getRandom(min, max)` is `min + rng() * (max - min)`. We drive the formula two
+ * ways:
+ *   - `scriptedCtx([...])` queues raw rng() values so we can pin the exact branch
+ *     (outlierRoll < 0.05 breakout, < 0.10 critical failure, else normal) and the
+ *     normal-variance magnitude. scripted([0.5, 0.5]) => outlierRoll 0.5 (normal)
+ *     and variance draw 0.5 => `-r + 0.5*2r = 0` => variance factor exactly 1.0,
+ *     giving the deterministic "no-variance baseline".
+ *   - `seededCtx('seed')` uses the real production `seedrandom` stream so a fixed
+ *     seed reproduces identical quality (draw-order == behavior).
+ *
+ * The gameData reuses the golden-master fixtures' `createGameData` (real sync
+ * balance getters + real FinancialSystem validation) but augments
+ * `getBalanceConfigSync` with quality.json's `quality_system` /
+ * `producer_tier_system` — the fixtures balance omits them, so the budget factor
+ * would otherwise no-op (and, notably, that omission is exactly why the golden
+ * master's recording scenario generates zero songs).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import seedrandom from 'seedrandom';
+import { FinancialSystem } from '@shared/engine/FinancialSystem';
+import { SongGenerationProcessor } from '@shared/engine/processors/SongGenerationProcessor';
+import type { WeekContext } from '@shared/engine/processors/types';
+import { createGameData } from './golden-master-fixtures';
+
+// ---------------------------------------------------------------------------
+// gameData: fixtures config getters + real quality_system / producer_tier_system
+// ---------------------------------------------------------------------------
+const quality = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), 'data', 'balance', 'quality.json'), 'utf-8'),
+);
+const baseGameData = createGameData({} as any, []);
+const fullBalance = {
+  ...baseGameData.getBalanceConfigSync(),
+  quality_system: quality.quality_system,
+  producer_tier_system: quality.producer_tier_system,
+};
+const gameData: any = { ...baseGameData, getBalanceConfigSync: () => fullBalance };
+
+// ---------------------------------------------------------------------------
+// ctx builders
+// ---------------------------------------------------------------------------
+function makeCtx(rng: () => number): WeekContext {
+  const financialSystem = new FinancialSystem(gameData, rng);
+  return {
+    gameState: {} as any,
+    summary: { changes: [] } as any,
+    gameData,
+    storage: {},
+    financialSystem,
+    getRandom: (min: number, max: number) => min + rng() * (max - min),
+  };
+}
+
+/** Queues raw rng() values (cycled if exhausted) so we pin the exact RNG branch. */
+function scriptedCtx(values: number[]): WeekContext {
+  let i = 0;
+  return makeCtx(() => values[i++ % values.length]);
+}
+
+/** Uses the real production seedrandom stream (draw-order == behavior). */
+function seededCtx(seed: string): WeekContext {
+  return makeCtx(seedrandom(seed));
+}
+
+const proc = new SongGenerationProcessor();
+const PROJECT = { type: 'single', songCount: 1 };
+const NEUTRAL_ARTIST = { talent: 50, workEthic: 50, popularity: 0, mood: 50 };
+
+/** Convenience wrapper for the neutral no-variance baseline (variance factor 1.0). */
+function qual(
+  ctx: WeekContext,
+  artist: any,
+  producerTier: string,
+  timeInvestment: string,
+  budget: number,
+  songCount: number,
+) {
+  return proc.calculateEnhancedSongQuality(
+    ctx,
+    artist,
+    PROJECT,
+    producerTier,
+    timeInvestment,
+    budget,
+    songCount,
+  );
+}
+
+// ===========================================================================
+describe('SongGenerationProcessor.calculateEnhancedSongQuality', () => {
+  // --- (a) determinism -----------------------------------------------------
+  it('same seed => identical quality (draw-order is behavior)', () => {
+    const q1 = qual(seededCtx('DET'), NEUTRAL_ARTIST, 'regional', 'extended', 4000, 2);
+    const q2 = qual(seededCtx('DET'), NEUTRAL_ARTIST, 'regional', 'extended', 4000, 2);
+    expect(q1).toBe(q2);
+    expect(q1).toBe(36); // pinned against live code
+  });
+
+  it('different seeds can produce different quality (RNG actually varies output)', () => {
+    const results = new Set<number>();
+    for (const s of ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8']) {
+      results.add(qual(seededCtx(s), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1));
+    }
+    expect(results.size).toBeGreaterThan(1);
+  });
+
+  // --- (b) multiplicative factor boundaries --------------------------------
+  // All boundary tests use scriptedCtx([0.5, 0.5]) => variance factor exactly 1.0,
+  // so ONLY the factor under test moves the number.
+
+  it('talent boundary: 0 vs 100 (talent dominates base quality, monotonic up)', () => {
+    const t0 = qual(scriptedCtx([0.5, 0.5]), { ...NEUTRAL_ARTIST, talent: 0 }, 'local', 'standard', 4000, 1);
+    const t100 = qual(scriptedCtx([0.5, 0.5]), { ...NEUTRAL_ARTIST, talent: 100 }, 'local', 'standard', 4000, 1);
+    expect(t0).toBe(44);
+    expect(t100).toBe(75);
+    expect(t100).toBeGreaterThan(t0);
+  });
+
+  it('producer tiers map local<regional<national<legendary (40/55/75/95 skill)', () => {
+    const local = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 20000, 1);
+    const regional = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'regional', 'standard', 20000, 1);
+    const national = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'national', 'standard', 20000, 1);
+    const legendary = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'legendary', 'standard', 20000, 1);
+    expect([local, regional, national, legendary]).toEqual([66, 73, 83, 93]);
+    expect(local).toBeLessThan(regional);
+    expect(regional).toBeLessThan(national);
+    expect(national).toBeLessThan(legendary);
+  });
+
+  it('unknown producer tier falls back to local skill (40)', () => {
+    const unknown = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'garbage-tier', 'standard', 20000, 1);
+    const local = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 20000, 1);
+    expect(unknown).toBe(local);
+  });
+
+  it('time investment multipliers rushed<standard<extended<perfectionist (0.7/1.0/1.1/1.2)', () => {
+    const rushed = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'rushed', 4000, 1);
+    const standard = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1);
+    const extended = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'extended', 4000, 1);
+    const perfectionist = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'perfectionist', 4000, 1);
+    expect([rushed, standard, extended, perfectionist]).toEqual([31, 44, 48, 53]);
+    expect(rushed).toBeLessThan(standard);
+    expect(standard).toBeLessThan(extended);
+    expect(extended).toBeLessThan(perfectionist);
+  });
+
+  it('mood factor is a bounded 0.9x-1.1x swing (mood 0 < mood 100, small delta)', () => {
+    const m0 = qual(scriptedCtx([0.5, 0.5]), { ...NEUTRAL_ARTIST, mood: 0 }, 'local', 'standard', 4000, 1);
+    const m100 = qual(scriptedCtx([0.5, 0.5]), { ...NEUTRAL_ARTIST, mood: 100 }, 'local', 'standard', 4000, 1);
+    expect(m0).toBe(44);
+    expect(m100).toBe(48);
+    expect(m100).toBeGreaterThan(m0);
+    // 0.9x..1.1x over baseline ~46 => at most ~a few points; never a large swing
+    expect(m100 - m0).toBeLessThanOrEqual(6);
+  });
+
+  it('popularity factor is a bounded 0.95x-1.05x swing (pop 0 < pop 100, small delta)', () => {
+    const p0 = qual(scriptedCtx([0.5, 0.5]), { ...NEUTRAL_ARTIST, popularity: 0 }, 'local', 'standard', 4000, 1);
+    const p100 = qual(scriptedCtx([0.5, 0.5]), { ...NEUTRAL_ARTIST, popularity: 100 }, 'local', 'standard', 4000, 1);
+    expect(p0).toBe(44);
+    expect(p100).toBe(49);
+    expect(p100).toBeGreaterThan(p0);
+    expect(p100 - p0).toBeLessThanOrEqual(6);
+  });
+
+  it('session fatigue: songCount beyond 3 (0.97^n) reduces quality at matched per-song budget', () => {
+    // per-song budget held at 4000 => budgetAmount = 4000 * songCount.
+    // focusFactor = 0.97^max(0, songCount-3): equal at 1 & 3, then decays.
+    const sc3 = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 12000, 3);
+    const sc6 = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 24000, 6);
+    expect(sc3).toBe(46);
+    expect(sc6).toBe(42);
+    expect(sc6).toBeLessThan(sc3);
+  });
+
+  it('budget factor: higher per-song budget raises quality (real FinancialSystem multiplier)', () => {
+    const low = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 500, 1);
+    const high = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 30000, 1);
+    expect(low).toBe(33);
+    expect(high).toBe(69);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  // --- (c) clamp floor/ceiling 25 / 98 -------------------------------------
+  it('clamps to floor 25 with worst-case inputs + critical failure', () => {
+    const floor = qual(
+      scriptedCtx([0.07]), // critical-failure branch (single draw)
+      { talent: 0, workEthic: 0, popularity: 0, mood: 0 },
+      'local',
+      'rushed',
+      0,
+      10,
+    );
+    expect(floor).toBe(25);
+  });
+
+  it('clamps to ceiling 98 with best-case inputs + breakout hit', () => {
+    const ceil = qual(
+      scriptedCtx([0.01]), // breakout branch (single draw)
+      { talent: 100, workEthic: 100, popularity: 100, mood: 100 },
+      'legendary',
+      'perfectionist',
+      50000,
+      1,
+    );
+    expect(ceil).toBe(98);
+  });
+
+  // --- (d) outlier branches ------------------------------------------------
+  it('breakout hit (outlierRoll < 0.05): variance multiplier 1.5x-2.0x, beats no-variance baseline', () => {
+    const baseline = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1); // 44
+    const breakout = qual(scriptedCtx([0.01]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1); // 78
+    expect(baseline).toBe(44);
+    expect(breakout).toBe(78);
+    expect(breakout).toBeGreaterThan(baseline);
+    // boost is 1.5x-2.0x; raw baseline (pre-clamp) is ~44, so breakout >= 1.5x baseline region
+    expect(breakout).toBeGreaterThanOrEqual(Math.round(baseline * 1.5));
+  });
+
+  it('breakout boost is larger for lower combined skill (skill still matters)', () => {
+    // low skill (talent 0, local) gets a bigger multiplier than mid skill, but low
+    // base can leave the final number equal after rounding — assert boost direction
+    // via the pre-clamp relationship: low-skill breakout is not below mid-skill * (base ratio).
+    const midBreakout = qual(scriptedCtx([0.01]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1);
+    const lowBreakout = qual(scriptedCtx([0.01]), { ...NEUTRAL_ARTIST, talent: 0 }, 'local', 'standard', 4000, 1);
+    // Both land at breakout; low-skill's higher multiplier compensates its lower base.
+    expect(midBreakout).toBe(78);
+    expect(lowBreakout).toBe(78);
+  });
+
+  it('critical failure (0.05 <= outlierRoll < 0.10): variance multiplier 0.5x-0.7x, below baseline', () => {
+    const baseline = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1); // 44
+    const critfail = qual(scriptedCtx([0.07]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1); // 26
+    expect(baseline).toBe(44);
+    expect(critfail).toBe(26);
+    expect(critfail).toBeLessThan(baseline);
+    // penalty 0.5x-0.7x; result should be at or below 0.7x baseline region
+    expect(critfail).toBeLessThanOrEqual(Math.round(baseline * 0.7));
+  });
+
+  it('critical failure is less severe for high skill (skill protects)', () => {
+    // High-skill critfail penalty is only 0.7x and base is very high, so it clamps
+    // at the ceiling — demonstrably less punished than a mid-skill critfail.
+    const highSkillCritfail = qual(
+      scriptedCtx([0.07]),
+      { talent: 100, workEthic: 100, popularity: 100, mood: 100 },
+      'legendary',
+      'perfectionist',
+      20000,
+      1,
+    );
+    const midCritfail = qual(scriptedCtx([0.07]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1);
+    expect(highSkillCritfail).toBe(98);
+    expect(highSkillCritfail).toBeGreaterThan(midCritfail);
+  });
+
+  it('normal branch variance widens quality symmetrically around baseline (skill-based range)', () => {
+    // outlierRoll 0.5 (normal), then variance draw at +max and -max of the range.
+    const plusMax = qual(scriptedCtx([0.5, 1.0]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1); // 54
+    const minusMax = qual(scriptedCtx([0.5, 0.0]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1); // 35
+    const baseline = qual(scriptedCtx([0.5, 0.5]), NEUTRAL_ARTIST, 'local', 'standard', 4000, 1); // 44
+    expect(plusMax).toBe(54);
+    expect(minusMax).toBe(35);
+    expect(plusMax).toBeGreaterThan(baseline);
+    expect(minusMax).toBeLessThan(baseline);
+  });
+});


### PR DESCRIPTION
## Summary
PR-8 of the Phase 2 plan — the quality formula ("crown jewel") moved verbatim:
- `SongGenerationProcessor` (468 lines, 9 methods): song generation, the multiplicative quality formula with the seeded outlier system, weekly generation gating, flavor-text helpers. game-engine.ts → 4,001 lines
- Two delegates kept for external callers (`processRecordingProjects` for advanceWeek, `calculateEnhancedSongQuality` for engine diagnostics + a verification script); everything else had zero outside users (audited)
- **New `tests/engine/song-quality.test.ts` (17 tests)** — first real coverage of the formula (review gap W3): producer skill map 40/55/75/95, time multipliers 0.7/1.0/1.1/1.2, mood 0.9–1.1×, popularity 0.95–1.05×, fatigue 0.97^(n−3), outlier branches (<0.05 breakout 1.5–2.0×, <0.10 critical 0.5–0.7×), clamp 25/98 — all pinned by executing the code with fixed seeds, not from the (drifted) docs

## Verification
- Golden master 8/8, zero updates, twice; quality tests 17/17 twice (seed-stable); full suite 670/670; `npm run check` clean

**Found and flagged**: the golden-master fixtures omit `quality_system`/`producer_tier_system` config, so the recording-week scenario silently generates zero songs (swallowed TypeError) — the scenario pins a no-op, not the real quality path. Fixtures fix + snapshot regeneration lands at the start of PR-9, which needs songs to exist for the stage-machine move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)