### PR TITLE
feat(client): Phase 3 PR-5 — useCharts query hooks, charts off raw apiRequest

### DIFF
--- a/client/src/components/Top100ChartDisplay.tsx
+++ b/client/src/components/Top100ChartDisplay.tsx
@@ -1,21 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Trophy, BarChart3 } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
+import { useTop100Chart } from '@/hooks/useCharts';
 import { ChartDataTable } from '@/components/chart/ChartDataTable';
 import { ChartEntry, chartColumns } from '@/components/chart/chartColumns';
 import { isPlayerSongHighlight } from '../../../shared/utils/chartUtils';
-import { apiRequest } from '@/lib/queryClient';
 
 type Top100Entry = ChartEntry;
-
-interface Top100ChartData {
-  chartWeek: string;
-  currentWeek: number;
-  top100: Top100Entry[];
-}
 
 export function Top100ChartDisplay() {
   console.log('🚀 Top100ChartDisplay component rendering...');
@@ -23,50 +17,21 @@ export function Top100ChartDisplay() {
   const { gameState } = useGameStore();
   console.log('🎮 GameState from store:', { id: gameState?.id, currentWeek: gameState?.currentWeek });
 
-  const [chartData, setChartData] = useState<Top100ChartData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
   const [showAll, setShowAll] = useState(false);
 
-  const fetchTop100Data = async () => {
-    console.log('📡 fetchTop100Data called, gameState:', { id: gameState?.id, exists: !!gameState });
+  const {
+    data: chartData,
+    isLoading: loading,
+    isFetching,
+    error: queryError,
+    refetch,
+  } = useTop100Chart();
 
-    if (!gameState?.id) {
-      console.log('❌ No gameState.id, returning early');
-      return;
-    }
-
-    try {
-      console.log('🔄 Starting Top 100 chart fetch...');
-      setRefreshing(true);
-      const apiUrl = `/api/game/${gameState.id}/charts/top100`;
-      console.log('📍 Fetching from URL:', apiUrl);
-
-      const response = await apiRequest('GET', apiUrl);
-      const data = await response.json();
-      setChartData(data);
-      setError(null);
-    } catch (err) {
-      console.error('Error fetching Top 100 chart data:', err);
-      setError(err instanceof Error ? err.message : 'Failed to load chart data');
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  };
-
-  useEffect(() => {
-    console.log('🎵 Chart Debug Info:', {
-      gameStateId: gameState?.id,
-      hasGameState: !!gameState,
-      apiUrl: `/api/game/${gameState?.id}/charts/top100`
-    });
-    fetchTop100Data();
-  }, [gameState?.id]);
+  const refreshing = isFetching;
+  const error = queryError ? (queryError instanceof Error ? queryError.message : 'Failed to load chart data') : null;
 
   const handleRefresh = () => {
-    fetchTop100Data();
+    refetch();
   };
 
   if (loading) {

--- a/client/src/components/Top10ChartDisplay.tsx
+++ b/client/src/components/Top10ChartDisplay.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Trophy, BarChart3 } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
-import { apiRequest } from '@/lib/queryClient';
+import { useTop10Chart } from '@/hooks/useCharts';
 import { ChartDataTable } from '@/components/chart/ChartDataTable';
 import { ChartEntry, chartColumns } from '@/components/chart/chartColumns';
 import { isPlayerSongHighlight } from '../../../shared/utils/chartUtils';
@@ -12,61 +12,25 @@ import logger from '@/lib/logger';
 
 type Top10Entry = ChartEntry;
 
-interface Top10ChartData {
-  chartWeek: string;
-  currentWeek: number;
-  top10: Top10Entry[];
-}
-
 export function Top10ChartDisplay() {
   logger.debug('🚀 Top10ChartDisplay component rendering...');
 
   const { gameState } = useGameStore();
   logger.debug('🎮 GameState from store:', { id: gameState?.id, currentWeek: gameState?.currentWeek });
 
-  const [chartData, setChartData] = useState<Top10ChartData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
+  const {
+    data: chartData,
+    isLoading: loading,
+    isFetching,
+    error: queryError,
+    refetch,
+  } = useTop10Chart();
 
-  const fetchTop10Data = async () => {
-    logger.debug('📡 fetchTop10Data called, gameState:', { id: gameState?.id, exists: !!gameState });
-
-    if (!gameState?.id) {
-      logger.debug('❌ No gameState.id, returning early');
-      return;
-    }
-
-    try {
-      logger.debug('🔄 Starting Top 10 chart fetch...');
-      setRefreshing(true);
-      const apiUrl = `/api/game/${gameState.id}/charts/top10`;
-      logger.debug('📍 Fetching from URL:', apiUrl);
-
-      const response = await apiRequest('GET', apiUrl);
-      const data = await response.json();
-      setChartData(data);
-      setError(null);
-    } catch (err) {
-      logger.error('Error fetching Top 10 chart data:', err);
-      setError(err instanceof Error ? err.message : 'Failed to load chart data');
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  };
-
-  useEffect(() => {
-    logger.debug('🎵 Chart Debug Info:', {
-      gameStateId: gameState?.id,
-      hasGameState: !!gameState,
-      apiUrl: `/api/game/${gameState?.id}/charts/top10`
-    });
-    fetchTop10Data();
-  }, [gameState?.id]);
+  const refreshing = isFetching;
+  const error = queryError ? (queryError instanceof Error ? queryError.message : 'Failed to load chart data') : null;
 
   const handleRefresh = () => {
-    fetchTop10Data();
+    refetch();
   };
 
   if (loading) {

--- a/client/src/hooks/useCharts.ts
+++ b/client/src/hooks/useCharts.ts
@@ -1,0 +1,63 @@
+/**
+ * Chart Hooks
+ *
+ * TanStack Query hooks for the Top 10 / Top 100 chart reads. Charts are pure
+ * server reads never mirrored into the Zustand store (see Phase 3 PR-5 plan).
+ * Follows the scoped-key pattern from `useEmails.ts`: [SCOPE, gameId, ...].
+ */
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { apiRequest } from '@/lib/queryClient';
+import type { ChartEntry } from '@/components/chart/chartColumns';
+
+export const CHART_TOP10_SCOPE = 'charts:top10';
+export const CHART_TOP100_SCOPE = 'charts:top100';
+
+export interface Top10ChartData {
+  chartWeek: string;
+  currentWeek: number;
+  top10: ChartEntry[];
+}
+
+export interface Top100ChartData {
+  chartWeek: string;
+  currentWeek: number;
+  top100: ChartEntry[];
+}
+
+export function useTop10Chart() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(
+    () => [CHART_TOP10_SCOPE, gameId ?? null] as const,
+    [gameId],
+  );
+
+  return useQuery<Top10ChartData>({
+    queryKey,
+    enabled: Boolean(gameId),
+    queryFn: async () => {
+      const response = await apiRequest('GET', `/api/game/${gameId}/charts/top10`);
+      return response.json();
+    },
+  });
+}
+
+export function useTop100Chart() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(
+    () => [CHART_TOP100_SCOPE, gameId ?? null] as const,
+    [gameId],
+  );
+
+  return useQuery<Top100ChartData>({
+    queryKey,
+    enabled: Boolean(gameId),
+    queryFn: async () => {
+      const response = await apiRequest('GET', `/api/game/${gameId}/charts/top100`);
+      return response.json();
+    },
+  });
+}

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -10,6 +10,7 @@ import { buildGameSnapshot } from '@/utils/buildGameSnapshot';
 import { formatAutosaveName } from '@shared/utils/saveName';
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
 import { executivesQueryKey } from '@/hooks/useExecutives';
+import { CHART_TOP10_SCOPE, CHART_TOP100_SCOPE } from '@/hooks/useCharts';
 
 // Internal helper: the shared 6-endpoint + email-snapshot parallel reload used
 // identically by loadGame / loadGameFromSave / advanceWeek. Fans out the same
@@ -818,6 +819,12 @@ export const useGameStore = create<GameStore>()(
           await queryClient.invalidateQueries({
             predicate: (query) =>
               (query.queryKey[0] === EMAIL_LIST_SCOPE || query.queryKey[0] === EMAIL_UNREAD_SCOPE) &&
+              query.queryKey[1] === syncedGameState.id,
+          });
+          // Invalidate chart caches so Top 10 / Top 100 reflect the new week
+          await queryClient.invalidateQueries({
+            predicate: (query) =>
+              (query.queryKey[0] === CHART_TOP10_SCOPE || query.queryKey[0] === CHART_TOP100_SCOPE) &&
               query.queryKey[1] === syncedGameState.id,
           });
         } catch (error) {

--- a/tests/client/gameStore-email-invalidation.characterization.test.ts
+++ b/tests/client/gameStore-email-invalidation.characterization.test.ts
@@ -41,14 +41,25 @@ beforeEach(() => {
   resetGameStore();
 });
 
-/** Extract the last `predicate` passed to invalidateQueries. */
-function lastPredicate(): (query: { queryKey: readonly unknown[] }) => boolean {
+/**
+ * Extract the `predicate` passed to invalidateQueries that matches the EMAIL
+ * scopes specifically, scoped to `gameId`. `advanceWeek`/`loadGameFromSave`
+ * fire several scoped predicate invalidations (ROI analytics, charts, emails)
+ * — search by scope+id rather than assuming email is the last call, so this
+ * pin doesn't break when another predicate invalidation is added alongside it.
+ */
+function lastPredicate(gameId: string): (query: { queryKey: readonly unknown[] }) => boolean {
   const calls = mockedInvalidateQueries.mock.calls;
   for (let i = calls.length - 1; i >= 0; i--) {
     const arg = calls[i][0];
-    if (arg && typeof arg.predicate === 'function') return arg.predicate;
+    if (arg && typeof arg.predicate === 'function') {
+      const predicate = arg.predicate;
+      if (predicate({ queryKey: [EMAIL_LIST_SCOPE, gameId] })) {
+        return predicate;
+      }
+    }
   }
-  throw new Error('No invalidateQueries call with a predicate was recorded');
+  throw new Error('No invalidateQueries call with an email-scoped predicate was recorded');
 }
 
 function assertEmailPredicateScopedTo(
@@ -109,7 +120,7 @@ describe('loadGameFromSave email invalidation (C49)', () => {
     await useGameStore.getState().loadGameFromSave('save-1', snapshot, 'overwrite');
 
     // The predicate must be keyed on the RESTORED id, not the snapshot's own id.
-    assertEmailPredicateScopedTo(lastPredicate(), restoredGameId);
+    assertEmailPredicateScopedTo(lastPredicate(restoredGameId), restoredGameId);
   });
 });
 
@@ -138,6 +149,6 @@ describe('advanceWeek email invalidation', () => {
 
     await useGameStore.getState().advanceWeek();
 
-    assertEmailPredicateScopedTo(lastPredicate(), gameId);
+    assertEmailPredicateScopedTo(lastPredicate(gameId), gameId);
   });
 });

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect } from 'vitest';
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
 import { EXECUTIVES_SCOPE, executivesQueryKey } from '@/hooks/useExecutives';
+import { CHART_TOP10_SCOPE, CHART_TOP100_SCOPE } from '@/hooks/useCharts';
 
 const GAME_ID = 'game-1';
 const ARTIST_ID = 'artist-1';
@@ -32,6 +33,7 @@ const RELEASE_ID = 'release-1';
  * Representative REAL query keys produced by the app's hooks.
  * - Analytics keys (useAnalytics.ts): `[url, 'analytics:<scope>-roi', { ... }]`
  * - Email keys (useEmails.ts): `[SCOPE, gameId, ...filters]`
+ * - Chart keys (useCharts.ts): `[SCOPE, gameId]`
  * - Saves key (SaveGameModal.tsx): `['api', 'saves']`
  */
 const REAL_QUERY_KEYS: readonly unknown[][] = [
@@ -43,6 +45,8 @@ const REAL_QUERY_KEYS: readonly unknown[][] = [
   [EMAIL_UNREAD_SCOPE, GAME_ID],
   // Executives (useExecutives.ts, PR-8): [EXECUTIVES_SCOPE, gameId]
   [...executivesQueryKey(GAME_ID)],
+  [CHART_TOP10_SCOPE, GAME_ID],
+  [CHART_TOP100_SCOPE, GAME_ID],
   ['api', 'saves'],
 ];
 
@@ -72,6 +76,27 @@ describe('query-key contract: invalidations that DO match a real hook key', () =
       (q.queryKey[0] === EMAIL_LIST_SCOPE || q.queryKey[0] === EMAIL_UNREAD_SCOPE) &&
       q.queryKey[1] === GAME_ID;
     expect(someRealKeyMatchesPredicate(emailPredicate)).toBe(true);
+  });
+});
+
+describe('query-key contract: advanceWeek chart invalidations (PR-5)', () => {
+  // Mirrors client/src/store/gameStore.ts advanceWeek's chart invalidation
+  // predicate exactly: matches CHART_TOP10_SCOPE/CHART_TOP100_SCOPE at
+  // queryKey[0] and requires queryKey[1] to equal the current game's id.
+  function chartPredicate(gameId: string) {
+    return (q: { queryKey: readonly unknown[] }) =>
+      (q.queryKey[0] === CHART_TOP10_SCOPE || q.queryKey[0] === CHART_TOP100_SCOPE) &&
+      q.queryKey[1] === gameId;
+  }
+
+  it('advanceWeek chart predicate matches both real chart query keys', () => {
+    const predicate = chartPredicate(GAME_ID);
+    const matches = REAL_QUERY_KEYS.filter((real) => predicate({ queryKey: real }));
+    expect(matches.length).toBe(2);
+  });
+
+  it('advanceWeek chart predicate does NOT match a different game\'s chart keys', () => {
+    expect(someRealKeyMatchesPredicate(chartPredicate('some-other-game'))).toBe(false);
   });
 });
 

