### PR TITLE
test(client): Phase 3 PR-1 — client-state characterization net

### DIFF
--- a/tests/client/buildGameSnapshot.shape.test.ts
+++ b/tests/client/buildGameSnapshot.shape.test.ts
@@ -1,0 +1,87 @@
+/**
+ * buildGameSnapshot shape pins (Phase 3 PR-1).
+ *
+ * Guards the save-snapshot invariant documented in CLAUDE.md "Save/Load
+ * Snapshots": `musicLabel` and every collection are SIBLINGS of `gameState`,
+ * never nested inside it. A test that nests them can pass while the real code
+ * path is broken (this class of bug shipped a real migration regression).
+ */
+import { describe, it, expect } from 'vitest';
+import { SNAPSHOT_VERSION } from '@shared/schema';
+import { buildGameSnapshot } from '@/utils/buildGameSnapshot';
+
+function minimalParams(overrides: Partial<Parameters<typeof buildGameSnapshot>[0]> = {}) {
+  return {
+    gameState: {
+      id: 'game-1',
+      currentWeek: 4,
+      money: 12345,
+      musicLabel: { name: 'My Label' },
+    } as any,
+    emailSnapshot: { emails: [{ id: 'em1' }], total: 1, unreadCount: 0, truncated: false },
+    artists: [{ id: 'a1' }] as any,
+    projects: [{ id: 'p1' }] as any,
+    roles: [{ id: 'r1' }] as any,
+    songs: [{ id: 's1' }],
+    releases: [{ id: 'rel1' }],
+    releaseSongs: [{ id: 'rs1' }],
+    executives: [{ id: 'e1' }],
+    moodEvents: [{ id: 'm1' }],
+    weeklyActions: [{ id: 'wa1' }] as any,
+    weeklyOutcome: { week: 4 },
+    ...overrides,
+  };
+}
+
+describe('buildGameSnapshot shape', () => {
+  it('includes snapshotVersion equal to SNAPSHOT_VERSION', () => {
+    const snap = buildGameSnapshot(minimalParams()) as any;
+    expect(snap.snapshotVersion).toBe(SNAPSHOT_VERSION);
+  });
+
+  it('places musicLabel as a top-level SIBLING of gameState, not nested inside it', () => {
+    const snap = buildGameSnapshot(minimalParams()) as any;
+    expect(snap.musicLabel).toEqual({ name: 'My Label' });
+    // The invariant: musicLabel is stripped OUT of gameState.
+    expect(snap.gameState.musicLabel).toBeUndefined();
+  });
+
+  it('nulls musicLabel when the incoming gameState has no label', () => {
+    const snap = buildGameSnapshot(
+      minimalParams({ gameState: { id: 'g', currentWeek: 1 } as any }),
+    ) as any;
+    expect(snap.musicLabel).toBeNull();
+  });
+
+  it('places every collection as a top-level sibling of gameState', () => {
+    const snap = buildGameSnapshot(minimalParams()) as any;
+    expect(snap.artists).toEqual([{ id: 'a1' }]);
+    expect(snap.projects).toEqual([{ id: 'p1' }]);
+    expect(snap.roles).toEqual([{ id: 'r1' }]);
+    expect(snap.songs).toEqual([{ id: 's1' }]);
+    expect(snap.releases).toEqual([{ id: 'rel1' }]);
+    expect(snap.releaseSongs).toEqual([{ id: 'rs1' }]);
+    expect(snap.executives).toEqual([{ id: 'e1' }]);
+    expect(snap.moodEvents).toEqual([{ id: 'm1' }]);
+    expect(snap.weeklyActions).toEqual([{ id: 'wa1' }]);
+    expect(snap.emails).toEqual([{ id: 'em1' }]);
+    // None of the collections leaked into gameState.
+    for (const key of ['artists', 'projects', 'roles', 'songs', 'releases']) {
+      expect((snap.gameState as any)[key]).toBeUndefined();
+    }
+  });
+
+  it('propagates emailMetadata including the truncated flag', () => {
+    const snap = buildGameSnapshot(
+      minimalParams({
+        emailSnapshot: { emails: [], total: 250, unreadCount: 7, truncated: true },
+      }),
+    ) as any;
+    expect(snap.emailMetadata).toEqual({ total: 250, unreadCount: 7, truncated: true });
+  });
+
+  it('defaults weeklyOutcome to null when not provided', () => {
+    const snap = buildGameSnapshot(minimalParams({ weeklyOutcome: null })) as any;
+    expect(snap.weeklyOutcome).toBeNull();
+  });
+});

