### PR TITLE
feat(client): Phase 3 PR-8 — useExecutives, collapse executives triple copy

### DIFF
--- a/client/src/components/executive-meetings/ExecutiveMeetings.tsx
+++ b/client/src/components/executive-meetings/ExecutiveMeetings.tsx
@@ -1,6 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useMachine } from '@xstate/react';
+import { useQueryClient } from '@tanstack/react-query';
 import { executiveMeetingMachine } from '../../machines/executiveMeetingMachine';
+import { makeCachedFetchExecutives } from '../../hooks/useExecutives';
 import { ExecutiveCard } from './ExecutiveCard';
 import { MeetingSelector } from './MeetingSelector';
 import { DialogueInterface } from './DialogueInterface';
@@ -8,7 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { ArrowLeft, Loader2, Zap } from 'lucide-react';
-import { fetchExecutives, fetchRoleMeetings, fetchMeetingDialogue, fetchAllRoles } from '../../services/executiveService';
+import { fetchRoleMeetings, fetchMeetingDialogue, fetchAllRoles } from '../../services/executiveService';
 import { useGameStore } from '../../store/gameStore';
 
 interface ExecutiveMeetingsProps {
@@ -49,13 +51,23 @@ export function ExecutiveMeetings({
 
   const { getAROfficeStatus, selectedActions, artists } = useGameStore();
 
+  // Phase 3 PR-8: route the machine's executives fetch through the TanStack
+  // Query cache (key ['executives', gameId]) so the meeting flow and any
+  // useExecutives() consumers share ONE cached source. The machine keeps its
+  // injected-service pattern — it never imports TanStack or the store itself.
+  const queryClient = useQueryClient();
+  const cachedFetchExecutives = useMemo(
+    () => makeCachedFetchExecutives(queryClient),
+    [queryClient],
+  );
+
   const [state, send] = useMachine(executiveMeetingMachine, {
     input: {
       gameId,
       currentWeek,
       focusSlotsTotal: focusSlots.total,
       onActionSelected,
-      fetchExecutives,
+      fetchExecutives: cachedFetchExecutives,
       fetchRoleMeetings,
       fetchMeetingDialogue,
     },

--- a/client/src/hooks/useExecutives.ts
+++ b/client/src/hooks/useExecutives.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { fetchExecutives } from '@/services/executiveService';
+import type { Executive } from '@shared/types/gameTypes';
+
+/**
+ * Executives query hook (Phase 3 PR-8).
+ *
+ * Single cached source of truth for the executive roster. Collapses the former
+ * triple copy (Zustand store array + `executiveMeetingMachine` context copy +
+ * save-snapshot need) onto ONE TanStack Query cache entry.
+ *
+ * Key convention: this hook supplies its own explicit `queryFn` (it wraps
+ * `executiveService.fetchExecutives`, which also synthesizes the CEO row and
+ * sorts by display order), so it does NOT route through the default
+ * `getQueryFn` in `queryClient.ts` that requires the request URL at element 0.
+ * That default-key contract only applies to queries relying on the shared
+ * default queryFn (`useEmails` is the precedent: scoped string at element 0,
+ * gameId at element 1, own queryFn). So we follow the plan's literal
+ * `['executives', gameId]` key here.
+ *
+ * The meeting machine keeps its injected-service pattern; it is handed a
+ * cache-backed fetch (see `fetchExecutivesThroughCache`) so the machine and any
+ * UI consumers share this one cached source.
+ */
+export const EXECUTIVES_SCOPE = 'executives';
+
+export function executivesQueryKey(gameId: string | null | undefined) {
+  return [EXECUTIVES_SCOPE, gameId ?? null] as const;
+}
+
+/**
+ * Fetch executives through the TanStack Query cache using the same key as
+ * `useExecutives`. Intended to be injected into `executiveMeetingMachine` as its
+ * `fetchExecutives` service so the machine reads/writes the shared cache instead
+ * of firing its own uncached request. `ensureQueryData` returns the cached value
+ * when fresh and fetches otherwise; the weekly-refresh flow invalidates the key
+ * (see gameStore.advanceWeek) so post-week mood/loyalty changes refetch.
+ */
+export function makeCachedFetchExecutives(
+  queryClient: ReturnType<typeof useQueryClient>,
+): (gameId: string) => Promise<Executive[]> {
+  return (gameId: string) =>
+    queryClient.ensureQueryData({
+      queryKey: executivesQueryKey(gameId),
+      queryFn: () => fetchExecutives(gameId),
+    });
+}
+
+export function useExecutives() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(() => executivesQueryKey(gameId), [gameId]);
+
+  return useQuery<Executive[]>({
+    queryKey,
+    enabled: Boolean(gameId),
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) return [];
+      return fetchExecutives(gameId);
+    },
+  });
+}

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -9,6 +9,7 @@ import { fetchSnapshotCollections, fetchEmailSnapshot } from '@/utils/emailSnaps
 import { buildGameSnapshot } from '@/utils/buildGameSnapshot';
 import { formatAutosaveName } from '@shared/utils/saveName';
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
+import { executivesQueryKey } from '@/hooks/useExecutives';
 
 // Internal helper: the shared 6-endpoint + email-snapshot parallel reload used
 // identically by loadGame / loadGameFromSave / advanceWeek. Fans out the same
@@ -807,7 +808,12 @@ export const useGameStore = create<GameStore>()(
               ROI_ANALYTICS_SCOPES.has(query.queryKey[1] as string) &&
               (query.queryKey[2] as { gameId?: string } | undefined)?.gameId === syncedGameState.id,
           });
-          // TODO(phase-3 PR-8): executives not in TanStack yet; invalidate ['executives', gameId] once useExecutives exists
+          // Phase 3 PR-8: refetch executives so post-week mood/loyalty changes
+          // show. useExecutives + the meeting machine share the ['executives',
+          // gameId] cache; invalidating it here is the weekly-refresh hook.
+          await queryClient.invalidateQueries({
+            queryKey: executivesQueryKey(syncedGameState.id),
+          });
           // Invalidate emails cache to refresh inbox with new week's emails
           await queryClient.invalidateQueries({
             predicate: (query) =>

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -21,6 +21,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
+import { EXECUTIVES_SCOPE, executivesQueryKey } from '@/hooks/useExecutives';
 
 const GAME_ID = 'game-1';
 const ARTIST_ID = 'artist-1';
@@ -40,6 +41,8 @@ const REAL_QUERY_KEYS: readonly unknown[][] = [
   [`/api/analytics/${GAME_ID}/release/${RELEASE_ID}/roi`, 'analytics:release-roi', { gameId: GAME_ID, releaseId: RELEASE_ID }],
   [EMAIL_LIST_SCOPE, GAME_ID, null, null, null, null, null],
   [EMAIL_UNREAD_SCOPE, GAME_ID],
+  // Executives (useExecutives.ts, PR-8): [EXECUTIVES_SCOPE, gameId]
+  [...executivesQueryKey(GAME_ID)],
   ['api', 'saves'],
 ];
 
@@ -103,9 +106,20 @@ describe('query-key contract: advanceWeek invalidations (PR-3 fixed)', () => {
     expect(someRealKeyMatchesPredicate(roiPredicate('some-other-game'))).toBe(false);
   });
 
-  it('advanceWeek no longer emits a dead ["executives"] invalidation (not in TanStack yet)', () => {
-    // No hook produces an ["executives"] query key today — asserting this stays
-    // false documents that gameStore.ts must not reintroduce that dead key.
-    expect(someRealKeyMatchesInvalidationKey(['executives'])).toBe(false);
+  it('advanceWeek executives invalidation matches the useExecutives hook key (PR-8)', () => {
+    // PR-8 wired executives into TanStack: useExecutives keys on
+    // [EXECUTIVES_SCOPE, gameId] and advanceWeek invalidates the same key via
+    // executivesQueryKey(gameId). The invalidation must now match the hook.
+    expect(someRealKeyMatchesInvalidationKey(executivesQueryKey(GAME_ID))).toBe(true);
+  });
+
+  it('advanceWeek executives invalidation does NOT match a different game', () => {
+    expect(someRealKeyMatchesInvalidationKey(executivesQueryKey('some-other-game'))).toBe(false);
+  });
+
+  it('the executives scope invalidation and hook key agree element-for-element', () => {
+    // Guards against drift: the store invalidation and the hook must produce the
+    // byte-identical key shape [EXECUTIVES_SCOPE, gameId].
+    expect(executivesQueryKey(GAME_ID)).toEqual([EXECUTIVES_SCOPE, GAME_ID]);
   });
 });


### PR DESCRIPTION
## Phase 3 PR-8 — `useExecutives`, collapse the executives triple copy

Implements row 8 of the Phase 3 client-state-ownership plan (`docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md`) and the §6 risk note on executives triple-ownership.

### Problem
The executive roster was held in three places: the Zustand store `executives` array (fed by every fan-out), the `executiveMeetingMachine` context copy (what the meeting UI actually renders), and the save-snapshot need. The store's `['executives']` invalidation in `advanceWeek` matched nothing (dead no-op), so post-week mood/loyalty could show stale.

### Changes
- **New `client/src/hooks/useExecutives.ts`** — `useQuery` keyed `['executives', gameId]` wrapping `executiveService.fetchExecutives` (which synthesizes the CEO row + sort order). Exports `EXECUTIVES_SCOPE`, `executivesQueryKey`, and `makeCachedFetchExecutives` (a `queryClient.ensureQueryData`-backed fetch).
- **`ExecutiveMeetings.tsx`** — injects `makeCachedFetchExecutives(queryClient)` as the machine's `fetchExecutives` service. The meeting flow now reads/writes the shared cache; render path (machine `context.executives`) is preserved unchanged. The machine itself is untouched and still imports no TanStack/store.
- **`gameStore.ts` `advanceWeek`** — the `// TODO(phase-3 PR-8)` is now a real `invalidateQueries({ queryKey: executivesQueryKey(gameId) })`, so the weekly refresh drives the one cached source.
- **`tests/client/query-key-contract.test.ts`** — adds the executives key to the real-key list and pins that the `advanceWeek` executives invalidation matches the `useExecutives` hook key (and does not cross games).

### Key convention used
Followed the plan's literal `['executives', gameId]`. `useExecutives` supplies its own explicit `queryFn`, so it does **not** route through the default `getQueryFn` that requires the URL at element 0 — exactly the precedent set by `useEmails` (scoped string at element 0). Noted in the hook header.

### Step-4 call: thin store copy (not cache-sourced snapshot)
Kept the store `executives` array purely as snapshot fallback input. `saveGame` already re-fetches executives fresh via `fetchSnapshotCollections` and only falls back to the store copy (`executivesSnapshot ?? executives`), so pulling from the cache at save time would add churn for no behavioral gain. Removing the store field would touch the `GameState` type, store interface, initial state, and all three fan-out write sites — a large, risky diff. Per §6 this is the sanctioned smaller-diff option. Snapshot shape is unchanged (PR-1 shape test green).

### Constraints honored (plan §5)
No `apiRequest`/store writes inside `machines/*.ts`; snapshot shape unchanged; client-only.

### Verification
- `npm run check` — clean.
- `npx vitest run tests/client/` — 27/27 green (query-key-contract now 8 tests; snapshot shape 6 tests).

> Note to reviewer: kept the `advanceWeek` invalidation edit to a single self-contained block to avoid conflicting with the parallel PR-5 chart-invalidation work in the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)