### PR TITLE
fix(client): Phase 3 PR-3 — repair dead ROI/executives invalidations in advanceWeek

### DIFF
--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -791,13 +791,24 @@ export const useGameStore = create<GameStore>()(
             }
           }
           
-          // Invalidate React Query caches to refresh UI components
-          await queryClient.invalidateQueries({ queryKey: ['artist-roi'] });
-          await queryClient.invalidateQueries({ queryKey: ['project-roi'] });
-          await queryClient.invalidateQueries({ queryKey: ['portfolio-roi'] });
-          await queryClient.invalidateQueries({ queryKey: ['release-roi'] });
-          // CRITICAL: Invalidate executives cache to refresh mood/loyalty after meetings
-          await queryClient.invalidateQueries({ queryKey: ['executives'] });
+          // Invalidate React Query caches to refresh UI components.
+          // Real analytics keys are shaped [url, 'analytics:<scope>-roi', { gameId, ... }]
+          // (see client/src/hooks/useAnalytics.ts) — the scope string lives at
+          // queryKey[1], not queryKey[0], so match it there and scope to the
+          // current game via the params object at queryKey[2].
+          const ROI_ANALYTICS_SCOPES = new Set([
+            'analytics:artist-roi',
+            'analytics:project-roi',
+            'analytics:portfolio-roi',
+            'analytics:release-roi',
+          ]);
+          await queryClient.invalidateQueries({
+            predicate: (query) =>
+              typeof query.queryKey[1] === 'string' &&
+              ROI_ANALYTICS_SCOPES.has(query.queryKey[1] as string) &&
+              (query.queryKey[2] as { gameId?: string } | undefined)?.gameId === syncedGameState.id,
+          });
+          // TODO(phase-3 PR-8): executives not in TanStack yet; invalidate ['executives', gameId] once useExecutives exists
           // Invalidate emails cache to refresh inbox with new week's emails
           await queryClient.invalidateQueries({
             predicate: (query) =>

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -7,15 +7,15 @@
  * invalidation key is an element-by-element PREFIX of the query key (NOT a string
  * prefix). Predicate-based invalidations are checked by running the predicate.
  *
- * Per the Phase 3 plan, FOUR `['*-roi']` keys and `['executives']` in
- * `advanceWeek` match NOTHING today — the real analytics keys are shaped
- * `[url, 'analytics:artist-roi', {...}]` and no hook produces an `['executives']`
- * key. Those assertions are intentionally RED-PINNED via `it.fails(...)` so they
- * flip to green when PR-3 fixes the invalidation keys.
+ * PR-3 fixed the four ROI invalidations in `advanceWeek` to use a
+ * predicate matching the real analytics key shape `[url, 'analytics:<scope>-roi',
+ * { gameId, ... }]` (scope in element 1, gameId in element 2), and removed the
+ * dead `['executives']` invalidation entirely (no hook produces that key —
+ * executives aren't wired into TanStack yet; see the PR-8 TODO in gameStore.ts).
  *
  * Reference invalidations in client/src/store/gameStore.ts (advanceWeek):
- *   queryKey: ['artist-roi'] | ['project-roi'] | ['portfolio-roi'] | ['release-roi']
- *   queryKey: ['executives']
+ *   predicate: matches queryKey[1] in the ROI analytics scopes AND
+ *              queryKey[2].gameId === current gameId
  *   predicate: EMAIL_LIST_SCOPE / EMAIL_UNREAD_SCOPE keyed on gameId
  * and saveGame: queryKey: ['api', 'saves'].
  */
@@ -72,32 +72,40 @@ describe('query-key contract: invalidations that DO match a real hook key', () =
   });
 });
 