--- a/tests/client/gameStore-actions.characterization.test.ts
+++ b/tests/client/gameStore-actions.characterization.test.ts
@@ -1,0 +1,256 @@
+/**
+ * gameStore action characterization tests (Phase 3 PR-1).
+ *
+ * SAFETY NET for the Phase 3 client-state-ownership refactor. These pins assert
+ * the CURRENT behavior of the real store exactly — including places the plan
+ * flags as drift bugs that later PRs (esp. PR-10) will fix. Do NOT "correct"
+ * these assertions; a later PR that changes behavior should update the pin
+ * deliberately.
+ *
+ * See: docs Phase 3 client-state-ownership plan (PR-1 = client-state
+ * characterization net).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the network + cache layer BEFORE the store import (vitest hoists these).
+vi.mock('@/lib/queryClient', () => ({
+  apiRequest: vi.fn(),
+  queryClient: { invalidateQueries: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import { apiRequest } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import {
+  routeApiRequest as routeApiRequestImpl,
+  jsonResponse,
+  resetGameStore as resetGameStoreImpl,
+  baseGameState,
+} from './gameStore-harness';
+
+const mockedApiRequest = apiRequest as unknown as ReturnType<typeof vi.fn>;
+const routeApiRequest = (routes: Array<{ match: (url: string) => boolean; body: unknown }>) =>
+  routeApiRequestImpl(mockedApiRequest, routes);
+const resetGameStore = () => resetGameStoreImpl(useGameStore);
+
+beforeEach(() => {
+  mockedApiRequest.mockReset();
+  resetGameStore();
+});
+
+describe('signArtist optimistic delta', () => {
+  it('deducts signingCost from money and appends the returned artist', async () => {
+    useGameStore.setState({ gameState: baseGameState({ money: 100000 }), artists: [] });
+    const newArtist = { id: 'artist-99', name: 'Signed One' };
+    routeApiRequest([{ match: (u) => u.includes('/artists'), body: newArtist }]);
+
+    await useGameStore.getState().signArtist({ name: 'Signed One', signingCost: 15000 });
+
+    const state = useGameStore.getState();
+    expect(state.gameState!.money).toBe(85000); // 100000 - 15000
+    expect(state.artists).toEqual([newArtist]);
+  });
+
+  it('clamps money at 0 (Math.max floor) when signingCost exceeds balance', async () => {
+    useGameStore.setState({ gameState: baseGameState({ money: 5000 }), artists: [] });
+    routeApiRequest([{ match: (u) => u.includes('/artists'), body: { id: 'a1' } }]);
+
+    await useGameStore.getState().signArtist({ signingCost: 15000 });
+
+    expect(useGameStore.getState().gameState!.money).toBe(0);
+  });
+
+  it('treats a missing signingCost as 0 (no money change)', async () => {
+    useGameStore.setState({ gameState: baseGameState({ money: 42000 }), artists: [] });
+    routeApiRequest([{ match: (u) => u.includes('/artists'), body: { id: 'a1' } }]);
+
+    await useGameStore.getState().signArtist({ name: 'No Cost' });
+
+    expect(useGameStore.getState().gameState!.money).toBe(42000);
+  });
+});
+
+describe('createProject optimistic delta', () => {
+  it('deducts totalCost from money and 1 from creativeCapital, appends project', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ money: 100000, creativeCapital: 4 }),
+      projects: [],
+    });
+    const newProject = { id: 'proj-1', title: 'EP' };
+    routeApiRequest([{ match: (u) => u.includes('/projects'), body: newProject }]);
+
+    await useGameStore.getState().createProject({ totalCost: 20000 });
+
+    const state = useGameStore.getState();
+    expect(state.gameState!.money).toBe(80000); // 100000 - 20000
+    expect((state.gameState as any).creativeCapital).toBe(3); // 4 - 1
+    expect(state.projects).toEqual([newProject]);
+  });
+
+  it('falls back to budgetPerSong when totalCost is absent', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ money: 50000, creativeCapital: 2 }),
+      projects: [],
+    });
+    routeApiRequest([{ match: (u) => u.includes('/projects'), body: { id: 'p2' } }]);
+
+    await useGameStore.getState().createProject({ budgetPerSong: 8000 });
+
+    expect(useGameStore.getState().gameState!.money).toBe(42000); // 50000 - 8000
+    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(1);
+  });
+
+  it('deducts creative capital even when cost is 0', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ money: 30000, creativeCapital: 3 }),
+      projects: [],
+    });
+    routeApiRequest([{ match: (u) => u.includes('/projects'), body: { id: 'p3' } }]);
+
+    await useGameStore.getState().createProject({});
+
+    expect(useGameStore.getState().gameState!.money).toBe(30000);
+    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(2);
+  });
+});
+
+describe('planRelease optimistic delta', () => {
+  it('deducts metadata.totalInvestment from money and 1 from creativeCapital', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ money: 100000, creativeCapital: 4 }),
+    });
+    routeApiRequest([{ match: (u) => u.includes('/releases/plan'), body: { ok: true } }]);
+
+    await useGameStore.getState().planRelease({ metadata: { totalInvestment: 12000 } });
+
+    const state = useGameStore.getState();
+    expect(state.gameState!.money).toBe(88000); // 100000 - 12000
+    expect((state.gameState as any).creativeCapital).toBe(3);
+  });
+
+  it('treats a missing totalInvestment as 0 for money but still deducts creative capital', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ money: 60000, creativeCapital: 2 }),
+    });
+    routeApiRequest([{ match: (u) => u.includes('/releases/plan'), body: {} }]);
+
+    await useGameStore.getState().planRelease({});
+
+    expect(useGameStore.getState().gameState!.money).toBe(60000);
+    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(1);
+  });
+});
+
+describe('cancelProject adopts server balance', () => {
+  it('sets money to result.newBalance (NOT a local delta) and removes the project', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ money: 20000 }),
+      projects: [{ id: 'proj-1' } as any, { id: 'proj-2' } as any],
+    });
+    routeApiRequest([
+      {
+        match: (u) => u.includes('/cancel'),
+        body: { newBalance: 27500, refundAmount: 7500 },
+      },
+    ]);
+
+    await useGameStore.getState().cancelProject('proj-1', { refundAmount: 7500 });
+
+    const state = useGameStore.getState();
+    expect(state.gameState!.money).toBe(27500); // adopts server newBalance verbatim
+    expect(state.projects).toEqual([{ id: 'proj-2' }]);
+  });
+});
+
+describe('loadGame set(...) state shape', () => {
+  it('writes exactly the collections loadGame owns and resets selectedActions', async () => {
+    mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
+      if (url.endsWith('/songs')) return jsonResponse([{ id: 's1' }]);
+      if (url.endsWith('/releases')) return jsonResponse([{ id: 'r1' }]);
+      if (url.endsWith('/release-songs')) return jsonResponse([{ id: 'rs1' }]);
+      if (url.endsWith('/executives')) return jsonResponse([{ id: 'e1' }]);
+      if (url.endsWith('/mood-events')) return jsonResponse([{ id: 'm1' }]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [{ id: 'em1' }], total: 1, unreadCount: 0 });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      // GET /api/game/:id (the base game fetch)
+      return jsonResponse({
+        gameState: { id: 'game-1', currentWeek: 3, money: 5000, arOfficeSlotUsed: false },
+        musicLabel: { name: 'Loaded Label' },
+        artists: [{ id: 'a1' }],
+        projects: [{ id: 'p1' }],
+        roles: [{ id: 'role1' }],
+        weeklyActions: [{ id: 'wa1' }],
+      });
+    });
+
+    await useGameStore.getState().loadGame('game-1');
+
+    const state = useGameStore.getState();
+    // gameState carries musicLabel nested in (loadGame's shape), plus synced AR fields.
+    expect(state.gameState!.id).toBe('game-1');
+    expect((state.gameState as any).musicLabel).toEqual({ name: 'Loaded Label' });
+    expect((state.gameState as any).usedFocusSlots).toBe(0);
+    expect(state.artists).toEqual([{ id: 'a1' }]);
+    expect(state.projects).toEqual([{ id: 'p1' }]);
+    expect(state.roles).toEqual([{ id: 'role1' }]);
+    expect(state.weeklyActions).toEqual([{ id: 'wa1' }]);
+    expect(state.songs).toEqual([{ id: 's1' }]);
+    expect(state.releases).toEqual([{ id: 'r1' }]);
+    expect(state.emails).toEqual([{ id: 'em1' }]);
+    expect(state.releaseSongs).toEqual([{ id: 'rs1' }]);
+    expect(state.executives).toEqual([{ id: 'e1' }]);
+    expect(state.moodEvents).toEqual([{ id: 'm1' }]);
+    expect(state.selectedActions).toEqual([]);
+  });
+});
+
+describe('advanceWeek set(...) state shape', () => {
+  it('writes the post-advance collections, weeklyOutcome/campaignResults, and clears flags', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }),
+      selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
+    });
+
+    mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
+      if (url.includes('/advance-week')) {
+        return jsonResponse({
+          gameState: { id: 'game-1', currentWeek: 6, money: 9000 },
+          summary: { week: 6 },
+          campaignResults: null,
+        });
+      }
+      if (url.endsWith('/songs')) return jsonResponse([{ id: 's1' }]);
+      if (url.endsWith('/releases')) return jsonResponse([{ id: 'r1' }]);
+      if (url.endsWith('/release-songs')) return jsonResponse([{ id: 'rs1' }]);
+      if (url.endsWith('/executives')) return jsonResponse([{ id: 'e1' }]);
+      if (url.endsWith('/mood-events')) return jsonResponse([{ id: 'm1' }]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [{ id: 'em1' }], total: 1, unreadCount: 0 });
+      if (url.includes('/saves')) return jsonResponse({ ok: true });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      // GET /api/game/:id reload
+      return jsonResponse({
+        gameState: { id: 'game-1', currentWeek: 6, money: 9000 },
+        musicLabel: { name: 'Test Label' },
+        artists: [{ id: 'a1' }],
+        projects: [{ id: 'p1' }],
+      });
+    });
+
+    await useGameStore.getState().advanceWeek();
+
+    const state = useGameStore.getState();
+    expect((state.gameState as any).currentWeek).toBe(6);
+    expect(state.artists).toEqual([{ id: 'a1' }]);
+    expect(state.projects).toEqual([{ id: 'p1' }]);
+    expect(state.songs).toEqual([{ id: 's1' }]);
+    expect(state.releases).toEqual([{ id: 'r1' }]);
+    expect(state.emails).toEqual([{ id: 'em1' }]);
+    expect(state.releaseSongs).toEqual([{ id: 'rs1' }]);
+    expect(state.executives).toEqual([{ id: 'e1' }]);
+    expect(state.moodEvents).toEqual([{ id: 'm1' }]);
+    expect(state.weeklyOutcome).toEqual({ week: 6 });
+    expect(state.campaignResults).toBeNull();
+    expect(state.selectedActions).toEqual([]);
+    expect(state.isAdvancingWeek).toBe(false);
+  });
+});

--- a/tests/client/gameStore-email-invalidation.characterization.test.ts
+++ b/tests/client/gameStore-email-invalidation.characterization.test.ts
@@ -1,0 +1,143 @@
+/**
+ * C49 email-cache-invalidation regression pins (Phase 3 PR-1).
+ *
+ * The C49 fix (commit 2b57880) makes `loadGameFromSave` invalidate email queries
+ * via a PREDICATE scoped to the RESTORED gameId, so the inbox reflects the
+ * restored save immediately instead of showing stale pre-restore emails.
+ *
+ * `advanceWeek` uses the same email-invalidation predicate keyed on the new
+ * game id. Both are pinned here.
+ *
+ * We assert two things:
+ *   1. `queryClient.invalidateQueries` is called with a `predicate`.
+ *   2. That predicate matches the correct query keys: matching scope + correct
+ *      id => true; matching scope + wrong id => false; wrong scope => false.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the network + cache layer BEFORE the store import (vitest hoists these).
+vi.mock('@/lib/queryClient', () => ({
+  apiRequest: vi.fn(),
+  queryClient: { invalidateQueries: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
+import { apiRequest, queryClient } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import {
+  jsonResponse,
+  resetGameStore as resetGameStoreImpl,
+  baseGameState,
+} from './gameStore-harness';
+
+const mockedApiRequest = apiRequest as unknown as ReturnType<typeof vi.fn>;
+const mockedInvalidateQueries = queryClient.invalidateQueries as unknown as ReturnType<typeof vi.fn>;
+const resetGameStore = () => resetGameStoreImpl(useGameStore);
+
+beforeEach(() => {
+  mockedApiRequest.mockReset();
+  mockedInvalidateQueries.mockClear();
+  resetGameStore();
+});
+
+/** Extract the last `predicate` passed to invalidateQueries. */
+function lastPredicate(): (query: { queryKey: readonly unknown[] }) => boolean {
+  const calls = mockedInvalidateQueries.mock.calls;
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const arg = calls[i][0];
+    if (arg && typeof arg.predicate === 'function') return arg.predicate;
+  }
+  throw new Error('No invalidateQueries call with a predicate was recorded');
+}
+
+function assertEmailPredicateScopedTo(
+  predicate: (q: { queryKey: readonly unknown[] }) => boolean,
+  gameId: string,
+) {
+  // matching scope + correct id => true
+  expect(predicate({ queryKey: [EMAIL_LIST_SCOPE, gameId] })).toBe(true);
+  expect(predicate({ queryKey: [EMAIL_UNREAD_SCOPE, gameId] })).toBe(true);
+  // matching scope + WRONG id => false
+  expect(predicate({ queryKey: [EMAIL_LIST_SCOPE, 'some-other-id'] })).toBe(false);
+  expect(predicate({ queryKey: [EMAIL_UNREAD_SCOPE, 'some-other-id'] })).toBe(false);
+  // WRONG scope + correct id => false
+  expect(predicate({ queryKey: ['executives', gameId] })).toBe(false);
+  expect(predicate({ queryKey: ['artist-roi', gameId] })).toBe(false);
+}
+
+describe('loadGameFromSave email invalidation (C49)', () => {
+  it('invalidates email queries via a predicate scoped to the restored gameId', async () => {
+    const restoredGameId = 'restored-game-abc';
+
+    mockedApiRequest.mockImplementation(async (method: string, url: string) => {
+      if (url.includes('/restore')) return jsonResponse({ gameId: restoredGameId });
+      if (url.endsWith('/songs')) return jsonResponse([]);
+      if (url.endsWith('/releases')) return jsonResponse([]);
+      if (url.endsWith('/release-songs')) return jsonResponse([]);
+      if (url.endsWith('/executives')) return jsonResponse([]);
+      if (url.endsWith('/mood-events')) return jsonResponse([]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [], total: 0, unreadCount: 0 });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      // GET /api/game/:restoredGameId
+      return jsonResponse({
+        gameState: { id: restoredGameId, currentWeek: 2, arOfficeSlotUsed: false },
+        musicLabel: null,
+        artists: [],
+        projects: [],
+        roles: [],
+        weeklyActions: [],
+      });
+    });
+
+    const snapshot = {
+      snapshotVersion: 2,
+      gameState: { id: 'pre-restore-id', currentWeek: 2 },
+      artists: [],
+      projects: [],
+      roles: [],
+      songs: [],
+      releases: [],
+      emails: [],
+      releaseSongs: [],
+      executives: [],
+      moodEvents: [],
+      weeklyActions: [],
+      weeklyOutcome: null,
+    } as any;
+
+    await useGameStore.getState().loadGameFromSave('save-1', snapshot, 'overwrite');
+
+    // The predicate must be keyed on the RESTORED id, not the snapshot's own id.
+    assertEmailPredicateScopedTo(lastPredicate(), restoredGameId);
+  });
+});
+
+describe('advanceWeek email invalidation', () => {
+  it('invalidates email queries via a predicate scoped to the advanced gameId', async () => {
+    const gameId = 'game-adv-1';
+    useGameStore.setState({
+      gameState: baseGameState({ id: gameId, currentWeek: 5, arOfficeSlotUsed: false }),
+      selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
+    });
+
+    mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
+      if (url.includes('/advance-week')) {
+        return jsonResponse({ gameState: { id: gameId, currentWeek: 6 }, summary: {}, campaignResults: null });
+      }
+      if (url.endsWith('/songs')) return jsonResponse([]);
+      if (url.endsWith('/releases')) return jsonResponse([]);
+      if (url.endsWith('/release-songs')) return jsonResponse([]);
+      if (url.endsWith('/executives')) return jsonResponse([]);
+      if (url.endsWith('/mood-events')) return jsonResponse([]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [], total: 0, unreadCount: 0 });
+      if (url.includes('/saves')) return jsonResponse({ ok: true });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      return jsonResponse({ gameState: { id: gameId, currentWeek: 6 }, musicLabel: null, artists: [], projects: [] });
+    });
+
+    await useGameStore.getState().advanceWeek();
+
+    assertEmailPredicateScopedTo(lastPredicate(), gameId);
+  });
+});

