### PR TITLE
fix(server): engine-boundary leftovers (Phase 2 PR-13)

### DIFF
--- a/server/routes/artists.ts
+++ b/server/routes/artists.ts
@@ -15,6 +15,22 @@ import {
 
 const router = Router();
 
+// HARDENING (PR-13): whitelist the fields the client is actually allowed to
+// PATCH on an artist. PATCH /api/artists/:id previously passed raw req.body
+// straight to storage.updateArtist — a mass-assignment hole. The only client
+// caller is gameStore.updateArtist (client/src/store/gameStore.ts), which has
+// no live callers today, so this locks the route down to the minimal safe set
+// of genuinely user-mutable runtime-state fields. mood/energy carry DB CHECK
+// constraints (0-100) mirrored here. .strict() rejects any other key so
+// identity (id, gameId) and server-computed fields (talent, popularity,
+// signingCost, weeklyCost, signed, signedWeek, ...) can never be mass-assigned.
+const patchArtistSchema = z
+  .object({
+    mood: z.number().int().min(0).max(100).optional(),
+    energy: z.number().int().min(0).max(100).optional(),
+  })
+  .strict();
+
 // ========================================
 // Artist Dialogue Endpoint
 // ========================================
@@ -209,8 +225,18 @@ router.post("/api/game/:gameId/artist-dialogue", requireClerkUser, requireGameOw
         return res.status(404).json({ error: 'ARTIST_NOT_FOUND', message: 'Artist not found' });
       }
 
-      // TODO(phase-2): whitelist mutable artist fields — raw body pass-through is mass-assignment
-      const updated = await storage.updateArtist(req.params.id, req.body);
+      // HARDENING (PR-13): reject unknown / identity / server-computed fields
+      // (mass-assignment). Mirrors INVALID_GAME_FIELDS in games.ts.
+      const parsed = patchArtistSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'INVALID_ARTIST_FIELDS',
+          message: 'Artist update payload contains unexpected fields',
+          details: parsed.error.errors,
+        });
+      }
+
+      const updated = await storage.updateArtist(req.params.id, parsed.data);
       res.json(updated);
     } catch (error) {
       res.status(500).json({ message: "Failed to update artist" });

--- a/server/routes/games.ts
+++ b/server/routes/games.ts
@@ -303,44 +303,13 @@ const patchGameStateSchema = z
         });
       }
 
