### PR TITLE
chore(engine): dead code + dead config sweep + stop legacy A&R writes (Phase 2 PR-12)

### DIFF
--- a/data/balance.ts
+++ b/data/balance.ts
@@ -49,7 +49,6 @@ const balance = {
     campaign_length_weeks: projects.time_progression.campaign_length_weeks,
     focus_slots_base: projects.time_progression.focus_slots_base,
     focus_slots_max: projects.time_progression.focus_slots_max,
-    project_durations: projects.time_progression.project_durations,
     seasonal_modifiers: markets.seasonal_modifiers
   },
   

--- a/data/balance/economy.json
+++ b/data/balance/economy.json
@@ -49,12 +49,6 @@
         "medium_project": 4,
         "large_project": 7
       }
-    },
-    "quality_per_song_impact": {
-      "enabled": true,
-      "base_quality_per_song": 0.95,
-      "min_quality_multiplier": 0.85,
-      "description": "More songs slightly reduce individual song quality due to divided attention"
     }
   },
   

--- a/data/balance/projects.json
+++ b/data/balance/projects.json
@@ -8,15 +8,7 @@
     ],
     "_dev_note_focus_slots": "The 4th-slot unlock is REPUTATION-based and lives in progression.json -> progression_thresholds.fourth_focus_slot_reputation (canonical). Only focus_slots_base/max live here.",
     "focus_slots_base": 3,
-    "focus_slots_max": 4,
-    
-    "project_durations": {
-      "single_recording": [2, 4],
-      "ep_recording": [4, 8], 
-      "mini_tour": [2, 6],
-      "pr_campaign": [1, 3],
-      "digital_campaign": [1, 4]
-    }
+    "focus_slots_max": 4
   },
   
   "save_system": {

--- a/data/balance/quality.json
+++ b/data/balance/quality.json
@@ -17,10 +17,6 @@
         "diminishing_threshold": 3.5
       },
       "segment_slopes": {
-        "penalty_range": -0.35,
-        "viable_range": 0.25,
-        "optimal_range": 0.15,
-        "luxury_range": 0.10,
         "diminishing_factor": 0.25
       },
       "efficiency_dampening": {
@@ -49,25 +45,21 @@
     "local": {
       "multiplier": 1.0,
       "unlock_rep": 0,
-      "quality_bonus": 0,
       "description": "Local producers with basic equipment and experience"
     },
     "regional": {
       "multiplier": 1.8,
       "unlock_rep": 15,
-      "quality_bonus": 5,
       "description": "Regional producers with professional equipment and experience"
     },
     "national": {
       "multiplier": 3.2,
       "unlock_rep": 35,
-      "quality_bonus": 12,
       "description": "National producers with industry connections and top-tier equipment"
     },
     "legendary": {
       "multiplier": 5.5,
       "unlock_rep": 60,
-      "quality_bonus": 20,
       "description": "Legendary producers with Grammy awards and platinum records"
     }
   },
@@ -76,25 +68,21 @@
     "rushed": {
       "multiplier": 0.7,
       "duration_modifier": 0.8,
-      "quality_bonus": -10,
       "description": "Rushed production to meet tight deadlines"
     },
     "standard": {
       "multiplier": 1.0,
       "duration_modifier": 1.0,
-      "quality_bonus": 0,
       "description": "Standard production timeline with adequate time for quality"
     },
     "extended": {
       "multiplier": 1.4,
       "duration_modifier": 1.3,
-      "quality_bonus": 8,
       "description": "Extended production time for higher quality and polish"
     },
     "perfectionist": {
       "multiplier": 2.1,
       "duration_modifier": 1.6,
-      "quality_bonus": 15,
       "description": "Perfectionist approach with unlimited time for the highest quality"
     }
   }