-describe('query-key contract: RED-PINNED invalidations (PR-3 will fix)', () => {
-  // These use it.fails: the assertion body FAILS today, and vitest reports the
-  // test as PASSING because failure is expected. When PR-3 changes the store to
-  // emit the correct keys AND the real keys here are updated to match, these
-  // will start passing the assertion, which flips it.fails to a (desired)
-  // failure — a loud signal that the pin must be converted to a normal `it`.
+describe('query-key contract: advanceWeek invalidations (PR-3 fixed)', () => {
+  // The ROI predicate now used by advanceWeek: matches queryKey[1] against the
+  // known analytics scopes and requires queryKey[2].gameId to equal the current
+  // game's id — mirrors client/src/store/gameStore.ts exactly.
+  const ROI_ANALYTICS_SCOPES = new Set([
+    'analytics:artist-roi',
+    'analytics:project-roi',
+    'analytics:portfolio-roi',
+    'analytics:release-roi',
+  ]);
+  function roiPredicate(gameId: string) {
+    return (q: { queryKey: readonly unknown[] }) =>
+      typeof q.queryKey[1] === 'string' &&
+      ROI_ANALYTICS_SCOPES.has(q.queryKey[1] as string) &&
+      (q.queryKey[2] as { gameId?: string } | undefined)?.gameId === gameId;
+  }
 
-  it.fails('advanceWeek ["artist-roi"] currently matches NO real analytics key', () => {
-    // Real key is [url, "analytics:artist-roi", {...}] — ["artist-roi"] matches nothing.
-    expect(someRealKeyMatchesInvalidationKey(['artist-roi'])).toBe(true);
+  it('advanceWeek ROI predicate matches the real artist-roi analytics key', () => {
+    expect(someRealKeyMatchesPredicate(roiPredicate(GAME_ID))).toBe(true);
   });
 
-  it.fails('advanceWeek ["project-roi"] currently matches NO real analytics key', () => {
-    expect(someRealKeyMatchesInvalidationKey(['project-roi'])).toBe(true);
+  it('advanceWeek ROI predicate matches all four real ROI analytics keys', () => {
+    const predicate = roiPredicate(GAME_ID);
+    const matches = REAL_QUERY_KEYS.filter((real) => predicate({ queryKey: real }));
+    expect(matches.length).toBe(4);
   });
 
-  it.fails('advanceWeek ["portfolio-roi"] currently matches NO real analytics key', () => {
-    expect(someRealKeyMatchesInvalidationKey(['portfolio-roi'])).toBe(true);
+  it('advanceWeek ROI predicate does NOT match a different game\'s analytics keys', () => {
+    expect(someRealKeyMatchesPredicate(roiPredicate('some-other-game'))).toBe(false);
   });
 
-  it.fails('advanceWeek ["release-roi"] currently matches NO real analytics key', () => {
-    expect(someRealKeyMatchesInvalidationKey(['release-roi'])).toBe(true);
-  });
-
-  it.fails('advanceWeek ["executives"] currently matches NO real hook key', () => {
-    // No hook produces an ["executives"] query key today.
-    expect(someRealKeyMatchesInvalidationKey(['executives'])).toBe(true);
+  it('advanceWeek no longer emits a dead ["executives"] invalidation (not in TanStack yet)', () => {
+    // No hook produces an ["executives"] query key today — asserting this stays
+    // false documents that gameStore.ts must not reintroduce that dead key.
+    expect(someRealKeyMatchesInvalidationKey(['executives'])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes dead cache invalidations in `advanceWeek` (`client/src/store/gameStore.ts`), verified red-pinned by Phase 3 PR-1 (`tests/client/query-key-contract.test.ts`).

**What was dead:**
- `queryClient.invalidateQueries({ queryKey: ['artist-roi'] })` (and `project-roi`, `portfolio-roi`, `release-roi`) matched nothing — the real hooks in `client/src/hooks/useAnalytics.ts` produce keys shaped `[url, 'analytics:<scope>-roi', { gameId, ... }]`, with the scope string in **element 1**, not element 0. TanStack matches `invalidateQueries({ queryKey })` element-by-element from the front, so these were silent no-ops and ROI cards could show stale data after advancing a week.
- `queryClient.invalidateQueries({ queryKey: ['executives'] })` matched nothing anywhere — executives aren't wired into TanStack Query yet.

**What matches now:**
Replaced the four ROI invalidations with a single predicate-based invalidation (mirroring the email predicate directly below it in the same function):

```ts
const ROI_ANALYTICS_SCOPES = new Set([
  'analytics:artist-roi',
  'analytics:project-roi',
  'analytics:portfolio-roi',
  'analytics:release-roi',
]);
await queryClient.invalidateQueries({
  predicate: (query) =>
    typeof query.queryKey[1] === 'string' &&
    ROI_ANALYTICS_SCOPES.has(query.queryKey[1] as string) &&
    (query.queryKey[2] as { gameId?: string } | undefined)?.gameId === syncedGameState.id,
});
```

Removed the dead `['executives']` invalidation, replaced with:
```ts
// TODO(phase-3 PR-8): executives not in TanStack yet; invalidate ['executives', gameId] once useExecutives exists
```

**Which pins flipped:**
All 5 `it.fails(...)` red pins in `tests/client/query-key-contract.test.ts` were converted to plain `it(...)`:
- 4 new assertions verify the ROI predicate matches all four real analytics keys and correctly scopes to the current `gameId` (a distinct-game predicate check was added to prove scoping actually works, not just presence-of-key).
- The `['executives']` pin became an assertion that the dead key stays unmatched, documenting the key must not be reintroduced until PR-8 wires up `useExecutives`.

Reference: `docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md` (PR table row 3).

## Test plan
- [x] `npm run check` — clean, no TS errors
- [x] `npx vitest run tests/client/` — 4 files / 25 tests passed (including all 6 in `query-key-contract.test.ts`)
- [ ] Full suite intentionally not run per task scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)