### PR TITLE
refactor(client): Phase 3 PR-4 — extract shared 6-endpoint reload into fetchGameBundle

### DIFF
--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -10,6 +10,52 @@ import { buildGameSnapshot } from '@/utils/buildGameSnapshot';
 import { formatAutosaveName } from '@shared/utils/saveName';
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
 
+// Internal helper: the shared 6-endpoint + email-snapshot parallel reload used
+// identically by loadGame / loadGameFromSave / advanceWeek. Fans out the same
+// seven GETs, parses the six JSON bodies, and returns the raw bundle. Callers
+// keep their OWN gameState-sync + set(...) logic — only the common fetch+parse
+// moved here (Phase 3 PR-4). Ordering and .json() semantics are preserved
+// byte-identical to the previous inline copies.
+interface GameBundle {
+  gameData: any;
+  songs: any;
+  releases: any;
+  releaseSongs: any;
+  executives: any;
+  moodEvents: any;
+  emails: any[];
+}
+
+async function fetchGameBundle(gameId: string): Promise<GameBundle> {
+  const [
+    gameResponse,
+    songsResponse,
+    releasesResponse,
+    releaseSongsResponse,
+    executivesResponse,
+    moodEventsResponse,
+    emailSnapshot
+  ] = await Promise.all([
+    apiRequest('GET', `/api/game/${gameId}`),
+    apiRequest('GET', `/api/game/${gameId}/songs`),
+    apiRequest('GET', `/api/game/${gameId}/releases`),
+    apiRequest('GET', `/api/game/${gameId}/release-songs`),
+    apiRequest('GET', `/api/game/${gameId}/executives`),
+    apiRequest('GET', `/api/game/${gameId}/mood-events`),
+    fetchEmailSnapshot(gameId)
+  ]);
+
+  const gameData = await gameResponse.json();
+  const songs = await songsResponse.json();
+  const releases = await releasesResponse.json();
+  const emails = emailSnapshot.emails;
+  const releaseSongs = await releaseSongsResponse.json();
+  const executives = await executivesResponse.json();
+  const moodEvents = await moodEventsResponse.json();
+
+  return { gameData, songs, releases, releaseSongs, executives, moodEvents, emails };
+}
+
 // Internal helper to sync focus slots and A&R operation status to the server
 async function syncSlotsPatch(
   gameId: string,
@@ -119,31 +165,15 @@ export const useGameStore = create<GameStore>()(
       // Load existing game
       loadGame: async (gameId: string) => {
         try {
-          const [
-            gameResponse,
-            songsResponse,
-            releasesResponse,
-            releaseSongsResponse,
-            executivesResponse,
-            moodEventsResponse,
-            emailSnapshot
-          ] = await Promise.all([
-            apiRequest('GET', `/api/game/${gameId}`),
-            apiRequest('GET', `/api/game/${gameId}/songs`),
-            apiRequest('GET', `/api/game/${gameId}/releases`),
-            apiRequest('GET', `/api/game/${gameId}/release-songs`),
-            apiRequest('GET', `/api/game/${gameId}/executives`),
-            apiRequest('GET', `/api/game/${gameId}/mood-events`),
-            fetchEmailSnapshot(gameId)
-          ]);
-
-          const data = await gameResponse.json();
-          const songs = await songsResponse.json();
-          const releases = await releasesResponse.json();
-          const emailList = emailSnapshot.emails;
-          const releaseSongs = await releaseSongsResponse.json();
-          const executives = await executivesResponse.json();
-          const moodEvents = await moodEventsResponse.json();
+          const {
+            gameData: data,
+            songs,
+            releases,
+            releaseSongs,
+            executives,
+            moodEvents,
+            emails: emailList,
+          } = await fetchGameBundle(gameId);
 
           console.log('GameStore loadGame debug:', {
             gameId,
@@ -256,31 +286,15 @@ export const useGameStore = create<GameStore>()(
 
           localStorage.setItem('currentGameId', restoredGameId);
 
-          const [
-            gameResponse,
-            songsResponse,
-            releasesResponse,
-            releaseSongsResponse,
-            executivesResponse,
-            moodEventsResponse,
-            emailSnapshot
-          ] = await Promise.all([
-            apiRequest('GET', `/api/game/${restoredGameId}`),
-            apiRequest('GET', `/api/game/${restoredGameId}/songs`),
-            apiRequest('GET', `/api/game/${restoredGameId}/releases`),
-            apiRequest('GET', `/api/game/${restoredGameId}/release-songs`),
-            apiRequest('GET', `/api/game/${restoredGameId}/executives`),
-            apiRequest('GET', `/api/game/${restoredGameId}/mood-events`),
-            fetchEmailSnapshot(restoredGameId),
-          ]);
-
-          const gameData = await gameResponse.json();
-          const songsData = await songsResponse.json();
-          const releasesData = await releasesResponse.json();
-          const emailList = emailSnapshot.emails;
-          const releaseSongsData = await releaseSongsResponse.json();
-          const executivesData = await executivesResponse.json();
-          const moodEventsData = await moodEventsResponse.json();
+          const {
+            gameData,
+            songs: songsData,
+            releases: releasesData,
+            releaseSongs: releaseSongsData,
+            executives: executivesData,
+            moodEvents: moodEventsData,
+            emails: emailList,
+          } = await fetchGameBundle(restoredGameId);
 
           const syncedGameState = {
             ...gameData.gameState,
@@ -677,30 +691,15 @@ export const useGameStore = create<GameStore>()(
           console.log('===============================');
           
           // Reload game data to get updated projects, songs, and releases after processing
-          const [
-            gameResponse,
-            songsResponse,
-            releasesResponse,
-            releaseSongsResponse,
-            executivesResponse,
-            moodEventsResponse,
-            emailSnapshot
-          ] = await Promise.all([
-            apiRequest('GET', `/api/game/${gameState.id}`),
-            apiRequest('GET', `/api/game/${gameState.id}/songs`),
-            apiRequest('GET', `/api/game/${gameState.id}/releases`),
-            apiRequest('GET', `/api/game/${gameState.id}/release-songs`),
-            apiRequest('GET', `/api/game/${gameState.id}/executives`),
-            apiRequest('GET', `/api/game/${gameState.id}/mood-events`),
-            fetchEmailSnapshot(gameState.id)
-          ]);
-          const gameData = await gameResponse.json();
-          const songs = await songsResponse.json();
-          const releases = await releasesResponse.json();
-          const emailList = emailSnapshot.emails;
-          const releaseSongsData = await releaseSongsResponse.json();
-          const executivesData = await executivesResponse.json();
-          const moodEventsData = await moodEventsResponse.json();
+          const {
+            gameData,
+            songs,
+            releases,
+            releaseSongs: releaseSongsData,
+            executives: executivesData,
+            moodEvents: moodEventsData,
+            emails: emailList,
+          } = await fetchGameBundle(gameState.id);
 
           console.log('=== POST-ADVANCE WEEK STATE SYNC ===');
           console.log('Game data releases count:', (gameData.releases || []).length);


### PR DESCRIPTION
## Summary

Phase 3 **PR-4** — pure move, **zero behavior change**. Extracts the shared 6-endpoint (+ email snapshot) parallel reload that was copied verbatim three times in `client/src/store/gameStore.ts` into one internal helper, `fetchGameBundle(gameId)`.

Ref: `docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md` (PR table row 4).

## What moved

The identical 7-way `Promise.all` (`GET /api/game/:id` + `/songs`, `/releases`, `/release-songs`, `/executives`, `/mood-events`, plus `fetchEmailSnapshot`) **and its subsequent `.json()` parsing** — previously duplicated in `loadGame`, `loadGameFromSave`, and `advanceWeek` — now lives in:

```ts
async function fetchGameBundle(gameId: string): Promise<GameBundle>
// returns { gameData, songs, releases, releaseSongs, executives, moodEvents, emails }
```

Endpoint order and the exact `.json()` / `emailSnapshot.emails` semantics are preserved byte-identical. Each caller keeps its **own** `gameState`-sync and `set(...)` block; they now just destructure the bundle, using rename-on-destructure to keep each caller's original local variable names (`data`/`emailList` in `loadGame`; `gameData`/`songsData`/… in `loadGameFromSave`; `songs`/`releases`/`emailList`/… in `advanceWeek`).

Result: exactly one `Promise.all([...songs...releases...])` block remains in the file (acceptance criterion #3).

## Caller-specific differences found & preserved

I diffed the three fan-outs carefully. The **fetch + parse** portion is truly identical across all three (same endpoints, same order, same JSON handling); only surrounding logic differs, and all of it stays at the call site:

- **`loadGame`** — syncs `arOfficeSlotUsed`/`usedFocusSlots` from `data.gameState`, nests `musicLabel`, then conditionally loads discovered artists. Unchanged.
- **`loadGameFromSave`** — runs over `restoredGameId` (post-restore), builds `syncedGameState` differently, and invalidates the email scopes (C49 fix). Unchanged.
- **`advanceWeek`** — merges `result.gameState` over the reloaded `gameData.gameState`, forces `usedFocusSlots`, autosaves, and runs the ROI/email invalidation. Unchanged.

No error-path or endpoint differences existed between the three — the only variation was local variable naming, handled by destructure aliases.

## emailSnapshot call

The plan suggested folding `utils/emailSnapshot.ts` helpers behind the new helper "where they duplicate the same GETs." **I declined to restructure `emailSnapshot.ts`.** `fetchEmailSnapshot` is already the single shared implementation these three call, and it carries its own pagination semantics (pages the inbox to a short page, `MAX_PAGES` truncation flag) — it is not a duplicated GET to collapse. `fetchGameBundle` simply calls it as part of the common fan-out (as before). `fetchSnapshotCollections` (used by `saveGame`) is a separate composition and was left untouched. A smaller, faithful PR beats a broader risky one here.

## Verification

- `npm run check` — clean (tsc, no errors)
- `npx vitest run tests/client/` — **25/25 passed**, including the PR-1 characterization pins for the `loadGame` / `advanceWeek` `set(...)` shapes, **unmodified**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
