### PR TITLE
feat(client): Phase 3 PR-6 — useReleases/useSongs hooks; store stops owning release/song data

### DIFF
--- a/client/src/components/ActiveReleases.tsx
+++ b/client/src/components/ActiveReleases.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useGameStore } from '@/store/gameStore';
+import { useReleases } from '@/hooks/useReleases';
+import { useSongs } from '@/hooks/useSongs';
 import { useState, useEffect } from 'react';
 import { AlertTriangle, Clock, CheckCircle, BarChart3 } from 'lucide-react';
 import { ReleaseWorkflowCard } from './ReleaseWorkflowCard';
@@ -13,7 +15,10 @@ import {
 } from '../../../shared/utils/chartUtils';
 
 export function ActiveReleases() {
-  const { releases, artists, songs, gameState } = useGameStore();
+  const { artists, gameState } = useGameStore();
+  // Phase 3 PR-6: releases / songs read from the TanStack Query cache, not Zustand.
+  const { data: releases = [] } = useReleases();
+  const { data: songs = [] } = useSongs();
   const [activeTab, setActiveTab] = useState<'upcoming' | 'released'>('upcoming');
   const [stateSync, setStateSync] = useState<'synced' | 'syncing' | 'error'>('synced');
   

--- a/client/src/components/MusicCalendar.tsx
+++ b/client/src/components/MusicCalendar.tsx
@@ -5,6 +5,7 @@ import { Calendar } from '@/components/ui/calendar';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Plus, Music, Mic2, Clock } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
+import { useReleases } from '@/hooks/useReleases';
 import { cn } from '@/lib/utils';
 import { getCompletedCities, getTourMetadata } from '@/utils/tourHelpers';
 import { getWeekDateRange, getWeekDates as getWeekDatesForYear, formatWeekEndDate } from '@shared/utils/seasonalCalculations';
@@ -42,7 +43,9 @@ export function MusicCalendar({
   minWeek = 1,
   weekPickerMode = false
 }: MusicCalendarProps) {
-  const { gameState, releases, projects, artists } = useGameStore();
+  const { gameState, projects, artists } = useGameStore();
+  // Phase 3 PR-6: releases read from the TanStack Query cache, not Zustand.
+  const { data: releases = [] } = useReleases();
 
   // Fast lookup of artist names by ID
   const artistNameById = useMemo(() => {

--- a/client/src/components/SaveGameModal.tsx
+++ b/client/src/components/SaveGameModal.tsx
@@ -14,12 +14,14 @@ import { useGameStore } from '@/store/gameStore';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGameContext } from '@/contexts/GameContext';
-import { apiRequest } from '@/lib/queryClient';
+import { apiRequest, queryClient } from '@/lib/queryClient';
 import type { GameSaveSnapshot } from '@shared/schema';
 import { gameSaveSnapshotSchema } from '@shared/schema';
 import { ZodError } from 'zod';
 import { fetchSnapshotCollections } from '@/utils/emailSnapshot';
 import { buildGameSnapshot } from '@/utils/buildGameSnapshot';
+import { songsQueryKey } from '@/hooks/useSongs';
+import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { useToast } from '@/hooks/use-toast';
 
 type SaveSummary = {
@@ -218,14 +220,18 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
         artists,
         projects,
         roles,
-        songs,
-        releases,
-        releaseSongs,
         executives,
         moodEvents,
         weeklyActions,
         weeklyOutcome
       } = useGameStore.getState();
+
+      // Phase 3 PR-6: songs / releases / releaseSongs are no longer store-owned.
+      // Source them from the TanStack Query cache so the export snapshot shape
+      // stays byte-identical to manual saves / autosaves.
+      const songs = queryClient.getQueryData<any[]>(songsQueryKey(gameState.id)) ?? [];
+      const releases = queryClient.getQueryData<any[]>(releasesQueryKey(gameState.id)) ?? [];
+      const releaseSongs = queryClient.getQueryData<any[]>(releaseSongsQueryKey(gameState.id)) ?? [];
 
       const snapshotCandidate = buildGameSnapshot({
         gameState,

--- a/client/src/components/SongCatalog.tsx
+++ b/client/src/components/SongCatalog.tsx
@@ -54,7 +54,6 @@ export function SongCatalog({ artistId, gameId, className = '' }: SongCatalogPro
   
   // Subscribe to gameState to detect week changes
   const currentWeek = useGameStore((state) => state.gameState?.currentWeek);
-  const storeSongs = useGameStore((state) => state.songs);
 
   useEffect(() => {
     if (artistId && gameId) {

--- a/client/src/hooks/useReleases.ts
+++ b/client/src/hooks/useReleases.ts
@@ -1,0 +1,65 @@
+/**
+ * Releases + Release-Songs query hooks (Phase 3 PR-6).
+ *
+ * `releases` and `releaseSongs` are server-canonical collections that used to be
+ * mirrored into the Zustand store by the loadGame/advanceWeek/loadGameFromSave
+ * fan-out. Phase 3 PR-6 moves ownership onto the TanStack Query cache: the
+ * fan-out seeds these keys via `queryClient.setQueryData` (zero extra requests)
+ * and mutations invalidate them.
+ *
+ * Key convention mirrors `useCharts`/`useEmails`: a scoped string at element 0
+ * and the gameId at element 1 (`[SCOPE, gameId]`). The scope constants and key
+ * builders are exported so `gameStore.ts` can seed/invalidate the exact same
+ * keys and the query-key contract test can assert they match.
+ */
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { apiRequest } from '@/lib/queryClient';
+
+export const RELEASES_SCOPE = 'releases:list';
+export const RELEASE_SONGS_SCOPE = 'release-songs:list';
+
+export function releasesQueryKey(gameId: string | null | undefined) {
+  return [RELEASES_SCOPE, gameId ?? null] as const;
+}
+
+export function releaseSongsQueryKey(gameId: string | null | undefined) {
+  return [RELEASE_SONGS_SCOPE, gameId ?? null] as const;
+}
+
+export function useReleases() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(() => releasesQueryKey(gameId), [gameId]);
+
+  return useQuery<any[]>({
+    queryKey,
+    enabled: Boolean(gameId),
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) return [];
+      const response = await apiRequest('GET', `/api/game/${gameId}/releases`);
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
+    },
+  });
+}
+
+export function useReleaseSongs() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(() => releaseSongsQueryKey(gameId), [gameId]);
+
+  return useQuery<any[]>({
+    queryKey,
+    enabled: Boolean(gameId),
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) return [];
+      const response = await apiRequest('GET', `/api/game/${gameId}/release-songs`);
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
+    },
+  });
+}

--- a/client/src/hooks/useSongs.ts
+++ b/client/src/hooks/useSongs.ts
@@ -1,0 +1,40 @@
+/**
+ * Songs query hook (Phase 3 PR-6).
+ *
+ * The full song catalog for the current game. Formerly mirrored into the Zustand
+ * store by the loadGame/advanceWeek/loadGameFromSave fan-out; Phase 3 PR-6 moves
+ * ownership onto the TanStack Query cache. The fan-out seeds this key via
+ * `queryClient.setQueryData` (zero extra requests) and mutations invalidate it.
+ *
+ * Key convention mirrors `useCharts`/`useEmails`: `[SCOPE, gameId]`. The scope
+ * constant and key builder are exported so `gameStore.ts` can seed/invalidate
+ * the exact same key and the query-key contract test can assert they match.
+ */
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { apiRequest } from '@/lib/queryClient';
+
+export const SONGS_SCOPE = 'songs:list';
+
+export function songsQueryKey(gameId: string | null | undefined) {
+  return [SONGS_SCOPE, gameId ?? null] as const;
+}
+
+export function useSongs() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(() => songsQueryKey(gameId), [gameId]);
+
+  return useQuery<any[]>({
+    queryKey,
+    enabled: Boolean(gameId),
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) return [];
+      const response = await apiRequest('GET', `/api/game/${gameId}/songs`);
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
+    },
+  });
+}