-      // Create new game state for user
-      // Get starting values from balance configuration
-      const startingValues = await serverGameData.getStartingValues();
-
-      // Determine initial access tiers based on starting reputation
-      // This ensures venue access starts at 'clubs' when starting reputation >= 5
-      // Reuses gameCreationService.deriveInitialAccessTiers (PR-15 dedup: the
-      // inline pickTier here was logic-identical to POST /api/game's).
-      const tiers = gameCreationService.deriveInitialAccessTiers(startingValues.reputation || 0);
-      const initialPlaylist = tiers.playlist;
-      const initialPress = tiers.press;
-      const initialVenue = tiers.venue;
-
-      const defaultState = {
-        userId: userId,
-          currentWeek: 1,
-          money: startingValues.money,
-          reputation: startingValues.reputation,
-          creativeCapital: startingValues.creativeCapital,
-          focusSlots: 3,
-          usedFocusSlots: 0,
-          playlistAccess: initialPlaylist,
-          pressAccess: initialPress,
-          venueAccess: initialVenue,
-          campaignType: "standard",
-          rngSeed: Math.random().toString(36).substring(7),
-          flags: {},
-          weeklyStats: {}
-        };
-
-        // Create game state without music label - label will be created separately via frontend flow
-        const gameState = await storage.createGameState(defaultState);
-        console.log('🎮 Created auto-generated game state (label will be created separately):', gameState.id);
-
-        return res.json({
-          ...gameState,
-          musicLabel: null
-        });
+      // Auto-create a game for a user with none. PR-13 / D4: route through
+      // gameCreationService so game creation lives in one module. createBareGame
+      // preserves this endpoint's historical shape (label-less, no executives,
+      // campaignType "standard", flags {}) — see its docstring for why GamePage
+      // depends on musicLabel being null here.
+      const bareGame = await gameCreationService.createBareGame(userId);
+      return res.json(bareGame);
     } catch (error) {
       console.error('Get game state error:', error);
       res.status(500).json({ message: "Failed to fetch game state" });

--- a/server/services/gameCreationService.ts
+++ b/server/services/gameCreationService.ts
@@ -152,11 +152,6 @@ export class GameCreationService {
       // Continue anyway - don't break game creation
     }
 
-    // TODO(phase-2): the original handler declared a `defaultRoles` array of 8
-    // named roles here but never persisted it (dead code). It was dropped in
-    // the PR-15 extraction. If default roles are ever needed, create them
-    // through the storage interface rather than reviving the dead array.
-
     return {
       ...gameState,
       musicLabel

--- a/server/services/gameCreationService.ts
+++ b/server/services/gameCreationService.ts
@@ -59,6 +59,54 @@ export class GameCreationService {
   }
 
   /**
+   * Auto-create a "bare" game for GET /api/game-state when the user has none.
+   *
+   * PR-13 / D4: this is the ONE remaining second creation path. It routes
+   * through gameCreationService (so game creation lives in one module) but
+   * intentionally produces the pre-existing GET /api/game-state auto-create
+   * SHAPE, which differs from POST /api/game:
+   *   - NO music label (returns musicLabel: null). GamePage.tsx keys its
+   *     label-creation modal off `!serverGameState.musicLabel` — seeding a
+   *     default label here would silently suppress that modal.
+   *   - NO executives (POST /api/game seeds 4; the auto-created game does not).
+   *   - campaignType "standard" and flags {} (POST /api/game defaults
+   *     campaignType from the body and writes flags.difficulty).
+   *
+   * Shares the balance-starting-values + reputation-derived-tier logic with
+   * createGame so those never drift. Difficulty is always normal (1.0x) — the
+   * auto-create path has no difficulty selection.
+   */
+  async createBareGame(userId: string) {
+    await this.serverGameData.initialize();
+
+    const startingValues = await this.serverGameData.getStartingValues();
+    const tiers = this.deriveInitialAccessTiers(startingValues.reputation || 0);
+
+    const gameState = await this.storage.createGameState({
+      userId,
+      currentWeek: 1,
+      money: startingValues.money,
+      reputation: startingValues.reputation,
+      creativeCapital: startingValues.creativeCapital,
+      focusSlots: 3,
+      usedFocusSlots: 0,
+      playlistAccess: tiers.playlist,
+      pressAccess: tiers.press,
+      venueAccess: tiers.venue,
+      campaignType: 'standard',
+      rngSeed: Math.random().toString(36).substring(7),
+      flags: {},
+      weeklyStats: {},
+    } as any);
+    console.log('🎮 Created auto-generated game state (label will be created separately):', gameState.id);
+
+    return {
+      ...gameState,
+      musicLabel: null,
+    };
+  }
+
+  /**
    * Create a new game for the given user from a raw request body. Returns the
    * created game state merged with its music label (the exact response shape of
    * the original POST /api/game handler).

--- a/tests/endpoints/artists-patch.characterization.test.ts
+++ b/tests/endpoints/artists-patch.characterization.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment node
+/**
+ * artists PATCH whitelist characterization test (Phase 2, PR-13 task 1).
+ *
+ * PATCH /api/artists/:id had the entity-walk ownership check (from the Phase 1
+ * ownership sweep) but still passed raw req.body straight to
+ * storage.updateArtist — a mass-assignment hole flagged with
+ * `// TODO(phase-2): whitelist mutable artist fields`.
+ *
+ * This test pins the OWNER path (whitelisted mood/energy accepted, ownership
+ * 404 preserved) BEFORE and AFTER the whitelist lands, and flips the
+ * mass-assignment behavior: pre-hardening a server-computed field like `talent`
+ * is silently written through; post-hardening the same body returns 400
+ * INVALID_ARTIST_FIELDS and nothing is mutated.
+ *
+ * Blocks tagged "(post-hardening)" only pass AFTER the whitelist commit lands.
+ * The single "(pre-hardening baseline)" block documents the old mass-assignment
+ * behavior and is REMOVED when the whitelist lands (it necessarily fails after).
+ *
+ * Drives the real games/artists router over supertest against the real test
+ * Postgres (Docker, localhost:5433). Harness mirrors
+ * tests/endpoints/sweep-migrations.characterization.test.ts.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import { gameStates, users, artists } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import artistsRouter from '../../server/routes/artists';
+
+let app: Express;
+
+/** Seed a game owned by ownerId plus one artist. Returns the ids. */
+async function seedGameWithArtist(ownerId: string) {
+  const gameId = crypto.randomUUID();
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: ownerId,
+    currentWeek: 1,
+    money: 100000,
+    reputation: 10,
+  });
+  const artistId = crypto.randomUUID();
+  await db.insert(artists).values({
+    id: artistId,
+    gameId,
+    name: 'Test Artist',
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood: 50,
+    energy: 50,
+    popularity: 40,
+    talent: 50,
+  });
+  return { gameId, artistId };
+}
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(artistsRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+describe('PATCH /api/artists/:id (characterization)', () => {
+  it('returns 404 ARTIST_NOT_FOUND for a nonexistent artist', async () => {
+    const res = await request(app)
+      .patch(`/api/artists/${crypto.randomUUID()}`)
+      .send({ mood: 60 });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('ARTIST_NOT_FOUND');
+  });
+
+  it("returns 404 ARTIST_NOT_FOUND when the artist belongs to another user's game (ownership preserved)", async () => {
+    const { artistId } = await seedGameWithArtist(OTHER_USER_ID);
+    // Authenticated as TEST_USER_ID; artist is owned by OTHER_USER_ID.
+    const res = await request(app)
+      .patch(`/api/artists/${artistId}`)
+      .send({ mood: 99 });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('ARTIST_NOT_FOUND');
+
+    // Victim data unchanged.
+    const [row] = await db.select().from(artists).where(eq(artists.id, artistId));
+    expect(row.mood).toBe(50);
+  });
+
+  it('updates whitelisted fields (mood, energy) for an owned artist', async () => {
+    const { artistId } = await seedGameWithArtist(TEST_USER_ID);
+    const res = await request(app)
+      .patch(`/api/artists/${artistId}`)
+      .send({ mood: 72, energy: 33 });
+    expect(res.status).toBe(200);
+    expect(res.body.mood).toBe(72);
+    expect(res.body.energy).toBe(33);
+
+    const [row] = await db.select().from(artists).where(eq(artists.id, artistId));
+    expect(row.mood).toBe(72);
+    expect(row.energy).toBe(33);
+  });
+
+  // --- Mass-assignment behavior flip -------------------------------------
+
+  // PRE-HARDENING baseline: server-computed `talent` is silently written
+  // through the raw-body pass-through. This block is REMOVED when the
+  // whitelist lands (it necessarily fails afterwards). Kept here to document
+  // the hole the whitelist closes.
+  it.skip('(pre-hardening baseline) silently mass-assigns a server-computed field (talent)', async () => {
+    const { artistId } = await seedGameWithArtist(TEST_USER_ID);
+    const res = await request(app)
+      .patch(`/api/artists/${artistId}`)
+      .send({ talent: 99 });
+    expect(res.status).toBe(200);
+    const [row] = await db.select().from(artists).where(eq(artists.id, artistId));
+    expect(row.talent).toBe(99); // mass-assignment: raw body written through
+  });
+
+  it('(post-hardening) rejects an unknown / server-computed field with 400 INVALID_ARTIST_FIELDS', async () => {
+    const { artistId } = await seedGameWithArtist(TEST_USER_ID);
+    const res = await request(app)
+      .patch(`/api/artists/${artistId}`)
+      .send({ talent: 99 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_ARTIST_FIELDS');
+    expect(Array.isArray(res.body.details)).toBe(true);
+
+    // Nothing mutated: talent stays at its seeded value.
+    const [row] = await db.select().from(artists).where(eq(artists.id, artistId));
+    expect(row.talent).toBe(50);
+  });
+
+  it('(post-hardening) rejects identity fields (id, gameId) with 400', async () => {
+    const { artistId, gameId } = await seedGameWithArtist(TEST_USER_ID);
+    const res = await request(app)
+      .patch(`/api/artists/${artistId}`)
+      .send({ mood: 60, gameId: crypto.randomUUID() });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_ARTIST_FIELDS');
+
+    // gameId untouched, mood untouched (whole payload rejected).
+    const [row] = await db.select().from(artists).where(eq(artists.id, artistId));
+    expect(row.gameId).toBe(gameId);
+    expect(row.mood).toBe(50);
+  });
+
+  it('(post-hardening) enforces mood/energy bounds (0-100) via the whitelist', async () => {
+    const { artistId } = await seedGameWithArtist(TEST_USER_ID);
+    const res = await request(app)
+      .patch(`/api/artists/${artistId}`)
+      .send({ mood: 150 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('INVALID_ARTIST_FIELDS');
+  });
+});

--- a/tests/endpoints/game-state.characterization.test.ts
+++ b/tests/endpoints/game-state.characterization.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+/**
+ * GET /api/game-state auto-creation characterization test (Phase 2, PR-13 task 3, D4).
+ *
+ * GET /api/game-state auto-creates a game when the user has none. Plan D4 keeps
+ * the auto-creation (client/src/pages/GamePage.tsx:42 depends on it) but routes
+ * the creation through gameCreationService so there is exactly one place a game
+ * comes into existence.
+ *
+ * CRITICAL SHAPE CONTRACT (D4 says "response shape unchanged"): the auto-created
+ * game must remain LABEL-LESS (`musicLabel: null`) and have NO executives.
+ * GamePage.tsx keys the label-creation modal off `!serverGameState.musicLabel`
+ * (line 53) — if the auto-create suddenly returned a default "New Music Label",
+ * that modal would never appear and the user would silently get an unnamed
+ * label. So the service is called in a "bare" mode (no label, no executives)
+ * that reuses the core createGameState + tier-derivation + difficulty-flag path
+ * WITHOUT the POST /api/game seeding. These tests pin that shape before AND
+ * after the routing change — they are green on both sides of the commit.
+ *
+ * Harness mirrors tests/endpoints/game-creation.characterization.test.ts.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = TEST_USER_ID;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import { gameStates, users, executives, musicLabels } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+
+let app: Express;
+
+/** Reproduce the tier-derivation from the live balance config. */
+function expectedTiers(rep: number) {
+  const accessTiers = serverGameData.getAccessTiersSync() as any;
+  const pick = (tiersObj: Record<string, { threshold: number }>) =>
+    Object.entries(tiersObj)
+      .sort(([, a], [, b]) => (b as any).threshold - (a as any).threshold)
+      .find(([, cfg]) => rep >= (cfg as any).threshold)?.[0] || 'none';
+  return {
+    playlist: pick(accessTiers.playlist_access),
+    press: pick(accessTiers.press_access),
+    venue: pick(accessTiers.venue_access),
+  };
+}
+
+beforeAll(async () => {
+  const { registerRoutes } = await import('../../server/routes');
+  app = express();
+  app.use(express.json());
+  const server = await registerRoutes(app);
+  server.close();
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+beforeEach(async () => {
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values({
+    id: TEST_USER_ID,
+    clerkId: 'clerk_test_user',
+    email: 'test@example.com',
+    username: 'tester',
+  });
+});
+
+describe('GET /api/game-state auto-creation (characterization, D4)', () => {
+  it('auto-creates a game with balance starting values and reputation-derived tiers', async () => {
+    const starting = await serverGameData.getStartingValues('normal');
+    const tiers = expectedTiers(starting.reputation || 0);
+
+    const res = await request(app).get('/api/game-state');
+    expect(res.status).toBe(200);
+    expect(res.body.money).toBe(starting.money);
+    expect(res.body.reputation).toBe(starting.reputation);
+    expect(res.body.creativeCapital).toBe(starting.creativeCapital);
+    expect(res.body.playlistAccess).toBe(tiers.playlist);
+    expect(res.body.pressAccess).toBe(tiers.press);
+    expect(res.body.venueAccess).toBe(tiers.venue);
+    expect(res.body.currentWeek).toBe(1);
+    expect(res.body.focusSlots).toBe(3);
+    expect(res.body.userId).toBe(TEST_USER_ID);
+  });
+
+  it('auto-created game is LABEL-LESS (musicLabel: null) — GamePage keys its label modal off this', async () => {
+    const res = await request(app).get('/api/game-state');
+    expect(res.status).toBe(200);
+    expect(res.body.musicLabel).toBeNull();
+
+    // No music-label row persisted for the auto-created game.
+    const labels = await db.select().from(musicLabels).where(eq(musicLabels.gameId, res.body.id));
+    expect(labels).toHaveLength(0);
+  });
+
+  it('auto-created game seeds NO executives (unlike POST /api/game)', async () => {
+    const res = await request(app).get('/api/game-state');
+    expect(res.status).toBe(200);
+    const rows = await db.select().from(executives).where(eq(executives.gameId, res.body.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('returns the existing game (with its label) on a second call — no duplicate creation', async () => {
+    const first = await request(app).get('/api/game-state');
+    expect(first.status).toBe(200);
+
+    const second = await request(app).get('/api/game-state');
+    expect(second.status).toBe(200);
+    expect(second.body.id).toBe(first.body.id);
+
+    const allGames = await db.select().from(gameStates).where(eq(gameStates.userId, TEST_USER_ID));
+    expect(allGames).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
PR-13 of the Phase 2 plan — the final PR, closing the three Phase-1-deferred server items:
1. **artists PATCH whitelist**: `PATCH /api/artists/:id` gets a `.strict()` zod whitelist (`{ mood, energy }`, 0–100) rejecting unknown fields with 400 `INVALID_ARTIST_FIELDS`, closing the mass-assignment TODO. The client's `updateArtist` has zero callers (route effectively dead) so it's locked down, not deleted
2. **defaultRoles**: the dead array was already removed in PR-15; deleted the stale leftover TODO comment
3. **game-state auto-creation → gameCreationService (D4)**: new `createBareGame(userId)` shares the balance-starting-values + reputation-tier logic with `createGame` (one module owns creation) while preserving this endpoint's historical shape

## D4 resolution (reviewed judgment call)
The plan's literal "route through `createGame`" contradicts "shape unchanged" — `createGame` seeds a default music label + 4 executives, and `GamePage.tsx` keys its label-creation modal off `!musicLabel`, so a default label would silently suppress the naming prompt. `createBareGame` honors D4's dedup intent without the user-visible regression; response is byte-equivalent to the prior inline path.

## Verification
- Characterization-first: new `artists-patch` + `game-state` pins (current → flipped), plus game-creation + sweep green
- Golden master 8/8 zero-update (no engine change); route-manifest unchanged; full suite 685 passed / 1 skipped (the documented pre-hardening mass-assignment baseline); `npm run check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)