### PR TITLE
docs: mark Phase 2 (engine seams) complete + log tour-estimate debt

### DIFF
--- a/DEVELOPMENT_STATUS.md
+++ b/DEVELOPMENT_STATUS.md
@@ -4,6 +4,36 @@
 
 ---
 
+## 📅 Session Log — July 2, 2026 Late Evening (Phase 2 engine seams: full decomposition, PRs #72–#84)
+
+**Phase 2 (engine seams) is DONE and merged to `main` — the entire 13-PR sequence executed in one session, same orchestrator/subagent factory pattern as Phase 1.** `shared/engine/game-engine.ts` went **5,116 → 1,136 lines**; 8 new processor modules live under `shared/engine/processors/` (~3,900 lines total). The engine is now fully deterministic and covered by a golden-master characterization harness. Suite grew **545 → 692 passing (3 skipped)**.
+
+**Done this session:**
+- **PR-1 (#72) — determinism foundation**: seeded every remaining gameplay `Math.random()` call — the song-quality outlier roll, tour attendance variance, and a `FinancialSystem` breakthrough-growth roll the original plan missed — through the seeded RNG. Deleted a dead block that was silently shifting the RNG stream. Switched A&R `discoveryTime` from a wall-clock ISO string to sim-time (`week N`) so save-restore is reproducible. Distribution-verified (outlier rates, variance bounds) before merge.
+- **PR-2 (#73) — golden-master harness**: 8 seeded fixture scenarios run `advanceWeek` end-to-end; a normalizer strips UUIDs/timestamps so snapshots are byte-comparable; run-twice stability check confirms determinism. This became the safety net for every extraction PR that followed.
+- **PR-3 — `advanceWeekService` extraction**: pulled the orchestration out of `gameLoop.ts` (407 → 75 lines); the two-transaction split moved verbatim (no transactionality changes — that's the filed D6 follow-up).
+- **PR-4 — A&R artists GET made a pure read**: deleted an in-GET `Math.random()` write and legacy dual-format branches; `arOffice.ts` 408 → 284 lines.
+- **PR-5..11 — the 8 engine processors**, each a verbatim move guarded byte-identical by the golden master, using a new `WeekContext` pattern + `GameEngine.weekContext()` helper: `AROfficeProcessor`, `ProgressionProcessor` + `WeeklyFinancesProcessor`, `TourProcessor`, `SongGenerationProcessor` (+17 quality unit tests — first-ever coverage for the quality formula), `ProjectStageProcessor` (**B6 resolved** — deleted the ~95-line no-op "recorded" pass and wired the previously-never-firing "ready for release" notification; songs are born recorded), `ReleaseProcessor` (the biggest, ~1,250 lines, split across 2 commits), and `ActionProcessor` + `ArtistStateProcessor` (the `applyEffects` coupling hub, extracted last by design).
+- **PR-12 — dead code + dead config sweep**: ~440 net lines removed (`quality_bonus`/`segment_slopes` ranges/`quality_per_song_impact`/`project_durations` config keys + their types); stopped the engine writing legacy A&R singular keys (re-sourced a hidden email read along the way to stay byte-identical).
+- **PR-13 (#84) — engine-boundary leftovers**: artists PATCH now `.strict()`-whitelisted (`{mood, energy}` only, `INVALID_ARTIST_FIELDS` on violation); removed the stale `defaultRoles` TODO; routed `GET /api/game-state` auto-create through the new `gameCreationService.createBareGame` (**D4** — deliberately the *bare* creation method, not full `createGame`, because `createGame` also seeds a label + executives, which would suppress `GamePage`'s label-creation modal; documented in the PR).
+
+**The one player-visible change:** the B6 fix in PR-9 — the "recording complete, ready for release" notification now actually fires. Everything else in this phase is refactor-only; the plan's three sanctioned behavior changes (seeded-RNG per-seed differences, the B6 notification, the A&R legacy-branch response) are the only intended deltas.
+
+**Decisions made:**
+- **D1**: engine stays in `shared/` (server-only in practice, but a move to `server/engine/` is zero-behavior-gain churn; revisit in Phase 3).
+- **D6**: whole-week transaction atomicity stays out of scope — the per-step tx boundaries moved verbatim; wrapping the whole week in one transaction is a filed hardening follow-up, not bundled into this phase.
+- Determinism (PR-1) and the golden master (PR-2) were treated as the enabling foundation — nothing in PR-3 onward was allowed to move until both landed, since RNG-stream order is behavior and the golden master is what proves a move is verbatim.
+
+**Honest status: everything above is merged to `main`.** No open PRs from this phase.
+
+**Open threads / next steps:**
+- **Manual authenticated smoke pass is STILL owed** (carried over from Phase 1, not done this session either): new game → sign artist → create project → plan release → A&R op → advance week → save/restore.
+- **Two tour-estimate inconsistencies found during PR-7**, both need a product/behavior decision (logged to the tech-debt backlog this session):
+  1. `POST /api/tour/estimate`'s `totalBudget` draws venue-capacity from the tier RNG even when the caller supplies an explicit capacity — display-only today, but makes `canAfford` checks flaky against the actual tour outcome.
+  2. `artistPopularity` defaults to `0` in the estimate route but `50` in the engine's actual tour processing — the estimate and the real tour can diverge for the same artist.
+- **Whole-week transaction atomicity** (D6 follow-up) — still just a filed idea, not scheduled.
+- **Phase 3 (client state ownership) planning can begin.**
+
 ## 📅 Session Log — July 2, 2026 Evening (PR-16..18 services + security hardening wave)
 
 **Continued the Phase 1 service-extraction sequence (PR-16, PR-17, PR-18) and, in parallel, ran a security-focused wave off this morning's three `docs/98-research` reviews (RECORDING_SESSION, OWNERSHIP_AUTHORIZATION_SWEEP, AR_OFFICE).** Same orchestrator pattern as the day session: parallel scout subagents plus one mutating agent per checkout, worktree-isolated, characterization-test-first for every behavior-touching PR. **Everything below is merged to `main`** — PR-16 (#61), PR-17 (#63), PR-18 (#64), and the full security wave.

--- a/docs/01-planning/implementation-specs/COMPLETED/[COMPLETE] phase-2-engine-seams-plan.md
+++ b/docs/01-planning/implementation-specs/COMPLETED/[COMPLETE] phase-2-engine-seams-plan.md
@@ -1,24 +1,26 @@
-# [READY] Phase 2: Engine Seams — decompose `shared/engine` + engine-boundary services
+# [COMPLETE] Phase 2: Engine Seams — decompose `shared/engine` + engine-boundary services
 
 *Created: July 2, 2026 — planned from a three-scout code-reading pass against the post-Phase-1 tree (`main` @ Phase 1 complete, PRs #61–#70 merged).*
-*Status: READY — not started.*
+*Status: COMPLETE — merged to main 2026-07-02 (PRs #72–#84). `shared/engine/game-engine.ts` 5,116 → 1,136 lines; 8 processors extracted under `shared/engine/processors/`; engine fully deterministic; golden-master + song-quality + stage-recording tests added; suite 545 → 692 passing (3 skipped). See DEVELOPMENT_STATUS.md session log for the full closeout entry.*
 *Part of the four-phase scaling arc (Phase 0: CI safety net · Phase 1: server seams · Phase 2: engine seams · Phase 3: client state ownership · Phase 4: game feel).*
 
 ## Execution status
 
-- ⏳ PR-1 — determinism fixes (seeded RNG everywhere)
-- ⏳ PR-2 — golden-master `advanceWeek` characterization harness
-- ⏳ PR-3 — `advanceWeekService` (server orchestration extraction)
-- ⏳ PR-4 — A&R artists GET cleanup (pure read, canonical array)
-- ⏳ PR-5 — `AROfficeProcessor` extraction
-- ⏳ PR-6 — `ProgressionProcessor` + weekly-finances extraction
-- ⏳ PR-7 — `TourProcessor` extraction + tour-estimate unification
-- ⏳ PR-8 — `SongGenerationProcessor` (song gen + quality) extraction
-- ⏳ PR-9 — `ProjectStageProcessor` extraction + B6 resolution
-- ⏳ PR-10 — `ReleaseProcessor` (releases/streaming/awareness) extraction
-- ⏳ PR-11 — `ActionProcessor` + `ArtistStateProcessor` (effects hub) extraction
-- ⏳ PR-12 — dead code + dead config sweep
-- ⏳ PR-13 — engine-boundary leftovers (PATCH whitelist, defaultRoles, game-state auto-creation routing)
+**Completed 2026-07-02 — all 13 PRs done and merged; `game-engine.ts` 5,116 → 1,136 lines; 8 processors extracted; suite 692 passing.**
+
+- ✅ PR-1 (#72) — determinism fixes (seeded RNG everywhere) — done, merged
+- ✅ PR-2 (#73) — golden-master `advanceWeek` characterization harness — done, merged
+- ✅ PR-3 — `advanceWeekService` (server orchestration extraction) — done, merged
+- ✅ PR-4 — A&R artists GET cleanup (pure read, canonical array) — done, merged
+- ✅ PR-5 — `AROfficeProcessor` extraction — done, merged
+- ✅ PR-6 — `ProgressionProcessor` + weekly-finances extraction — done, merged
+- ✅ PR-7 — `TourProcessor` extraction + tour-estimate unification — done, merged
+- ✅ PR-8 — `SongGenerationProcessor` (song gen + quality) extraction — done, merged
+- ✅ PR-9 — `ProjectStageProcessor` extraction + B6 resolution — done, merged
+- ✅ PR-10 — `ReleaseProcessor` (releases/streaming/awareness) extraction — done, merged
+- ✅ PR-11 — `ActionProcessor` + `ArtistStateProcessor` (effects hub) extraction — done, merged
+- ✅ PR-12 — dead code + dead config sweep — done, merged
+- ✅ PR-13 (#84) — engine-boundary leftovers (PATCH whitelist, defaultRoles, game-state auto-creation routing) — done, merged
 
 ## 0. Ground truth (verified against the working tree, 2026-07-02)
 

--- a/docs/09-troubleshooting/technical-debt-backlog.md
+++ b/docs/09-troubleshooting/technical-debt-backlog.md
@@ -9,10 +9,10 @@
 
 - **Created**: September 2025 (Artist Mood System Implementation - commit `4991ab3`)
 - **Last Updated**: July 2, 2026
-- **Total Items**: 45
-- **Completed**: 37
+- **Total Items**: 47
+- **Completed**: 38
 - **In Progress**: 0
-- **Pending**: 8
+- **Pending**: 9
 
 ---
 
@@ -731,18 +731,48 @@ Two small leftovers from the release trace: (1) `data/balance/markets.json` `str
 
 ---
 
+### Comment 46: Tour estimate's totalBudget draws tier-RNG capacity even when explicit capacity is supplied 🟢
+**Status**: 📋 **PENDING**
+
+`POST /api/tour/estimate` (`server/routes/tour.ts`) computes `totalBudget` by drawing venue capacity from the tier-based RNG helper even when the caller already supplied an explicit `venueCapacity`, so the displayed estimate total can vary run-to-run for what should be a deterministic preview of the same inputs. It's display-only — nothing charges the player at estimate time — but it makes `canAfford` checks against the estimate flaky relative to what the actual tour (via `TourProcessor`) will do with the same explicit capacity.
+
+**Action**: Product/behavior decision needed — either have the estimate always honor an explicit `venueCapacity` when provided (matching `TourProcessor`'s actual behavior) or document that the estimate is intentionally a range and stop treating `totalBudget` as a single comparable number for `canAfford`.
+
+**Relevant Files**:
+- [server/routes/tour.ts](server/routes/tour.ts)
+- [shared/engine/processors/TourProcessor.ts](shared/engine/processors/TourProcessor.ts)
+
+*Identified 2026-07-02 during Phase 2 PR-7 (TourProcessor extraction + tour-estimate unification).*
+
+---
+
+### Comment 47: artistPopularity defaults differ between tour estimate route and engine (0 vs 50) 🟢
+**Status**: 📋 **PENDING**
+
+`POST /api/tour/estimate` defaults `artistPopularity` to `0` when the field is absent from the request, while `TourProcessor`'s actual week-advance tour processing (`shared/engine/processors/TourProcessor.ts`) defaults the same field to `50`. For any caller that omits `artistPopularity`, the estimate and the real tour outcome are computed against different assumed popularity — a behavioral inconsistency between the preview and the executed tour, in the same family as C44 (release preview vs. execution divergence).
+
+**Action**: Product/behavior decision needed — pick one canonical default (50 matches the engine's general "unknown artist" convention used elsewhere) and align the route to it.
+
+**Relevant Files**:
+- [server/routes/tour.ts](server/routes/tour.ts)
+- [shared/engine/processors/TourProcessor.ts](shared/engine/processors/TourProcessor.ts)
+
+*Identified 2026-07-02 during Phase 2 PR-7 (TourProcessor extraction + tour-estimate unification).*
+
+---
+
 ## 📊 **Summary Statistics**
 
 ### By Priority
 - 🔴 Critical: 0 items (all completed! 🎉)
 - 🟡 High: 1 item (C44)
-- 🟢 Medium: 3 items (C41, C42, C43)
+- 🟢 Medium: 5 items (C41, C42, C43, C46, C47)
 - 🔵 Low: 3 items (C26, C32, C45)
 
 ### By Status
-- ✅ Completed: 38 items (84.4%)
+- ✅ Completed: 38 items (81.3%)
 - 🚧 In Progress: 0 items (0%)
-- 📋 Pending: 7 items (15.6%)
+- 📋 Pending: 9 items (18.7%)
 
 ---
 


### PR DESCRIPTION
## Summary
- Phase 2 plan doc moved to `COMPLETED/[COMPLETE] phase-2-engine-seams-plan.md` with all 13 PRs marked merged (game-engine.ts 5,116 → 1,136; 8 processors; suite 692 passing)
- DEVELOPMENT_STATUS.md: late-evening session log covering the full PR-1..13 execution, the D1/D6 decisions, the one player-visible change (B6 notification now fires), and open threads (smoke pass still owed; D6 atomicity follow-up; Phase 3 planning next)
- Backlog: Comments 46 + 47 added for the two tour-estimate inconsistencies PR-7 surfaced (tier-RNG capacity draw; artistPopularity 0-vs-50 default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)