--- a/client/src/pages/ArtistPage.tsx
+++ b/client/src/pages/ArtistPage.tsx
@@ -18,6 +18,8 @@ import {
   Eye
 } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
+import { useReleases } from '@/hooks/useReleases';
+import { useSongs } from '@/hooks/useSongs';
 import { useLocation, useParams } from 'wouter';
 import { apiRequest } from '@/lib/queryClient';
 import { useArtistROI } from '@/hooks/useAnalytics';
@@ -33,7 +35,10 @@ export default function ArtistPage() {
   const params = useParams();
   const artistParam = params.artistParam; // Can be either ID or slug
   const [, setLocation] = useLocation();
-  const { gameState, artists, projects, releases } = useGameStore();
+  const { gameState, artists, projects } = useGameStore();
+  // Phase 3 PR-6: releases / songs read from the TanStack Query cache, not Zustand.
+  const { data: releases = [] } = useReleases();
+  const { data: storeSongs = [] } = useSongs();
 
   // Find the actual artist first to get ID for ROI
   const foundArtist = artists ? findArtistBySlugOrId(artists, artistParam || '') : null;
@@ -125,24 +130,22 @@ export default function ArtistPage() {
         if (data.songs) {
           setSongs(data.songs);
         } else {
-          // Fallback to store
-          const { songs: allSongs } = useGameStore.getState();
-          const artistSongs = allSongs?.filter(s => s.artistId === actualArtistId) || [];
+          // Fallback to the cached song list (Phase 3 PR-6: query cache, not store)
+          const artistSongs = storeSongs?.filter((s: any) => s.artistId === actualArtistId) || [];
           setSongs(artistSongs as Song[]);
         }
       } catch (error: any) {
         console.error('Failed to load songs:', error);
-        // Fallback to store on error
-        const { songs: allSongs } = useGameStore.getState();
-        const artistSongs = allSongs?.filter(s => s.artistId === actualArtistId) || [];
+        // Fallback to the cached song list on error
+        const artistSongs = storeSongs?.filter((s: any) => s.artistId === actualArtistId) || [];
         setSongs(artistSongs as Song[]);
       } finally {
         setLoadingSongs(false);
       }
     };
-    
+
     loadSongsData();