--- a/tests/client/useCharts.test.tsx
+++ b/tests/client/useCharts.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * useCharts hook test (Phase 3 PR-5).
+ *
+ * Mocks `apiRequest` and `useGameStore` to verify the Top10/Top100 chart
+ * hooks fetch the right endpoint, key their queries by the scoped
+ * [SCOPE, gameId] shape, and skip fetching when there's no active game.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/queryClient', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/queryClient')>('@/lib/queryClient');
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: vi.fn(),
+}));
+
+import { apiRequest } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import { useTop10Chart, useTop100Chart, CHART_TOP10_SCOPE, CHART_TOP100_SCOPE } from '@/hooks/useCharts';
+
+const mockedApiRequest = vi.mocked(apiRequest);
+const mockedUseGameStore = vi.mocked(useGameStore);
+
+function jsonResponse(body: unknown): Response {
+  return { json: async () => body } as unknown as Response;
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return queryClient;
+}
+
+function TestTop10() {
+  const { data, isLoading } = useTop10Chart();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="top10">{JSON.stringify(data)}</div>;
+}
+
+function TestTop100() {
+  const { data, isLoading } = useTop100Chart();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="top100">{JSON.stringify(data)}</div>;
+}
+
+describe('useCharts', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+    mockedUseGameStore.mockReset();
+  });
+
+  it('useTop10Chart fetches the game-scoped top10 endpoint', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(
+      jsonResponse({ chartWeek: '2026-W01', currentWeek: 5, top10: [] }),
+    );
+
+    renderWithClient(<TestTop10 />);
+
+    await waitFor(() => expect(screen.getByTestId('top10')).toBeTruthy());
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1/charts/top10');
+  });
+
+  it('useTop100Chart fetches the game-scoped top100 endpoint', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(
+      jsonResponse({ chartWeek: '2026-W01', currentWeek: 5, top100: [] }),
+    );
+
+    renderWithClient(<TestTop100 />);
+
+    await waitFor(() => expect(screen.getByTestId('top100')).toBeTruthy());
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1/charts/top100');
+  });
+
+  it('does not fetch when there is no active game', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: null }));
+
+    renderWithClient(<TestTop10 />);
+
+    // Query stays disabled; no apiRequest call should ever fire.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('scope constants match the keys used in gameStore invalidation', () => {
+    expect(CHART_TOP10_SCOPE).toBe('charts:top10');
+    expect(CHART_TOP100_SCOPE).toBe('charts:top100');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `client/src/hooks/useCharts.ts` (`useTop10Chart` / `useTop100Chart`) — TanStack Query hooks for the Top 10 / Top 100 chart reads, keyed on the scoped-key pattern from `useEmails.ts` (`['charts:top10', gameId]` / `['charts:top100', gameId]`).
- `Top10ChartDisplay.tsx` and `Top100ChartDisplay.tsx` no longer fetch via raw `apiRequest` + `useState`/`useEffect`; they consume the new hooks. Loading/error/empty rendering paths are unchanged.
- `gameStore.ts` `advanceWeek` now invalidates the chart scopes (predicate matching `CHART_TOP10_SCOPE`/`CHART_TOP100_SCOPE` at `queryKey[0]` + gameId at `queryKey[1]`), mirroring the existing analytics-ROI and email invalidation predicates.
- Extends `tests/client/query-key-contract.test.ts` with the chart query keys and a predicate test asserting the `advanceWeek` chart invalidation matches both real chart keys and is scoped per-game.
- Adds `tests/client/useCharts.test.tsx` — hook tests with mocked `apiRequest`/`useGameStore` covering: correct endpoint fetched per hook, query disabled with no active game, and scope constants matching the invalidation predicate.
- Fixes an incidental fragility in `tests/client/gameStore-email-invalidation.characterization.test.ts`'s `lastPredicate()` helper: it previously assumed the email invalidation was always the *last* `invalidateQueries` call, which broke once the chart invalidation was added after it. Now it searches by scope+gameId match instead of call order.

Reference: `docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md` (PR-5 row).

No other raw chart-endpoint fetch sites were found (`grep` for `charts/top10` / `charts/top100` across `client/`) — only the two display components.

## Test plan
- [x] `npm run check` — clean
- [x] `npx vitest run tests/client/` — 5 files / 31 tests passed (Docker test DB on :5433)
- [ ] Manual smoke: Top 10 / Top 100 pages load and refresh after advancing a week (not run in this session; recommend before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)