--- a/tests/client/gameStore-harness.ts
+++ b/tests/client/gameStore-harness.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure (mock-free) helpers for gameStore characterization tests (Phase 3 PR-1).
+ *
+ * The `vi.mock('@/lib/queryClient')` / `vi.mock('@/hooks/use-toast')` calls MUST
+ * live at the top level of each test file so vitest can hoist them above the
+ * real store import. This module only provides helpers that don't depend on
+ * hoisting, so importing it never fights the mock ordering.
+ */
+import { vi } from 'vitest';
+import type { useGameStore as UseGameStore } from '@/store/gameStore';
+
+type Store = typeof UseGameStore;
+
+/** A minimal `Response`-like object whose `.json()` resolves to `body`. */
+export function jsonResponse(body: unknown): Response {
+  return {
+    json: async () => body,
+    clone() {
+      return this;
+    },
+    text: async () => JSON.stringify(body),
+    ok: true,
+    status: 200,
+  } as unknown as Response;
+}
+
+/**
+ * Route `apiRequest(method, url)` to a body by matching a substring of the URL.
+ * First matching route wins; unmatched requests resolve to `{}` so parallel
+ * `Promise.all` fetches don't reject.
+ */
+export function routeApiRequest(
+  mockedApiRequest: ReturnType<typeof vi.fn>,
+  routes: Array<{ match: (url: string) => boolean; body: unknown }>,
+) {
+  mockedApiRequest.mockImplementation(async (_method: string, url: string) => {
+    const route = routes.find((r) => r.match(url));
+    return jsonResponse(route ? route.body : {});
+  });
+}
+
+/** Reset Zustand store state to store defaults between tests. */
+export function resetGameStore(useGameStore: Store) {
+  useGameStore.setState({
+    gameState: null,
+    artists: [],
+    projects: [],
+    roles: [],
+    weeklyActions: [],
+    songs: [],
+    releases: [],
+    emails: [],
+    releaseSongs: [],
+    executives: [],
+    moodEvents: [],
+    discoveredArtists: [],
+    loadingDiscoveredArtists: false,
+    selectedActions: [],
+    isAdvancingWeek: false,
+    weeklyOutcome: null,
+    campaignResults: null,
+  });
+}
+
+/** A representative full-ish GameState fixture for optimistic-delta pins. */
+export function baseGameState(overrides: Record<string, any> = {}) {
+  return {
+    id: 'game-1',
+    currentWeek: 5,
+    money: 100000,
+    reputation: 10,
+    creativeCapital: 4,
+    focusSlots: 3,
+    usedFocusSlots: 0,
+    arOfficeSlotUsed: false,
+    arOfficeSourcingType: null,
+    musicLabel: { name: 'Test Label' },
+    ...overrides,
+  } as any;
+}

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Query-key contract test (Phase 3 PR-1).
+ *
+ * Enumerates every cache invalidation gameStore.ts performs and asserts each one
+ * actually matches a query key that a real hook produces. TanStack Query matches
+ * an `invalidateQueries({ queryKey })` against a cached query when the
+ * invalidation key is an element-by-element PREFIX of the query key (NOT a string
+ * prefix). Predicate-based invalidations are checked by running the predicate.
+ *
+ * Per the Phase 3 plan, FOUR `['*-roi']` keys and `['executives']` in
+ * `advanceWeek` match NOTHING today — the real analytics keys are shaped
+ * `[url, 'analytics:artist-roi', {...}]` and no hook produces an `['executives']`
+ * key. Those assertions are intentionally RED-PINNED via `it.fails(...)` so they
+ * flip to green when PR-3 fixes the invalidation keys.
+ *
+ * Reference invalidations in client/src/store/gameStore.ts (advanceWeek):
+ *   queryKey: ['artist-roi'] | ['project-roi'] | ['portfolio-roi'] | ['release-roi']
+ *   queryKey: ['executives']
+ *   predicate: EMAIL_LIST_SCOPE / EMAIL_UNREAD_SCOPE keyed on gameId
+ * and saveGame: queryKey: ['api', 'saves'].
+ */
+import { describe, it, expect } from 'vitest';
+import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
+
+const GAME_ID = 'game-1';
+const ARTIST_ID = 'artist-1';
+const PROJECT_ID = 'project-1';
+const RELEASE_ID = 'release-1';
+
+/**
+ * Representative REAL query keys produced by the app's hooks.
+ * - Analytics keys (useAnalytics.ts): `[url, 'analytics:<scope>-roi', { ... }]`
+ * - Email keys (useEmails.ts): `[SCOPE, gameId, ...filters]`
+ * - Saves key (SaveGameModal.tsx): `['api', 'saves']`
+ */
+const REAL_QUERY_KEYS: readonly unknown[][] = [
+  [`/api/analytics/${GAME_ID}/artist/${ARTIST_ID}/roi`, 'analytics:artist-roi', { gameId: GAME_ID, artistId: ARTIST_ID }],
+  [`/api/analytics/${GAME_ID}/project/${PROJECT_ID}/roi`, 'analytics:project-roi', { gameId: GAME_ID, projectId: PROJECT_ID }],
+  [`/api/analytics/${GAME_ID}/portfolio/roi`, 'analytics:portfolio-roi', { gameId: GAME_ID }],
+  [`/api/analytics/${GAME_ID}/release/${RELEASE_ID}/roi`, 'analytics:release-roi', { gameId: GAME_ID, releaseId: RELEASE_ID }],
+  [EMAIL_LIST_SCOPE, GAME_ID, null, null, null, null, null],
+  [EMAIL_UNREAD_SCOPE, GAME_ID],
+  ['api', 'saves'],
+];
+
+/** Element-by-element prefix match, mirroring TanStack's partial key matching. */
+function keyIsPrefixOf(invalidationKey: readonly unknown[], realKey: readonly unknown[]): boolean {
+  if (invalidationKey.length > realKey.length) return false;
+  return invalidationKey.every((el, i) => JSON.stringify(el) === JSON.stringify(realKey[i]));
+}
+
+function someRealKeyMatchesInvalidationKey(invalidationKey: readonly unknown[]): boolean {
+  return REAL_QUERY_KEYS.some((real) => keyIsPrefixOf(invalidationKey, real));
+}
+
+function someRealKeyMatchesPredicate(
+  predicate: (q: { queryKey: readonly unknown[] }) => boolean,
+): boolean {
+  return REAL_QUERY_KEYS.some((real) => predicate({ queryKey: real }));
+}
+
+describe('query-key contract: invalidations that DO match a real hook key', () => {
+  it('saveGame ["api","saves"] matches the SaveGameModal saves query', () => {
+    expect(someRealKeyMatchesInvalidationKey(['api', 'saves'])).toBe(true);
+  });
+
+  it('email invalidation predicate matches the scoped email queries for the game', () => {
+    const emailPredicate = (q: { queryKey: readonly unknown[] }) =>
+      (q.queryKey[0] === EMAIL_LIST_SCOPE || q.queryKey[0] === EMAIL_UNREAD_SCOPE) &&
+      q.queryKey[1] === GAME_ID;
+    expect(someRealKeyMatchesPredicate(emailPredicate)).toBe(true);
+  });
+});
+
+describe('query-key contract: RED-PINNED invalidations (PR-3 will fix)', () => {
+  // These use it.fails: the assertion body FAILS today, and vitest reports the
+  // test as PASSING because failure is expected. When PR-3 changes the store to
+  // emit the correct keys AND the real keys here are updated to match, these
+  // will start passing the assertion, which flips it.fails to a (desired)
+  // failure — a loud signal that the pin must be converted to a normal `it`.
+
+  it.fails('advanceWeek ["artist-roi"] currently matches NO real analytics key', () => {
+    // Real key is [url, "analytics:artist-roi", {...}] — ["artist-roi"] matches nothing.
+    expect(someRealKeyMatchesInvalidationKey(['artist-roi'])).toBe(true);
+  });
+
+  it.fails('advanceWeek ["project-roi"] currently matches NO real analytics key', () => {
+    expect(someRealKeyMatchesInvalidationKey(['project-roi'])).toBe(true);
+  });
+
+  it.fails('advanceWeek ["portfolio-roi"] currently matches NO real analytics key', () => {
+    expect(someRealKeyMatchesInvalidationKey(['portfolio-roi'])).toBe(true);
+  });
+
+  it.fails('advanceWeek ["release-roi"] currently matches NO real analytics key', () => {
+    expect(someRealKeyMatchesInvalidationKey(['release-roi'])).toBe(true);
+  });
+
+  it.fails('advanceWeek ["executives"] currently matches NO real hook key', () => {
+    // No hook produces an ["executives"] query key today.
+    expect(someRealKeyMatchesInvalidationKey(['executives'])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Phase 3 PR-1 — client-state characterization net

Safety net for the other Phase 3 PRs (client state ownership refactor). **Test files only — no production-code behavior changes.** All assertions are characterization pins of CURRENT behavior; a later PR that changes behavior updates the pin deliberately.

Files (`tests/client/`):
- `gameStore-harness.ts` — pure (mock-free) helpers; each test file declares its own hoisted `vi.mock('@/lib/queryClient')` / `vi.mock('@/hooks/use-toast')` and imports the REAL store.
- `gameStore-actions.characterization.test.ts`
- `gameStore-email-invalidation.characterization.test.ts`
- `buildGameSnapshot.shape.test.ts`
- `query-key-contract.test.ts`

### What's pinned
**gameStore optimistic deltas** (real store, `apiRequest`/`queryClient` mocked):
- `signArtist`: `money -= signingCost` (clamped at 0 via `Math.max`; missing cost = 0), appends returned artist.
- `createProject`: `money -= (totalCost ?? budgetPerSong ?? 0)`, `creativeCapital -= 1` (deducted even at 0 cost).
- `planRelease`: `money -= metadata.totalInvestment`, `creativeCapital -= 1`.
- `cancelProject`: adopts server `result.newBalance` verbatim (not a local delta); removes project.
- `loadGame` / `advanceWeek`: exact `set(...)` collection shape (which collections get written) and reset of `selectedActions` / flags.

**C49 regression** (fix already merged, commit 2b57880):
- `loadGameFromSave` invalidates email queries via a predicate scoped to the **restored** gameId — asserted against matching scope+id (true), matching scope+wrong id (false), wrong scope (false).
- `advanceWeek` email invalidation pinned the same way against the advanced gameId.

**buildGameSnapshot shape**: `musicLabel` and all collections are SIBLINGS of `gameState` (stripped out of it), `snapshotVersion === SNAPSHOT_VERSION`, `emailMetadata.truncated` propagated, `weeklyOutcome` defaults null.

**query-key contract**: enumerates every `invalidateQueries` in `gameStore.ts` and checks each against representative real hook keys (`useAnalytics.ts` `[url, 'analytics:*-roi', {...}]`, `useEmails.ts` scopes, `['api','saves']` from `SaveGameModal`).

### Intentionally RED-PINNED (via `it.fails`) — PR-3 will fix
Five assertions are live red-pins that flip when PR-3 corrects the invalidation keys:
- `advanceWeek` `['artist-roi']`, `['project-roi']`, `['portfolio-roi']`, `['release-roi']` — real analytics keys are `[url, 'analytics:*-roi', {...}]`, so these match nothing.
- `advanceWeek` `['executives']` — no hook produces an `['executives']` query key.

### Validation
- `npx vitest run tests/client/` → 4 files, 26 tests passing (includes the 5 `it.fails` red-pins reported as passing because they fail as expected).
- `npm run check` (tsc) → clean.

Reference: Phase 3 client-state-ownership plan (PR-1 row: client-state characterization net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