-  }, [actualArtistId, gameState?.id]);
+  }, [actualArtistId, gameState?.id, storeSongs]);
   
   const getArchetypeInfo = (archetype: string) => {
     const archetypeData: Record<string, any> = {

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -11,6 +11,8 @@ import { formatAutosaveName } from '@shared/utils/saveName';
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
 import { executivesQueryKey } from '@/hooks/useExecutives';
 import { CHART_TOP10_SCOPE, CHART_TOP100_SCOPE } from '@/hooks/useCharts';
+import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
+import { songsQueryKey } from '@/hooks/useSongs';
 
 // Internal helper: the shared 6-endpoint + email-snapshot parallel reload used
 // identically by loadGame / loadGameFromSave / advanceWeek. Fans out the same
@@ -55,7 +57,36 @@ async function fetchGameBundle(gameId: string): Promise<GameBundle> {
   const executives = await executivesResponse.json();
   const moodEvents = await moodEventsResponse.json();
 
+  // Phase 3 PR-6: songs / releases / releaseSongs are owned by the TanStack
+  // Query cache now, not Zustand. The fan-out already fetched them, so SEED the
+  // query cache here with the fresh bodies (`setQueryData`) instead of firing a
+  // second request from useSongs/useReleases/useReleaseSongs — zero extra GETs.
+  // Callers no longer write these three arrays into the store.
+  seedReleaseAndSongCache(gameId, { songs, releases, releaseSongs });
+
   return { gameData, songs, releases, releaseSongs, executives, moodEvents, emails };
+}
+
+// Phase 3 PR-6: seed the release/song query caches from an already-fetched
+// bundle so the hooks (useSongs/useReleases/useReleaseSongs) read fresh data
+// with no extra round-trip. Arrays are coerced to [] to match the hooks'
+// queryFn contract (they always resolve an array).
+function seedReleaseAndSongCache(
+  gameId: string,
+  data: { songs: unknown; releases: unknown; releaseSongs: unknown },
+) {
+  queryClient.setQueryData(
+    songsQueryKey(gameId),
+    Array.isArray(data.songs) ? data.songs : [],
+  );
+  queryClient.setQueryData(
+    releasesQueryKey(gameId),
+    Array.isArray(data.releases) ? data.releases : [],
+  );
+  queryClient.setQueryData(
+    releaseSongsQueryKey(gameId),
+    Array.isArray(data.releaseSongs) ? data.releaseSongs : [],
+  );
 }
 
 // Internal helper to sync focus slots and A&R operation status to the server
@@ -81,10 +112,11 @@ interface GameStore {
   projects: Project[];
   roles: Role[];
   weeklyActions: WeeklyAction[];
-  songs: any[];
-  releases: any[];
+  // Phase 3 PR-6: songs / releases / releaseSongs are no longer owned by the
+  // store — they live in the TanStack Query cache (hooks/useSongs.ts,
+  // hooks/useReleases.ts). Consumers read them via useSongs/useReleases/
+  // useReleaseSongs; the fan-out seeds the cache, mutations invalidate it.
   emails: any[]; // Email system support
-  releaseSongs: any[];
   executives: any[];
   moodEvents: any[];
 
@@ -152,10 +184,7 @@ export const useGameStore = create<GameStore>()(
       projects: [],
       roles: [],
       weeklyActions: [],
-      songs: [],
-      releases: [],
       emails: [],
-      releaseSongs: [],
       executives: [],
       moodEvents: [],
       discoveredArtists: [],
@@ -171,7 +200,6 @@ export const useGameStore = create<GameStore>()(
             gameData: data,
             songs,
             releases,
-            releaseSongs,
             executives,
             moodEvents,
             emails: emailList,
@@ -203,16 +231,15 @@ export const useGameStore = create<GameStore>()(
             musicLabel: data.musicLabel || null
           };
 
+          // Phase 3 PR-6: songs / releases / releaseSongs are seeded into the
+          // TanStack Query cache by fetchGameBundle — no longer written here.
           set({
             gameState: gameStateWithLabel,
             artists: data.artists,
             projects: data.projects,
             roles: data.roles,
             weeklyActions: data.weeklyActions,
-            songs,
-            releases,
             emails: emailList,
-            releaseSongs: Array.isArray(releaseSongs) ? releaseSongs : [],
             executives: Array.isArray(executives) ? executives : [],
             moodEvents: Array.isArray(moodEvents) ? moodEvents : [],
             selectedActions: []
@@ -261,15 +288,22 @@ export const useGameStore = create<GameStore>()(
             updatedAt: null,
           };
 
+          // Phase 3 PR-6: seed the release/song query cache from the snapshot so
+          // the restored data shows immediately, then drop those arrays from the
+          // store set(). The post-restore fetchGameBundle below re-seeds with the
+          // server's authoritative copy.
+          seedReleaseAndSongCache(baseGameState.id, {
+            songs: snapshot.songs || [],
+            releases: snapshot.releases || [],
+            releaseSongs: snapshot.releaseSongs || [],
+          });
+
           set({
             gameState: interimGameState,
             artists: (snapshot.artists || []) as unknown as Artist[],
             projects: (snapshot.projects || []) as unknown as Project[],
             roles: (snapshot.roles || []) as unknown as Role[],
-            songs: snapshot.songs || [],
-            releases: snapshot.releases || [],
             emails: snapshot.emails || [],
-            releaseSongs: snapshot.releaseSongs || [],
             executives: snapshot.executives || [],
             moodEvents: snapshot.moodEvents || [],
             weeklyActions: (snapshot.weeklyActions || []) as unknown as WeeklyAction[],
@@ -290,9 +324,6 @@ export const useGameStore = create<GameStore>()(
 
           const {
             gameData,
-            songs: songsData,
-            releases: releasesData,
-            releaseSongs: releaseSongsData,
             executives: executivesData,
             moodEvents: moodEventsData,
             emails: emailList,
@@ -305,16 +336,15 @@ export const useGameStore = create<GameStore>()(
             arOfficeSourcingType: gameData.gameState?.arOfficeSourcingType ?? null,
           };
 
+          // Phase 3 PR-6: songs / releases / releaseSongs seeded into the query
+          // cache by fetchGameBundle above — no longer written into the store.
           set({
             gameState: syncedGameState,
             artists: gameData.artists || [],
             projects: gameData.projects || [],
             roles: gameData.roles || [],
             weeklyActions: gameData.weeklyActions || [],
-            songs: songsData || [],
-            releases: releasesData || [],
             emails: emailList || [],
-            releaseSongs: Array.isArray(releaseSongsData) ? releaseSongsData : [],
             executives: Array.isArray(executivesData) ? executivesData : [],
             moodEvents: Array.isArray(moodEventsData) ? moodEventsData : [],
             selectedActions: [],
@@ -454,6 +484,10 @@ export const useGameStore = create<GameStore>()(
             musicLabel: completeGameData.musicLabel || null
           };
 
+          // Phase 3 PR-6: seed the new game's release/song caches empty so the
+          // hooks read [] rather than any stale prior-game data.
+          seedReleaseAndSongCache(gameState.id, { songs: [], releases: [], releaseSongs: [] });
+
           // Clear campaign results and set new state
           set({
             gameState: syncedGameState,
@@ -461,10 +495,7 @@ export const useGameStore = create<GameStore>()(
             projects: [],
             roles: [],
             weeklyActions: [],
-            songs: [],
-            releases: [],
             emails: [],
-            releaseSongs: [],
             executives: [],
             moodEvents: [],
             selectedActions: [],
@@ -697,7 +728,6 @@ export const useGameStore = create<GameStore>()(
             gameData,
             songs,
             releases,
-            releaseSongs: releaseSongsData,
             executives: executivesData,
             moodEvents: moodEventsData,
             emails: emailList,
@@ -723,14 +753,13 @@ export const useGameStore = create<GameStore>()(
             musicLabel: gameData.musicLabel || (resultGameState as any)?.musicLabel || null,
           } as GameState;
 
+          // Phase 3 PR-6: songs / releases / releaseSongs seeded into the query
+          // cache by fetchGameBundle — no longer written into the store.
           set({
             gameState: syncedGameState,
             artists: gameData.artists || [], // Update artists to reflect mood changes
             projects: gameData.projects || [], // Update projects with current state
-            songs: songs || [], // Update songs to include newly recorded ones
-            releases: releases || [], // FIXED: Use explicit releases fetch for accurate status
             emails: emailList || [],
-            releaseSongs: Array.isArray(releaseSongsData) ? releaseSongsData : [],
             executives: Array.isArray(executivesData) ? executivesData : [],
             moodEvents: Array.isArray(moodEventsData) ? moodEventsData : [],
             weeklyOutcome: result.summary,
@@ -1035,9 +1064,16 @@ export const useGameStore = create<GameStore>()(
           };
           
           set({ gameState: updatedGameState });
-          
+
+          // Phase 3 PR-6: releases/releaseSongs/songs now live in the query cache
+          // (formerly the store fan-out re-fetched them). Invalidate so the newly
+          // planned release shows up without a full reload.
+          await queryClient.invalidateQueries({ queryKey: releasesQueryKey(gameState.id) });
+          await queryClient.invalidateQueries({ queryKey: releaseSongsQueryKey(gameState.id) });
+          await queryClient.invalidateQueries({ queryKey: songsQueryKey(gameState.id) });
+
           console.log(`[FRONTEND] Synced release planning: -$${totalMarketingCost}, -1 creative capital, new balances: $${updatedGameState.money}, ${updatedGameState.creativeCapital} creative capital`);
-          
+
           return result;
         } catch (error) {
           console.error('Failed to plan release:', error);
@@ -1216,15 +1252,21 @@ export const useGameStore = create<GameStore>()(
           artists,
           projects,
           roles,
-          songs,
-          releases,
-          releaseSongs,
           executives,
           moodEvents,
           weeklyActions,
           weeklyOutcome
         } = get();
         if (!gameState) return;
+
+        // Phase 3 PR-6: songs / releases / releaseSongs are no longer store-owned.
+        // Source them from the TanStack Query cache (seeded by the fan-out) so the
+        // snapshot shape is byte-identical to before. Autosave runs right after
+        // advanceWeek's fan-out, so the cache is freshly populated here.
+        const songs = queryClient.getQueryData<any[]>(songsQueryKey(gameState.id)) ?? [];
+        const releases = queryClient.getQueryData<any[]>(releasesQueryKey(gameState.id)) ?? [];
+        const releaseSongs =
+          queryClient.getQueryData<any[]>(releaseSongsQueryKey(gameState.id)) ?? [];
 
         try {
           const { emailSnapshot, releaseSongs: releaseSongsSnapshot, executives: executivesSnapshot, moodEvents: moodEventsSnapshot } =

--- a/tests/client/gameStore-actions.characterization.test.ts
+++ b/tests/client/gameStore-actions.characterization.test.ts
@@ -13,13 +13,26 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock the network + cache layer BEFORE the store import (vitest hoists these).
+// Phase 3 PR-6: the store now seeds songs/releases/releaseSongs into the query
+// cache via setQueryData and reads them back via getQueryData, so the mocked
+// queryClient must expose a working in-memory cache for those methods.
+const queryCache = new Map<string, unknown>();
 vi.mock('@/lib/queryClient', () => ({
   apiRequest: vi.fn(),
-  queryClient: { invalidateQueries: vi.fn().mockResolvedValue(undefined) },
+  queryClient: {
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    setQueryData: vi.fn((key: unknown, value: unknown) => {
+      queryCache.set(JSON.stringify(key), value);
+      return value;
+    }),
+    getQueryData: vi.fn((key: unknown) => queryCache.get(JSON.stringify(key))),
+  },
 }));
 vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
 
-import { apiRequest } from '@/lib/queryClient';
+import { apiRequest, queryClient } from '@/lib/queryClient';
+import { songsQueryKey } from '@/hooks/useSongs';
+import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { useGameStore } from '@/store/gameStore';
 import {
   routeApiRequest as routeApiRequestImpl,
@@ -35,6 +48,7 @@ const resetGameStore = () => resetGameStoreImpl(useGameStore);
 
 beforeEach(() => {
   mockedApiRequest.mockReset();
+  queryCache.clear();
   resetGameStore();
 });
 
@@ -163,6 +177,11 @@ describe('cancelProject adopts server balance', () => {
 });
 
 describe('loadGame set(...) state shape', () => {
+  // Phase 3 PR-6 CHANGE: loadGame no longer writes songs / releases /
+  // releaseSongs into the store. It seeds those into the TanStack Query cache
+  // (via queryClient.setQueryData) so the useSongs/useReleases/useReleaseSongs
+  // hooks own them. The pins below assert the cache is seeded from the same
+  // fan-out bodies, and that the store set() no longer carries these arrays.
   it('writes exactly the collections loadGame owns and resets selectedActions', async () => {
     mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
       if (url.endsWith('/songs')) return jsonResponse([{ id: 's1' }]);
@@ -194,13 +213,20 @@ describe('loadGame set(...) state shape', () => {
     expect(state.projects).toEqual([{ id: 'p1' }]);
     expect(state.roles).toEqual([{ id: 'role1' }]);
     expect(state.weeklyActions).toEqual([{ id: 'wa1' }]);
-    expect(state.songs).toEqual([{ id: 's1' }]);
-    expect(state.releases).toEqual([{ id: 'r1' }]);
     expect(state.emails).toEqual([{ id: 'em1' }]);
-    expect(state.releaseSongs).toEqual([{ id: 'rs1' }]);
     expect(state.executives).toEqual([{ id: 'e1' }]);
     expect(state.moodEvents).toEqual([{ id: 'm1' }]);
     expect(state.selectedActions).toEqual([]);
+
+    // PR-6: songs / releases / releaseSongs are seeded into the query cache, NOT
+    // the store. Assert the cache holds the fan-out bodies keyed by gameId.
+    expect(queryClient.getQueryData(songsQueryKey('game-1'))).toEqual([{ id: 's1' }]);
+    expect(queryClient.getQueryData(releasesQueryKey('game-1'))).toEqual([{ id: 'r1' }]);
+    expect(queryClient.getQueryData(releaseSongsQueryKey('game-1'))).toEqual([{ id: 'rs1' }]);
+    // And the store no longer exposes them.
+    expect((state as any).songs).toBeUndefined();
+    expect((state as any).releases).toBeUndefined();
+    expect((state as any).releaseSongs).toBeUndefined();
   });
 });
 
@@ -242,15 +268,21 @@ describe('advanceWeek set(...) state shape', () => {
     expect((state.gameState as any).currentWeek).toBe(6);
     expect(state.artists).toEqual([{ id: 'a1' }]);
     expect(state.projects).toEqual([{ id: 'p1' }]);
-    expect(state.songs).toEqual([{ id: 's1' }]);
-    expect(state.releases).toEqual([{ id: 'r1' }]);
     expect(state.emails).toEqual([{ id: 'em1' }]);
-    expect(state.releaseSongs).toEqual([{ id: 'rs1' }]);
     expect(state.executives).toEqual([{ id: 'e1' }]);
     expect(state.moodEvents).toEqual([{ id: 'm1' }]);
     expect(state.weeklyOutcome).toEqual({ week: 6 });
     expect(state.campaignResults).toBeNull();
     expect(state.selectedActions).toEqual([]);
     expect(state.isAdvancingWeek).toBe(false);
+
+    // PR-6: advanceWeek seeds songs / releases / releaseSongs into the query
+    // cache (via fetchGameBundle) instead of the store. Assert the seeded cache.
+    expect(queryClient.getQueryData(songsQueryKey('game-1'))).toEqual([{ id: 's1' }]);
+    expect(queryClient.getQueryData(releasesQueryKey('game-1'))).toEqual([{ id: 'r1' }]);
+    expect(queryClient.getQueryData(releaseSongsQueryKey('game-1'))).toEqual([{ id: 'rs1' }]);
+    expect((state as any).songs).toBeUndefined();
+    expect((state as any).releases).toBeUndefined();
+    expect((state as any).releaseSongs).toBeUndefined();
   });
 });

--- a/tests/client/gameStore-email-invalidation.characterization.test.ts
+++ b/tests/client/gameStore-email-invalidation.characterization.test.ts
@@ -16,9 +16,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock the network + cache layer BEFORE the store import (vitest hoists these).
+// Phase 3 PR-6: the store seeds songs/releases/releaseSongs into the query cache
+// via setQueryData, so the mocked queryClient must expose it (a no-op is fine
+// here — these tests only assert email invalidation).
 vi.mock('@/lib/queryClient', () => ({
   apiRequest: vi.fn(),
-  queryClient: { invalidateQueries: vi.fn().mockResolvedValue(undefined) },
+  queryClient: {
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    setQueryData: vi.fn(),
+    getQueryData: vi.fn(),
+  },
 }));
 vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
 

--- a/tests/client/gameStore-harness.ts
+++ b/tests/client/gameStore-harness.ts
@@ -47,10 +47,9 @@ export function resetGameStore(useGameStore: Store) {
     projects: [],
     roles: [],
     weeklyActions: [],
-    songs: [],
-    releases: [],
+    // Phase 3 PR-6: songs / releases / releaseSongs are no longer store-owned
+    // (they live in the TanStack Query cache), so they are not reset here.
     emails: [],
-    releaseSongs: [],
     executives: [],
     moodEvents: [],
     discoveredArtists: [],

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -23,6 +23,13 @@ import { describe, it, expect } from 'vitest';
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
 import { EXECUTIVES_SCOPE, executivesQueryKey } from '@/hooks/useExecutives';
 import { CHART_TOP10_SCOPE, CHART_TOP100_SCOPE } from '@/hooks/useCharts';
+import {
+  RELEASES_SCOPE,
+  RELEASE_SONGS_SCOPE,
+  releasesQueryKey,
+  releaseSongsQueryKey,
+} from '@/hooks/useReleases';
+import { SONGS_SCOPE, songsQueryKey } from '@/hooks/useSongs';
 
 const GAME_ID = 'game-1';
 const ARTIST_ID = 'artist-1';
@@ -47,6 +54,10 @@ const REAL_QUERY_KEYS: readonly unknown[][] = [
   [...executivesQueryKey(GAME_ID)],
   [CHART_TOP10_SCOPE, GAME_ID],
   [CHART_TOP100_SCOPE, GAME_ID],
+  // Releases / songs (useReleases.ts, useSongs.ts, PR-6): [SCOPE, gameId]
+  [...releasesQueryKey(GAME_ID)],
+  [...releaseSongsQueryKey(GAME_ID)],
+  [...songsQueryKey(GAME_ID)],
   ['api', 'saves'],
 ];
 
@@ -97,6 +108,35 @@ describe('query-key contract: advanceWeek chart invalidations (PR-5)', () => {
 
   it('advanceWeek chart predicate does NOT match a different game\'s chart keys', () => {
     expect(someRealKeyMatchesPredicate(chartPredicate('some-other-game'))).toBe(false);
+  });
+});
+
+describe('query-key contract: planRelease invalidations (PR-6)', () => {
+  // planRelease invalidates the release/song caches with EXACT scoped keys
+  // (client/src/store/gameStore.ts): releasesQueryKey / releaseSongsQueryKey /
+  // songsQueryKey, each == [SCOPE, gameId]. Assert each matches its hook key.
+  it('planRelease releases invalidation matches the useReleases hook key', () => {
+    expect(someRealKeyMatchesInvalidationKey(releasesQueryKey(GAME_ID))).toBe(true);
+  });
+
+  it('planRelease release-songs invalidation matches the useReleaseSongs hook key', () => {
+    expect(someRealKeyMatchesInvalidationKey(releaseSongsQueryKey(GAME_ID))).toBe(true);
+  });
+
+  it('planRelease songs invalidation matches the useSongs hook key', () => {
+    expect(someRealKeyMatchesInvalidationKey(songsQueryKey(GAME_ID))).toBe(true);
+  });
+
+  it('none of the release/song invalidations match a different game', () => {
+    expect(someRealKeyMatchesInvalidationKey(releasesQueryKey('other'))).toBe(false);
+    expect(someRealKeyMatchesInvalidationKey(releaseSongsQueryKey('other'))).toBe(false);
+    expect(someRealKeyMatchesInvalidationKey(songsQueryKey('other'))).toBe(false);
+  });
+
+  it('release/song scope constants and hook keys agree element-for-element', () => {
+    expect(releasesQueryKey(GAME_ID)).toEqual([RELEASES_SCOPE, GAME_ID]);
+    expect(releaseSongsQueryKey(GAME_ID)).toEqual([RELEASE_SONGS_SCOPE, GAME_ID]);
+    expect(songsQueryKey(GAME_ID)).toEqual([SONGS_SCOPE, GAME_ID]);
   });
 });
 

--- a/tests/client/useReleases.test.tsx
+++ b/tests/client/useReleases.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * useReleases / useReleaseSongs hook test (Phase 3 PR-6).
+ *
+ * Mocks `apiRequest` and `useGameStore` to verify the releases + release-songs
+ * hooks fetch the right endpoint, key their queries by the scoped
+ * [SCOPE, gameId] shape, and skip fetching when there's no active game.
+ * Mirrors tests/client/useCharts.test.tsx.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/queryClient', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/queryClient')>('@/lib/queryClient');
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: vi.fn(),
+}));
+
+import { apiRequest } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import {
+  useReleases,
+  useReleaseSongs,
+  RELEASES_SCOPE,
+  RELEASE_SONGS_SCOPE,
+} from '@/hooks/useReleases';
+
+const mockedApiRequest = vi.mocked(apiRequest);
+const mockedUseGameStore = vi.mocked(useGameStore);
+
+function jsonResponse(body: unknown): Response {
+  return { json: async () => body } as unknown as Response;
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return queryClient;
+}
+
+function TestReleases() {
+  const { data, isLoading } = useReleases();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="releases">{JSON.stringify(data)}</div>;
+}
+
+function TestReleaseSongs() {
+  const { data, isLoading } = useReleaseSongs();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="release-songs">{JSON.stringify(data)}</div>;
+}
+
+describe('useReleases / useReleaseSongs', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+    mockedUseGameStore.mockReset();
+  });
+
+  it('useReleases fetches the game-scoped releases endpoint', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(jsonResponse([{ id: 'r1' }]));
+
+    renderWithClient(<TestReleases />);
+
+    await waitFor(() => expect(screen.getByTestId('releases')).toBeTruthy());
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1/releases');
+  });
+
+  it('useReleaseSongs fetches the game-scoped release-songs endpoint', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(jsonResponse([{ id: 'rs1' }]));
+
+    renderWithClient(<TestReleaseSongs />);
+
+    await waitFor(() => expect(screen.getByTestId('release-songs')).toBeTruthy());
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1/release-songs');
+  });
+
+  it('coerces a non-array response to []', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(jsonResponse(null));
+
+    renderWithClient(<TestReleases />);
+
+    await waitFor(() => expect(screen.getByTestId('releases').textContent).toBe('[]'));
+  });
+
+  it('does not fetch when there is no active game', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: null }));
+
+    renderWithClient(<TestReleases />);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('scope constants match the keys used in gameStore invalidation', () => {
+    expect(RELEASES_SCOPE).toBe('releases:list');
+    expect(RELEASE_SONGS_SCOPE).toBe('release-songs:list');
+  });
+});

--- a/tests/client/useSongs.test.tsx
+++ b/tests/client/useSongs.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * useSongs hook test (Phase 3 PR-6).
+ *
+ * Mocks `apiRequest` and `useGameStore` to verify the songs hook fetches the
+ * right endpoint, keys its query by the scoped [SCOPE, gameId] shape, coerces
+ * non-array bodies to [], and skips fetching when there's no active game.
+ * Mirrors tests/client/useCharts.test.tsx.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/queryClient', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/queryClient')>('@/lib/queryClient');
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: vi.fn(),
+}));
+
+import { apiRequest } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import { useSongs, SONGS_SCOPE } from '@/hooks/useSongs';
+
+const mockedApiRequest = vi.mocked(apiRequest);
+const mockedUseGameStore = vi.mocked(useGameStore);
+
+function jsonResponse(body: unknown): Response {
+  return { json: async () => body } as unknown as Response;
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return queryClient;
+}
+
+function TestSongs() {
+  const { data, isLoading } = useSongs();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="songs">{JSON.stringify(data)}</div>;
+}
+
+describe('useSongs', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+    mockedUseGameStore.mockReset();
+  });
+
+  it('fetches the game-scoped songs endpoint', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(jsonResponse([{ id: 's1' }]));
+
+    renderWithClient(<TestSongs />);
+
+    await waitFor(() => expect(screen.getByTestId('songs')).toBeTruthy());
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1/songs');
+  });
+
+  it('coerces a non-array response to []', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(jsonResponse({ not: 'an array' }));
+
+    renderWithClient(<TestSongs />);
+
+    await waitFor(() => expect(screen.getByTestId('songs').textContent).toBe('[]'));
+  });
+
+  it('does not fetch when there is no active game', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: null }));
+
+    renderWithClient(<TestSongs />);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('scope constant matches the key used in gameStore invalidation', () => {
+    expect(SONGS_SCOPE).toBe('songs:list');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 PR-6 of the client-state-ownership arc (see `docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md`, PR table row 6). Moves the **releases**, **releaseSongs**, and **songs** domains out of Zustand ownership and into TanStack Query hooks, following the established scoped-key pattern (`useCharts`/`useExecutives`/`useEmails`). Behavior-preserving — rendering stays identical; the store just narrows.

## Hooks (new)

- `client/src/hooks/useReleases.ts` — `useReleases` (`releases:list`), `useReleaseSongs` (`release-songs:list`); covers `GET /api/game/:id/releases` and `/release-songs`. Exports `RELEASES_SCOPE`, `RELEASE_SONGS_SCOPE`, `releasesQueryKey`, `releaseSongsQueryKey`.
- `client/src/hooks/useSongs.ts` — `useSongs` (`songs:list`); covers `GET /api/game/:id/songs`. Exports `SONGS_SCOPE`, `songsQueryKey`.

**Scope keys chosen** (consistent with the `emails:list` / `charts:top10` convention): `releases:list`, `release-songs:list`, `songs:list`, each keyed `[SCOPE, gameId]`.

## Consumers migrated

- **ActiveReleases** — `releases` + `songs` now from `useReleases()`/`useSongs()`.
- **MusicCalendar** — `releases` from `useReleases()`.
- **ArtistPage** — `releases` from `useReleases()`; the two `useGameStore.getState().songs` fallbacks in the songs loader now read the cached list from `useSongs()`.
- **SaveGameModal.handleExport** — sources `songs`/`releases`/`releaseSongs` from the query cache (`getQueryData`) instead of the store.
- **SongCatalog** — removed a dead `storeSongs = useGameStore(s => s.songs)` read (never used; `currentWeek` already triggers its refetch effect).

## Step-3 choice — cache seed vs refetch

**Seed, not refetch.** `fetchGameBundle` (the shared fan-out used by `loadGame`/`loadGameFromSave`/`advanceWeek`) already GETs `/songs`, `/releases`, `/release-songs`. It now calls `seedReleaseAndSongCache(gameId, …)` which `queryClient.setQueryData`s those bodies into the three scoped keys — **zero extra requests**. The fan-out callers stop writing these arrays into Zustand. `createNewGame` seeds the new game's keys empty. `planRelease` switches from store-refetch reliance to **invalidating** `releasesQueryKey`/`releaseSongsQueryKey`/`songsQueryKey`.

## Step-4 choice — snapshot sourcing

`buildGameSnapshot` shape is preserved (PR-1's shape test still pins it). `saveGame` and `SaveGameModal.handleExport` previously read `songs`/`releases` from the store arrays; they now source them from the query cache via `queryClient.getQueryData(...QueryKey(gameId))` (`?? []`). Autosave runs immediately after `advanceWeek`'s fan-out, so the cache is freshly seeded at save time — no drift, no extra fetch. (`releaseSongs` was already re-fetched by `fetchSnapshotCollections`; its dead store fallback is now cache-sourced too.)

## Characterization-pin changes (deliberate, sanctioned ownership change)

`tests/client/gameStore-actions.characterization.test.ts`:
- **loadGame set-shape pin**: removed `state.songs/releases/releaseSongs` assertions (store no longer owns them); added assertions that the **query cache** holds the fan-out bodies (`getQueryData(songsQueryKey('game-1'))` etc.) and that `state.songs/releases/releaseSongs` are now `undefined`.
- **advanceWeek set-shape pin**: same substitution — cache-seed assertions replace the three store-array assertions; other pins (artists, projects, emails, executives, moodEvents, weeklyOutcome, flags) unchanged.
- Mock queryClient gained an in-memory `setQueryData`/`getQueryData` (backed by a Map, cleared each `beforeEach`) so the seed path works under mock.

`tests/client/gameStore-harness.ts`: `resetGameStore` no longer resets the three removed arrays.

`tests/client/gameStore-email-invalidation.characterization.test.ts`: mock queryClient gained no-op `setQueryData`/`getQueryData` (the fan-out now calls `setQueryData`); email-invalidation assertions unchanged.

`tests/client/query-key-contract.test.ts`: added the three new scopes to `REAL_QUERY_KEYS` and a new `planRelease invalidations (PR-6)` block asserting each `planRelease` invalidation matches its hook key element-for-element (and does not match a different game).

## New hook tests

`tests/client/useReleases.test.tsx`, `tests/client/useSongs.test.tsx` — mirror `useCharts.test.tsx`: correct endpoint, scoped key, non-array→`[]` coercion, disabled when no active game, scope-constant assertions.

## Validation

- `npm run check` — clean.
- `npx vitest run tests/client/` — 47 passed (7 files).
- Artist tab component tests (`client/src/components/artist/__tests__/`) — 12 passed.
- Full suite intentionally not run, per plan.

## Notes

- Single commit (component diff is 5 source files + store + 2 hooks, under the ~8-file split threshold).
- No docs touched; no `server/` changes; no `SNAPSHOT_VERSION` bump. XState machines untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