--- a/server/data/gameData.ts
+++ b/server/data/gameData.ts
@@ -668,10 +668,10 @@ export class ServerGameData {
   getProducerTierSystemSync() {
     if (!this.balanceData) {
       return {
-        local: { multiplier: 1.0, unlock_rep: 0, quality_bonus: 0, description: "Local producers" },
-        regional: { multiplier: 1.8, unlock_rep: 15, quality_bonus: 5, description: "Regional producers" },
-        national: { multiplier: 3.2, unlock_rep: 35, quality_bonus: 12, description: "National producers" },
-        legendary: { multiplier: 5.5, unlock_rep: 60, quality_bonus: 20, description: "Legendary producers" }
+        local: { multiplier: 1.0, unlock_rep: 0, description: "Local producers" },
+        regional: { multiplier: 1.8, unlock_rep: 15, description: "Regional producers" },
+        national: { multiplier: 3.2, unlock_rep: 35, description: "National producers" },
+        legendary: { multiplier: 5.5, unlock_rep: 60, description: "Legendary producers" }
       };
     }
     
@@ -682,10 +682,10 @@ export class ServerGameData {
   getTimeInvestmentSystemSync() {
     if (!this.balanceData) {
       return {
-        rushed: { multiplier: 0.7, duration_modifier: 0.8, quality_bonus: -10, description: "Rushed production" },
-        standard: { multiplier: 1.0, duration_modifier: 1.0, quality_bonus: 0, description: "Standard production" },
-        extended: { multiplier: 1.4, duration_modifier: 1.3, quality_bonus: 8, description: "Extended production" },
-        perfectionist: { multiplier: 2.1, duration_modifier: 1.6, quality_bonus: 15, description: "Perfectionist production" }
+        rushed: { multiplier: 0.7, duration_modifier: 0.8, description: "Rushed production" },
+        standard: { multiplier: 1.0, duration_modifier: 1.0, description: "Standard production" },
+        extended: { multiplier: 1.4, duration_modifier: 1.3, description: "Extended production" },
+        perfectionist: { multiplier: 2.1, duration_modifier: 1.6, description: "Perfectionist production" }
       };
     }
     

--- a/shared/engine/FinancialSystem.ts
+++ b/shared/engine/FinancialSystem.ts
@@ -1382,24 +1382,6 @@ export class FinancialSystem {
   }
   
   /**
-   * Legacy method for backward compatibility - redirects to new multiplier method
-   * @deprecated Use calculateBudgetQualityMultiplier instead
-   */
-  calculateBudgetQualityBonus(
-    budgetPerSong: number,
-    projectType: string,
-    producerTier: string,
-    timeInvestment: string,
-    songCount: number = 1
-  ): number {
-    // Convert multiplier back to additive bonus for legacy callers
-    const multiplier = this.calculateBudgetQualityMultiplier(budgetPerSong, projectType, producerTier, timeInvestment, songCount);
-    const neutralMult = this.gameData.getBalanceConfigSync().quality_system.budget_quality_system.neutral_multiplier || 1.0;
-    // Convert from multiplier to percentage bonus
-    return Math.round((multiplier - neutralMult) * 100);
-  }
-
-  /**
    * Calculates economies of scale multiplier for cost reduction
    * Helper method used by dynamic minimum viable cost calculation
    */
@@ -1490,38 +1472,6 @@ export class FinancialSystem {
     }
     
     return { rating, description, efficiencyRatio };
-  }
-
-  /**
-   * Calculates song count impact on individual song quality
-   * Originally from game-engine.ts line 1534-1560
-   */
-  calculateSongCountQualityImpact(songCount: number): number {
-    const balance = this.gameData.getBalanceConfigSync();
-    const songCountSystem = balance.economy.song_count_cost_system?.quality_per_song_impact;
-    
-    if (!songCountSystem?.enabled || songCount <= 1) {
-      return 1.0; // No impact for single songs
-    }
-    
-    // Quality decreases slightly for each additional song due to divided attention
-    const baseQualityPerSong = songCountSystem.base_quality_per_song;
-    const minMultiplier = songCountSystem.min_quality_multiplier;
-    
-    // Exponential decay: quality = baseQualityPerSong^(songCount-1)
-    const qualityImpact = Math.pow(baseQualityPerSong, songCount - 1);
-    
-    // Ensure it doesn't go below minimum
-    const finalImpact = Math.max(minMultiplier, qualityImpact);
-    
-    // console.log(`[SONG COUNT IMPACT] Quality impact calculation:`, {
-    //   songCount,
-    //   baseQualityPerSong,
-    //   qualityImpact: qualityImpact.toFixed(3),
-    //   finalImpact: finalImpact.toFixed(3)
-    // });
-    
-    return finalImpact;
   }
 
   /**

--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -475,10 +475,15 @@ export class GameEngine {
       console.log('[EMAIL GENERATION] Checking for discovered artist:', summary.arOffice?.discoveredArtistId);
 
       // BUGFIX: Artist IDs from JSON files are strings (e.g., "art_3"), not UUIDs
-      // We already have the artist data cached in gameState.flags, so use that instead of database lookup
+      // We already have the artist data cached in gameState.flags, so use that instead of database lookup.
+      // Sourced from the canonical ar_office_discovered_artists array (the legacy
+      // singular ar_office_discovered_artist_info flag was retired in Phase 2 PR-12).
       let discoveredArtist = null;
       if (summary.arOffice?.discoveredArtistId) {
-        const artistInfo = (this.gameState.flags as any)?.ar_office_discovered_artist_info;
+        const discoveredArtists = (this.gameState.flags as any)?.ar_office_discovered_artists;
+        const artistInfo = Array.isArray(discoveredArtists)
+          ? discoveredArtists.find((a: any) => a?.id === summary.arOffice?.discoveredArtistId)
+          : undefined;
         if (artistInfo) {
           // Use cached artist info from flags (already populated by processAROfficeWeekly)
           discoveredArtist = {

--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -597,58 +597,6 @@ export class GameEngine {
   }
 
   /**
-   * Processes a role meeting and applies effects
-   */
-  private async processRoleMeeting(action: GameEngineAction, summary: WeekSummary, dbTransaction?: any): Promise<void> {
-    return new ActionProcessor().processRoleMeeting(
-      this.weekContext(summary, dbTransaction),
-      action,
-      dbTransaction
-    );
-  }
-
-  /**
-   * Processes executive-specific effects from actions
-   * Updates mood, loyalty, and lastActionWeek when executives are used
-   */
-  private async processExecutiveActions(
-    action: GameEngineAction,
-    summary: WeekSummary,
-    dbTransaction?: any
-  ): Promise<void> {
-    return new ActionProcessor().processExecutiveActions(
-      this.weekContext(summary, dbTransaction),
-      action,
-      dbTransaction
-    );
-  }
-
-  /**
-   * Select artist with highest popularity for predetermined meetings
-   * Handles edge cases: 0 artists (null), 1 artist (auto-select), ties (random)
-   * Per FR-10 (Predetermined meeting logic)
-   */
-  // DELEGATED TO ArtistStateProcessor (Phase 2 engine-seams PR-11). Same-signature
-  // wrapper; called from processRoleMeeting (predetermined targeting). RNG tie-break
-  // draws from the engine's single seeded stream via weekContext().
-  private async selectHighestPopularityArtist(): Promise<Artist | null> {
-    return new ArtistStateProcessor().selectHighestPopularityArtist(
-      this.weekContext({ changes: [] } as unknown as WeekSummary)
-    );
-  }
-
-  /**
-   * Load signed artists from storage (helper method)
-   */
-  // DELEGATED TO ArtistStateProcessor (Phase 2 engine-seams PR-11). Same-signature
-  // wrapper; called from the applyEffects hub for global artist targeting.
-  private async loadSignedArtists(): Promise<Artist[]> {
-    return new ArtistStateProcessor().loadSignedArtists(
-      this.weekContext({ changes: [] } as unknown as WeekSummary)
-    );
-  }
-
-  /**
    * Applies immediate effects to game state
    * @param effects - Effects to apply
    * @param summary - Week summary to update
@@ -657,6 +605,10 @@ export class GameEngine {
    * @param meetingName - Optional meeting name for logging
    * @param choiceId - Optional choice ID for logging
    */
+  // KEPT (PR-12): no longer called by advanceWeek (moved into ActionProcessor),
+  // but the mood test suite drives the engine's effect application directly via
+  // `(engine as any).applyEffects(...)` (immediate-mood-effect, mood-application-
+  // verification, etc.), so this delegate is part of the tested engine surface.
   private async applyEffects(effects: Record<string, number>, summary: WeekSummary, artistId?: string, targetScope?: string, meetingName?: string, choiceId?: string): Promise<void> {
     return new ActionProcessor().applyEffects(
       this.weekContext(summary),
@@ -753,30 +705,6 @@ export class GameEngine {
     return this.financialSystem.getAccessChance(type, tier);
   }
   
-  /**
-   * Helper to get project duration from balance config
-   */
-  private getProjectDuration(projectType: string): number {
-    // Default durations based on project type
-    const durations = {
-      'single': 2,
-      'ep': 4, 
-      'mini-tour': 1,
-      'mini_tour': 1
-    };
-    
-    return durations[projectType.toLowerCase() as keyof typeof durations] || 2;
-  }
-
-  /**
-   * Calculates weekly operational costs including artist payments
-   */
-  private async calculateWeeklyBurn(): Promise<number> {
-    return new WeeklyFinancesProcessor().calculateWeeklyBurn(
-      this.weekContext({ changes: [] } as unknown as WeekSummary)
-    );
-  }
-
   /**
    * Calculates weekly operational costs with detailed breakdown for transparency
    */
@@ -917,55 +845,11 @@ export class GameEngine {
     );
   }
 
-  /**
-   * Calculates budget bonus for song quality using diminishing returns
-   * Now works with per-song budget amounts for clearer understanding
-   */
-  // DELEGATED TO FinancialSystem (originally lines 1559-1619)
-  calculateBudgetQualityBonus(
-    budgetPerSong: number,
-    projectType: string,
-    producerTier: string,
-    timeInvestment: string,
-    songCount: number = 1
-  ): number {
-    return this.financialSystem.calculateBudgetQualityBonus(
-      budgetPerSong,
-      projectType,
-      producerTier,
-      timeInvestment,
-      songCount
-    );
-  }
-
-  /**
-   * Calculates song count impact on individual song quality
-   */
-  // DELEGATED TO FinancialSystem (originally lines 1534-1560)
-  calculateSongCountQualityImpact(songCount: number): number {
-    return this.financialSystem.calculateSongCountQualityImpact(songCount);
-  }
-
   // MOVED TO SongGenerationProcessor (Phase 2 engine-seams PR-8):
   //   generateSong, generateWeeklyProjectSongs, shouldGenerateProjectSongs,
   //   getSongsPerWeek, generateSongMood, generateSongEconomicInsight,
   //   generateProjectCompletionSummary. These had no callers outside the moved
   //   song-generation set, so no engine delegates are kept for them.
-
-  /**
-   * Calculates ongoing revenue for an individual released song using streaming decay formula
-   * Each song has its own decay pattern based on individual quality and release timing
-   */
-  // DELEGATED TO ReleaseProcessor (Phase 2 engine-seams PR-10). Same-signature
-  // wrapper; kept because the release pipeline formerly called
-  // this.calculateOngoingSongRevenue.
-  private async calculateOngoingSongRevenue(song: any): Promise<number> {
-    return await new ReleaseProcessor().calculateOngoingSongRevenue(
-      this.weekContext({ changes: [] } as unknown as WeekSummary),
-      song
-    );
-  }
-
 
   /**
    * Processes song release - calculates individual song streams and sets initial values
@@ -1108,37 +992,8 @@ export class GameEngine {
   // LEGACY METHOD REMOVED - calculateCityRevenue()
   // Replaced with unified FinancialSystem calculations in processUnifiedTourRevenue()
 
-  /**
-   * Processes tour revenue using unified FinancialSystem calculations
-   * Replaces legacy random-based city revenue system
-   */
-  // DELEGATED TO TourProcessor (Phase 2 engine-seams PR-7). Same-signature wrapper;
-  // still called from advanceProjectStages (stays in engine until PR-9).
-  private async processUnifiedTourRevenue(project: any, cityNumber: number, summary: WeekSummary, dbTransaction?: any): Promise<void> {
-    return new TourProcessor().processUnifiedTourRevenue(
-      this.weekContext(summary, dbTransaction),
-      project,
-      cityNumber,
-      dbTransaction
-    );
-  }
-
   // LEGACY METHOD REMOVED - processTourCityRevenue()
-  // Replaced with processUnifiedTourRevenue() using FinancialSystem calculations
-
-  /**
-   * Processes marketing campaigns (PR, Digital Ads, etc.)
-   */
-  private async processMarketing(action: GameEngineAction, summary: WeekSummary): Promise<void> {
-    return new ActionProcessor().processMarketing(this.weekContext(summary), action);
-  }
-
-  /**
-   * Processes artist dialogue interactions
-   */
-  private async processArtistDialogue(action: GameEngineAction, summary: WeekSummary): Promise<void> {
-    return new ActionProcessor().processArtistDialogue(this.weekContext(summary), action);
-  }
+  // Replaced with TourProcessor.processUnifiedTourRevenue() using FinancialSystem calculations
 
   /**
    * Process weekly charts after releases have been processed
@@ -1240,189 +1095,6 @@ export class GameEngine {
   // Budget efficiency is now handled by FinancialSystem.getBudgetEfficiencyRating()
 
   /**
-   * Calculates outcomes when a project completes
-   */
-  async calculateProjectOutcomes(project: any, summary: WeekSummary): Promise<{
-    revenue: number;
-    streams?: number;
-    pressPickups?: number;
-    description: string;
-  }> {
-    console.log(`[DEBUG] calculateProjectOutcomes called with project:`, {
-      type: project.type,
-      name: project.name,
-      quality: project.quality
-    });
-    
-    let revenue = 0;
-    let streams = 0;
-    let pressPickups = 0;
-    let description = '';
-
-    switch (project.type) {
-      case 'Single':
-      case 'single':
-      case 'EP':
-      case 'ep':
-        // Get artist popularity
-        const artist = await this.storage?.getArtist(project.artistId);
-        const artistPopularity = artist?.popularity || 0;
-
-        // Calculate streaming outcome
-        console.log(`[DEBUG] Calculating streams for ${project.type} project:`, {
-          quality: project.quality || 40,
-          playlistAccess: this.gameState.playlistAccess || 'none',
-          reputation: this.gameState.reputation || 5,
-          marketingSpend: project.marketingSpend || 0,
-          artistPopularity: artistPopularity
-        });
-
-        streams = this.calculateStreamingOutcome(
-          project.quality || 40,
-          this.gameState.playlistAccess || 'none',
-          this.gameState.reputation || 5,
-          project.marketingSpend || 0,
-          artistPopularity
-        );
-        
-        console.log(`[DEBUG] Calculated ${streams} streams for project ${project.name}`);
-        
-        // Revenue = streams × revenue per stream using balance.json configuration
-        const streamingConfig = this.gameData.getStreamingConfigSync();
-        const revenuePerStream = streamingConfig.ongoing_streams.revenue_per_stream;
-        revenue = streams * revenuePerStream;
-        console.log(`[DEBUG] Revenue calculation: ${streams} * ${revenuePerStream} = ${revenue}`);
-        
-        // Calculate press coverage
-        pressPickups = this.calculatePressPickups(
-          this.gameState.pressAccess || 'none',
-          project.marketingSpend || 0,
-          this.gameState.reputation || 5,
-          false // No story flag for basic project completion
-        );
-        
-        // Update reputation based on success
-        const reputationGain = Math.floor(streams / 10000); // 1 rep per 10k streams
-        this.gameState.reputation = Math.min(100, (this.gameState.reputation || 0) + reputationGain);
-        
-        description = `${streams.toLocaleString()} streams, $${Math.round(revenue).toLocaleString()} revenue`;
-        break;
-        
-      case 'Mini-Tour':
-      case 'mini_tour':
-        // NO CALCULATIONS HERE - just check if tour generated revenue
-        const tourStats = project.metadata?.tourStats;
-        if (tourStats?.cities && tourStats.cities.length > 0) {
-          // Sum revenue from completed cities - NO RECALCULATION
-          revenue = tourStats.cities.reduce((sum: number, city: any) => sum + (city.revenue || 0), 0);
-        } else {
-          revenue = 0; // No cities completed yet
-        }
-        
-        description = `$${Math.round(revenue).toLocaleString()} tour revenue`;
-        break;
-    }
-    
-    // Add revenue to summary
-    summary.revenue += revenue;
-    
-    // Add streams to summary for music projects
-    if (streams > 0) {
-      summary.streams = (summary.streams || 0) + streams;
-    }
-    
-    // Add detailed changes
-    if (streams > 0) {
-      summary.changes.push({
-        type: 'revenue',
-        description: `Streaming: ${streams.toLocaleString()} streams`,
-        amount: Math.round(revenue)
-      });
-    }
-    
-    if (pressPickups > 0) {
-      summary.changes.push({
-        type: 'unlock',
-        description: `Press coverage: ${pressPickups} pickup${pressPickups > 1 ? 's' : ''}`
-      });
-    }
-    
-    return { revenue, streams, pressPickups, description };
-  }
-
-  /**
-   * Tests the producer tier and time investment integration systems
-   * Used for debugging and validation of the complete integration
-   */
-  testProducerTierIntegration(): {
-    systemsLoaded: boolean;
-    availableTiers: string[];
-    availableTimeInvestments: string[];
-    costCalculations: Record<string, any>;
-    qualityCalculations: Record<string, any>;
-    validationTests: Record<string, any>;
-  } {
-    const reputation = this.gameState.reputation || 0;
-    
-    // Test system loading
-    const producerSystem = this.gameData.getProducerTierSystemSync();
-    const timeSystem = this.gameData.getTimeInvestmentSystemSync();
-    
-    // Test tier availability
-    const availableTiers = this.gameData.getAvailableProducerTiers(reputation);
-    const availableTimeInvestments = Object.keys(timeSystem);
-    
-    // Test cost calculations
-    const costCalculations: Record<string, any> = {};
-    for (const tier of availableTiers) {
-      for (const time of availableTimeInvestments) {
-        try {
-          const cost = this.calculateEnhancedProjectCost('single', tier, time, 50);
-          costCalculations[`${tier}_${time}`] = { cost, success: true };
-        } catch (error) {
-          costCalculations[`${tier}_${time}`] = { error: error instanceof Error ? error.message : 'Unknown error', success: false };
-        }
-      }
-    }
-    
-    // Test quality calculations
-    const qualityCalculations: Record<string, any> = {};
-    const mockArtist = { mood: 70, archetype: 'workhorse' };
-    const mockProject = { quality: 50, producerTier: 'regional', timeInvestment: 'extended' };
-    
-    try {
-      const quality = this.calculateEnhancedSongQuality(mockArtist, mockProject, 'regional', 'extended');
-      qualityCalculations.enhanced = { quality, success: true };
-    } catch (error) {
-      qualityCalculations.enhanced = { error: error instanceof Error ? error.message : 'Unknown error', success: false };
-    }
-    
-    // Test validation systems
-    const validationTests: Record<string, any> = {};
-    
-    // Test valid combination
-    const validTest = this.validateProducerTierAndTimeInvestment('local', 'standard', reputation);
-    validationTests.valid_combination = validTest;
-    
-    // Test invalid reputation
-    const invalidRepTest = this.validateProducerTierAndTimeInvestment('legendary', 'standard', 5);
-    validationTests.invalid_reputation = invalidRepTest;
-    
-    // Test business rule violation
-    const businessRuleTest = this.validateProducerTierAndTimeInvestment('legendary', 'rushed', 100);
-    validationTests.business_rule_violation = businessRuleTest;
-    
-    return {
-      systemsLoaded: Object.keys(producerSystem).length > 0 && Object.keys(timeSystem).length > 0,
-      availableTiers,
-      availableTimeInvestments,
-      costCalculations,
-      qualityCalculations,
-      validationTests
-    };
-  }
-  
-  /**
    * Enhanced weekly summary generation with economic insights
    */
   private generateEconomicInsights(summary: WeekSummary): void {
@@ -1484,16 +1156,6 @@ export class GameEngine {
       songCount,
       producerTier,
       timeInvestment
-    );
-  }
-
-  /**
-   * Generates human-readable financial breakdown string
-   */
-  private generateFinancialBreakdown(f: WeeklyFinancials): string {
-    return new WeeklyFinancesProcessor().generateFinancialBreakdown(
-      this.weekContext({ changes: [] } as unknown as WeekSummary),
-      f
     );
   }
 

--- a/shared/engine/processors/AROfficeProcessor.ts
+++ b/shared/engine/processors/AROfficeProcessor.ts
@@ -3,8 +3,7 @@
  *
  * First extraction of the Phase 2 engine-seams plan (§2 row 1). The body below
  * is a VERBATIM move of `GameEngine.processAROfficeWeekly`: every log line,
- * branch, flag write (discovered-artists array + legacy singular keys), and the
- * passive-mode `getRandom` draw are preserved character-for-character, with only
+ * branch, and the passive-mode `getRandom` draw are preserved, with only
  * `this.` rebound to the injected `WeekContext` (`this.gameState` → `ctx.gameState`,
  * `this.gameData` → `ctx.gameData`, `this.storage` → `ctx.storage`,
  * `this.getRandom` → `ctx.getRandom`). The `selectBestArtist` helper is a local
@@ -48,6 +47,14 @@ export class AROfficeProcessor {
           gameState.flags = flags;
         }
 
+        // Carry the discovered artist across the inner try/catch scope. The legacy
+        // singular flags (ar_office_discovered_artist_id / _info) are no longer
+        // written (Phase 2 PR-12): the ar_office_discovered_artists array is the
+        // canonical write. These locals reproduce the exact summary/description
+        // values the old legacy-flag reads produced.
+        let discoveredArtistId: string | null = null;
+        let discoveredArtistName: string | undefined;
+
         // Clear start-week flag used by server validation
         if ('ar_office_start_week' in flags) {
           delete flags.ar_office_start_week;
@@ -64,7 +71,6 @@ export class AROfficeProcessor {
 
           if (!allArtists || allArtists.length === 0) {
             console.error('[A&R DEBUG] No artists available in game data');
-            flags.ar_office_discovered_artist_id = null;
             flags.ar_office_error = 'No artists available in game data';
           } else {
             let unsigned = [...allArtists];
@@ -216,15 +222,10 @@ export class AROfficeProcessor {
                 console.log('[A&R DEBUG] Genre filter result:', genreUsed);
               }
 
-              // Keep legacy fields for backwards compatibility
-              flags.ar_office_discovered_artist_id = picked.id;
-              flags.ar_office_discovered_artist_info = {
-                name: picked.name,
-                archetype: picked.archetype,
-                talent: picked.talent || 0,
-                popularity: picked.popularity || 0,
-                genre: picked.genre || null
-              };
+              // Track discovery for summary/description (replaces the retired legacy
+              // ar_office_discovered_artist_id / _info flag reads — Phase 2 PR-12).
+              discoveredArtistId = picked.id;
+              discoveredArtistName = picked.name;
 
               // Populate week summary A&R section with discovered artist id
               // NOTE: This ID may differ from what /ar-office/artists returns if fallback logic is triggered
@@ -235,7 +236,6 @@ export class AROfficeProcessor {
               };
             } else {
               console.log('[A&R DEBUG] No artist selected - no unsigned artists available');
-              flags.ar_office_discovered_artist_id = null;
               flags.ar_office_error = 'No unsigned artists available';
 
               // Create synthetic "no artists available" flag for better client handling
@@ -259,7 +259,6 @@ export class AROfficeProcessor {
 
         } catch (selectErr) {
           console.error('[A&R] Failed to select/persist discovered artist:', selectErr);
-          flags.ar_office_discovered_artist_id = null;
           flags.ar_office_error = selectErr instanceof Error ? selectErr.message : 'Artist selection failed';
           gameState.flags = flags;
         }
@@ -269,12 +268,11 @@ export class AROfficeProcessor {
           summary.arOffice = {
             completed: true,
             sourcingType: sourcingType ?? null,
-            discoveredArtistId: flags.ar_office_discovered_artist_id || null
+            discoveredArtistId: discoveredArtistId || null
           } as any;
         }
 
         // Add comprehensive change description
-        const discoveredArtistName = flags.ar_office_discovered_artist_info?.name;
         let description;
         if (discoveredArtistName) {
           description = `A&R sourcing (${sourcingType || 'active'}) completed. Discovered ${discoveredArtistName}.`;

--- a/shared/engine/processors/ReleaseProcessor.ts
+++ b/shared/engine/processors/ReleaseProcessor.ts
@@ -1193,22 +1193,6 @@ export class ReleaseProcessor {
   }
 
   /**
-   * Gets the release type multiplier from balance.json
-   */
-  private getReleaseTypeMultiplier(ctx: WeekContext, releaseType: string): number {
-    const balance = ctx.gameData.getBalanceConfigSync();
-    const releaseTypeBonuses = balance?.market_formulas?.release_planning?.release_type_bonuses;
-    
-    if (!releaseTypeBonuses) {
-      console.warn('[PLANNED RELEASE] No release type bonuses found in balance.json');
-      return 1.0;
-    }
-    
-    const typeData = releaseTypeBonuses[releaseType.toLowerCase()];
-    return typeData?.revenue_multiplier || 1.0;
-  }
-
-  /**
    * Processes song release - calculates individual song streams and sets initial values
    * This is called when a project completes and songs are released
    */

--- a/shared/types/gameTypes.ts
+++ b/shared/types/gameTypes.ts
@@ -178,14 +178,12 @@ export interface GameProject {
 export interface ProducerTierData {
   multiplier: number;
   unlock_rep: number;
-  quality_bonus: number;
   description: string;
 }
 
 export interface TimeInvestmentData {
   multiplier: number;
   duration_modifier: number;
-  quality_bonus: number;
   description: string;
 }
 
@@ -205,7 +203,6 @@ export interface BalanceConfig {
     campaign_length_weeks: number;
     focus_slots_base: number;
     focus_slots_max: number;
-    project_durations: Record<string, number[]>;
     seasonal_modifiers: Record<string, number>;
   };
   reputation_system: {

--- a/shared/utils/dataLoader.ts
+++ b/shared/utils/dataLoader.ts
@@ -266,7 +266,6 @@ export class GameDataLoader {
         campaign_length_weeks: projects.time_progression.campaign_length_weeks,
         focus_slots_base: projects.time_progression.focus_slots_base,
         focus_slots_max: projects.time_progression.focus_slots_max,
-        project_durations: projects.time_progression.project_durations,
         seasonal_modifiers: markets.seasonal_modifiers // CORRECTLY ASSEMBLED HERE
       }
     };

--- a/tests/engine/__snapshots__/golden-master-advance-week.test.ts.snap
+++ b/tests/engine/__snapshots__/golden-master-advance-week.test.ts.snap
@@ -428,14 +428,6 @@ exports[`GameEngine.advanceWeek — golden master > ar-office-week: sourcing slo
     },
     "flags": {
       "after": {
-        "ar_office_discovered_artist_id": "<id>",
-        "ar_office_discovered_artist_info": {
-          "archetype": "Visionary",
-          "genre": "pop",
-          "name": "Discovery One",
-          "popularity": 40,
-          "talent": 85,
-        },
         "ar_office_discovered_artists": [
           {
             "archetype": "Visionary",


### PR DESCRIPTION
## Summary
PR-12 of the Phase 2 plan — ~440 net lines deleted (game-engine.ts 1,589 → 1,256):
- **Dead code**: `testProducerTierIntegration`, `calculateProjectOutcomes`, the now-dead `processUnifiedTourRevenue`/`generateFinancialBreakdown` engine delegates, `getReleaseTypeMultiplier`, the deprecated `calculateBudgetQualityBonus`/`calculateSongCountQualityImpact` pair (engine delegates + FinancialSystem copies — all four dead), and nine other private delegates whose only callers moved into processors. Each grep-audited; public-surface methods and test-referenced delegates kept with reasons
- **Dead config**: `quality.json` tier `quality_bonus` fields + `segment_slopes.*_range` endpoints (kept `diminishing_factor`), `economy.json quality_per_song_impact`, `projects.json project_durations` — removed from JSON, loader, and types together
- **Sanctioned behavior change**: the engine no longer writes the legacy singular A&R keys (`ar_office_discovered_artist_id`/`_info`); canonical array is the only write (completes PR-4's TODO). Caught and fixed a hidden read in `generateAndPersistEmails` so the discovery email stays byte-identical; artistService's defensive cleanup and the client are untouched (plan §5)

## Verification
- Golden master 8/8 stable twice — only the ar-office-week flags delta changed (exactly 8 lines removed, 0 added, explained); other 7 scenarios byte-identical
- Full suite 675/675; `npm run check` clean at every step

🤖 Generated with [Claude Code](https://claude.com/claude-code)