### PR TITLE
feat(client): Phase 3 PR-7 — useProjects hook; store stops owning projects

### DIFF
--- a/client/src/components/ActiveTours.tsx
+++ b/client/src/components/ActiveTours.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useGameStore } from '@/store/gameStore';
+import { useProjects } from '@/hooks/useProjects';
 import { useLocation } from 'wouter';
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, DollarSign, Users, Calculator } from 'lucide-react';
@@ -260,7 +261,9 @@ function CompletedToursTable({ completedTours, getArtistName }: { completedTours
 }
 
 export function ActiveTours() {
-  const { projects, artists, cancelProject, gameState } = useGameStore();
+  const { artists, cancelProject, gameState } = useGameStore();
+  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { data: projects = [] } = useProjects();
   const [, setLocation] = useLocation();
   const [activeTab, setActiveTab] = useState<'active' | 'completed'>('active');
   const [showCancelModal, setShowCancelModal] = useState(false);

--- a/client/src/components/ArtistCard.tsx
+++ b/client/src/components/ArtistCard.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { TrendingUp, TrendingDown, Heart, Info, ExternalLink } from 'lucide-react';
 import { SongCatalog } from './SongCatalog';
 import { useArtistROI } from '@/hooks/useAnalytics';
-import { useGameStore } from '@/store/gameStore';
+import { useProjects } from '@/hooks/useProjects';
 
 export interface ArtistCardProps {
   artist: any;
@@ -30,7 +30,8 @@ export function ArtistCard({
   gameState,
   roiData: passedRoiData
 }: ArtistCardProps) {
-  const { projects } = useGameStore();
+  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { data: projects = [] } = useProjects();
 
   // Fetch ROI from backend only if not provided as prop (backward compatibility)
   const { data: fetchedRoiData } = useArtistROI(passedRoiData ? null : artist.id);

--- a/client/src/components/ArtistRoster.tsx
+++ b/client/src/components/ArtistRoster.tsx
@@ -10,6 +10,7 @@ import {
   MenubarTrigger,
 } from '@/components/ui/menubar';
 import { useGameStore } from '@/store/gameStore';
+import { useProjects } from '@/hooks/useProjects';
 import { ArtistDiscoveryModal } from './ArtistDiscoveryModal';
 import { ArtistDashboardCard } from './ArtistDashboardCard';
 import { ArtistDialogueModal } from './artist-dialogue/ArtistDialogueModal';
@@ -45,7 +46,9 @@ const toGameArtist = (artist: DbArtist | (DbArtist & { loyalty?: number | null }
 };
 
 export function ArtistRoster() {
-  const { gameState, artists, signArtist, projects, loadGame } = useGameStore();
+  const { gameState, artists, signArtist, loadGame } = useGameStore();
+  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { data: projects = [] } = useProjects();
   const [showDiscoveryModal, setShowDiscoveryModal] = useState(false);
   const [isDialogueModalOpen, setIsDialogueModalOpen] = useState(false);
   const [selectedArtistForDialogue, setSelectedArtistForDialogue] = useState<DbArtist | null>(null);

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -23,7 +23,7 @@ export function Dashboard({
   showSaveModal = false,
   setShowSaveModal = () => {}
 }: DashboardProps) {
-  const { gameState, isAdvancingWeek, advanceWeek, weeklyOutcome, artists, projects, createProject } = useGameStore();
+  const { gameState, isAdvancingWeek, advanceWeek, weeklyOutcome, artists, createProject } = useGameStore();
   const [, setLocation] = useLocation();
   const [showWeekSummary, setShowWeekSummary] = useState(false);
   const [lastProcessedWeek, setLastProcessedWeek] = useState<number | null>(null);

--- a/client/src/components/MusicCalendar.tsx
+++ b/client/src/components/MusicCalendar.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Plus, Music, Mic2, Clock } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
 import { useReleases } from '@/hooks/useReleases';
+import { useProjects } from '@/hooks/useProjects';
 import { cn } from '@/lib/utils';
 import { getCompletedCities, getTourMetadata } from '@/utils/tourHelpers';
 import { getWeekDateRange, getWeekDates as getWeekDatesForYear, formatWeekEndDate } from '@shared/utils/seasonalCalculations';
@@ -43,9 +44,11 @@ export function MusicCalendar({
   minWeek = 1,
   weekPickerMode = false
 }: MusicCalendarProps) {
-  const { gameState, projects, artists } = useGameStore();
-  // Phase 3 PR-6: releases read from the TanStack Query cache, not Zustand.
+  const { gameState, artists } = useGameStore();
+  // Phase 3 PR-6/PR-7: releases / projects read from the TanStack Query cache,
+  // not Zustand.
   const { data: releases = [] } = useReleases();
+  const { data: projects = [] } = useProjects();
 
   // Fast lookup of artist names by ID
   const artistNameById = useMemo(() => {

--- a/client/src/components/SaveGameModal.tsx
+++ b/client/src/components/SaveGameModal.tsx
@@ -22,6 +22,7 @@ import { fetchSnapshotCollections } from '@/utils/emailSnapshot';
 import { buildGameSnapshot } from '@/utils/buildGameSnapshot';
 import { songsQueryKey } from '@/hooks/useSongs';
 import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
+import { projectsQueryKey } from '@/hooks/useProjects';
 import { useToast } from '@/hooks/use-toast';
 
 type SaveSummary = {
@@ -218,7 +219,6 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
       // manual saves / autosaves and validates against gameSaveSnapshotSchema.
       const {
         artists,
-        projects,
         roles,
         executives,
         moodEvents,
@@ -226,12 +226,13 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
         weeklyOutcome
       } = useGameStore.getState();
 
-      // Phase 3 PR-6: songs / releases / releaseSongs are no longer store-owned.
-      // Source them from the TanStack Query cache so the export snapshot shape
-      // stays byte-identical to manual saves / autosaves.
+      // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are no
+      // longer store-owned. Source them from the TanStack Query cache so the
+      // export snapshot shape stays byte-identical to manual saves / autosaves.
       const songs = queryClient.getQueryData<any[]>(songsQueryKey(gameState.id)) ?? [];
       const releases = queryClient.getQueryData<any[]>(releasesQueryKey(gameState.id)) ?? [];
       const releaseSongs = queryClient.getQueryData<any[]>(releaseSongsQueryKey(gameState.id)) ?? [];
+      const projects = queryClient.getQueryData<any[]>(projectsQueryKey(gameState.id)) ?? [];
 
       const snapshotCandidate = buildGameSnapshot({
         gameState,

--- a/client/src/components/ToastNotification.tsx
+++ b/client/src/components/ToastNotification.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 
 export function ToastNotification() {
   const { toast, dismiss } = useToast();
-  const { gameState, weeklyOutcome, projects } = useGameStore();
+  const { gameState, weeklyOutcome } = useGameStore();
   const prevGameState = useRef(gameState);
   const prevWeeklyOutcome = useRef(weeklyOutcome);
   const [recentToasts, setRecentToasts] = useState<Set<string>>(new Set());

--- a/client/src/components/__tests__/ArtistRoster.test.tsx
+++ b/client/src/components/__tests__/ArtistRoster.test.tsx
@@ -13,6 +13,12 @@ vi.mock('@/store/gameStore', () => ({
   useGameStore: mockUseGameStore,
 }));
 
+// Phase 3 PR-7: ArtistRoster now reads projects via useProjects (TanStack).
+// Mock it so this component test stays store-only and needs no QueryClient.
+vi.mock('@/hooks/useProjects', () => ({
+  useProjects: () => ({ data: [] }),
+}));
+
 vi.mock('wouter', () => ({
   useLocation: () => [null, setLocationMock],
 }));

--- a/client/src/hooks/useProjects.ts
+++ b/client/src/hooks/useProjects.ts
@@ -1,0 +1,51 @@
+/**
+ * Projects query hook (Phase 3 PR-7).
+ *
+ * The full project list for the current game. Formerly mirrored into the Zustand
+ * store by the loadGame/advanceWeek/loadGameFromSave fan-out; Phase 3 PR-7 moves
+ * ownership onto the TanStack Query cache. The fan-out seeds this key via
+ * `queryClient.setQueryData` (zero extra requests) and mutations invalidate it.
+ *
+ * Endpoint note: unlike releases/songs (PR-6), there is NO dedicated
+ * `GET /api/game/:id/projects` route on the server, and Phase 3 is client-only
+ * (no server changes). Projects arrive inside the `/api/game/:id` payload as
+ * `data.projects` — the exact same source the store read before. So the queryFn
+ * fetches `/api/game/:id` and selects `.projects`. In practice the fan-out
+ * pre-seeds the cache from the same body, so this queryFn only fires when a
+ * mutation invalidates the key (createProject/updateProject/cancelProject),
+ * faithfully re-reading the server's authoritative project list.
+ *
+ * Key convention mirrors `useSongs`/`useReleases`: `[SCOPE, gameId]`. The scope
+ * constant and key builder are exported so `gameStore.ts` can seed/invalidate
+ * the exact same key and the query-key contract test can assert they match.
+ */
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { apiRequest } from '@/lib/queryClient';
+
+export const PROJECTS_SCOPE = 'projects:list';
+
+export function projectsQueryKey(gameId: string | null | undefined) {
+  return [PROJECTS_SCOPE, gameId ?? null] as const;
+}
+
+export function useProjects() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(() => projectsQueryKey(gameId), [gameId]);
+
+  return useQuery<any[]>({
+    queryKey,
+    enabled: Boolean(gameId),
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) return [];
+      // No dedicated projects endpoint (client-only PR): read the projects
+      // collection off the base game payload, matching the store's old source.
+      const response = await apiRequest('GET', `/api/game/${gameId}`);
+      const data = await response.json();
+      return Array.isArray(data?.projects) ? data.projects : [];
+    },
+  });
+}

--- a/client/src/pages/ArtistPage.tsx
+++ b/client/src/pages/ArtistPage.tsx
@@ -20,6 +20,7 @@ import {
 import { useGameStore } from '@/store/gameStore';
 import { useReleases } from '@/hooks/useReleases';
 import { useSongs } from '@/hooks/useSongs';
+import { useProjects } from '@/hooks/useProjects';
 import { useLocation, useParams } from 'wouter';
 import { apiRequest } from '@/lib/queryClient';
 import { useArtistROI } from '@/hooks/useAnalytics';
@@ -35,10 +36,12 @@ export default function ArtistPage() {
   const params = useParams();
   const artistParam = params.artistParam; // Can be either ID or slug
   const [, setLocation] = useLocation();
-  const { gameState, artists, projects } = useGameStore();
-  // Phase 3 PR-6: releases / songs read from the TanStack Query cache, not Zustand.
+  const { gameState, artists } = useGameStore();
+  // Phase 3 PR-6/PR-7: releases / songs / projects read from the TanStack Query
+  // cache, not Zustand.
   const { data: releases = [] } = useReleases();
   const { data: storeSongs = [] } = useSongs();
+  const { data: projects = [] } = useProjects();
 
   // Find the actual artist first to get ID for ROI
   const foundArtist = artists ? findArtistBySlugOrId(artists, artistParam || '') : null;

--- a/client/src/pages/ArtistsLandingPage.tsx
+++ b/client/src/pages/ArtistsLandingPage.tsx
@@ -8,6 +8,7 @@ import { ArtistDiscoveryModal } from '../components/ArtistDiscoveryModal';
 import { ArtistDialogueModal } from '../components/artist-dialogue/ArtistDialogueModal';
 import { ArtistCard as RichArtistCard, getArchetypeInfo, getRelationshipStatus } from '../components/ArtistCard';
 import { useGameStore } from '../store/gameStore';
+import { useProjects } from '../hooks/useProjects';
 import { usePortfolioROI, useArtistROI } from '../hooks/useAnalytics';
 import { generateArtistSlug } from '../utils/artistSlug';
 import { Card, CardContent } from '../components/ui/card';
@@ -49,7 +50,9 @@ const ArtistsLandingPage: React.FC = () => {
   const [expandedArtist, setExpandedArtist] = useState<string | null>(null);
   const [isDialogueModalOpen, setIsDialogueModalOpen] = useState(false);
   const [selectedArtistForDialogue, setSelectedArtistForDialogue] = useState<Artist | null>(null);
-  const { gameState, artists, signArtist, projects, loadGame } = useGameStore();
+  const { gameState, artists, signArtist, loadGame } = useGameStore();
+  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { data: projects = [] } = useProjects();
   const { data: portfolioROI, isLoading: portfolioLoading, error: portfolioError } = usePortfolioROI();
 
   const signedArtists = artists || [];

--- a/client/src/pages/LivePerformancePage.tsx
+++ b/client/src/pages/LivePerformancePage.tsx
@@ -11,6 +11,7 @@ import { MapPin, Music, Calendar, Users, DollarSign, AlertCircle, Info, Target, 
 import type { GameState } from '@shared/schema';
 import { apiRequest } from '@/lib/queryClient';
 import { useGameStore } from '@/store/gameStore';
+import { useProjects } from '@/hooks/useProjects';
 import GameLayout from '@/layouts/GameLayout';
 
 
@@ -110,7 +111,9 @@ const PERFORMANCE_TYPES = [
 
 export default function LivePerformancePage() {
   const [, setLocation] = useLocation();
-  const { gameState, artists, projects, createProject } = useGameStore();
+  const { gameState, artists, createProject } = useGameStore();
+  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { data: projects = [] } = useProjects();
   const [isCreating, setIsCreating] = useState(false);
 
   const [selectedType, setSelectedType] = useState<'single_show' | 'mini_tour' | null>(null);

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { Artist, Project, Role, WeeklyAction, MusicLabel, GameSaveSnapshot } from '@shared/schema';
+import type { Artist, Role, WeeklyAction, MusicLabel, GameSaveSnapshot } from '@shared/schema';
 import type { GameState, LabelData, SourcingTypeString } from '@shared/types/gameTypes';
 // Game engine moved to shared - client no longer calculates outcomes
 import { apiRequest, queryClient } from '@/lib/queryClient';
@@ -13,6 +13,7 @@ import { executivesQueryKey } from '@/hooks/useExecutives';
 import { CHART_TOP10_SCOPE, CHART_TOP100_SCOPE } from '@/hooks/useCharts';
 import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { songsQueryKey } from '@/hooks/useSongs';
+import { projectsQueryKey } from '@/hooks/useProjects';
 
 // Internal helper: the shared 6-endpoint + email-snapshot parallel reload used
 // identically by loadGame / loadGameFromSave / advanceWeek. Fans out the same
@@ -64,6 +65,12 @@ async function fetchGameBundle(gameId: string): Promise<GameBundle> {
   // Callers no longer write these three arrays into the store.
   seedReleaseAndSongCache(gameId, { songs, releases, releaseSongs });
 
+  // Phase 3 PR-7: projects are owned by the TanStack Query cache too. There is
+  // no dedicated projects endpoint — they arrive inside the base game payload
+  // (`gameData.projects`), so seed from there (zero extra GETs). useProjects
+  // reads this key; callers no longer write `projects` into the store.
+  seedProjectsCache(gameId, gameData?.projects);
+
   return { gameData, songs, releases, releaseSongs, executives, moodEvents, emails };
 }
 
@@ -89,6 +96,16 @@ function seedReleaseAndSongCache(
   );
 }
 
+// Phase 3 PR-7: seed the projects query cache from an already-fetched game
+// payload so useProjects reads fresh data with no extra round-trip. Coerced to
+// [] to match the hook's queryFn contract (it always resolves an array).
+function seedProjectsCache(gameId: string, projects: unknown) {
+  queryClient.setQueryData(
+    projectsQueryKey(gameId),
+    Array.isArray(projects) ? projects : [],
+  );
+}
+
 // Internal helper to sync focus slots and A&R operation status to the server
 async function syncSlotsPatch(
   gameId: string,
@@ -109,13 +126,15 @@ interface GameStore {
   // Game state
   gameState: GameState | null;
   artists: Artist[];
-  projects: Project[];
   roles: Role[];
   weeklyActions: WeeklyAction[];
   // Phase 3 PR-6: songs / releases / releaseSongs are no longer owned by the
   // store — they live in the TanStack Query cache (hooks/useSongs.ts,
   // hooks/useReleases.ts). Consumers read them via useSongs/useReleases/
   // useReleaseSongs; the fan-out seeds the cache, mutations invalidate it.
+  // Phase 3 PR-7: `projects` is likewise cache-owned (hooks/useProjects.ts).
+  // Consumers read it via useProjects; the fan-out seeds the cache and the
+  // createProject/updateProject/cancelProject mutations invalidate it.
   emails: any[]; // Email system support
   executives: any[];
   moodEvents: any[];
@@ -181,7 +200,6 @@ export const useGameStore = create<GameStore>()(
       // Initial state
       gameState: null,
       artists: [],
-      projects: [],
       roles: [],
       weeklyActions: [],
       emails: [],
@@ -231,12 +249,12 @@ export const useGameStore = create<GameStore>()(
             musicLabel: data.musicLabel || null
           };
 
-          // Phase 3 PR-6: songs / releases / releaseSongs are seeded into the
-          // TanStack Query cache by fetchGameBundle — no longer written here.
+          // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are
+          // seeded into the TanStack Query cache by fetchGameBundle — no longer
+          // written here.
           set({
             gameState: gameStateWithLabel,
             artists: data.artists,
-            projects: data.projects,
             roles: data.roles,
             weeklyActions: data.weeklyActions,
             emails: emailList,
@@ -297,11 +315,14 @@ export const useGameStore = create<GameStore>()(
             releases: snapshot.releases || [],
             releaseSongs: snapshot.releaseSongs || [],
           });
+          // Phase 3 PR-7: seed the projects cache from the snapshot so restored
+          // projects show immediately; the post-restore fetchGameBundle below
+          // re-seeds with the server's authoritative copy.
+          seedProjectsCache(baseGameState.id, snapshot.projects || []);
 
           set({
             gameState: interimGameState,
             artists: (snapshot.artists || []) as unknown as Artist[],
-            projects: (snapshot.projects || []) as unknown as Project[],
             roles: (snapshot.roles || []) as unknown as Role[],
             emails: snapshot.emails || [],
             executives: snapshot.executives || [],
@@ -336,12 +357,12 @@ export const useGameStore = create<GameStore>()(
             arOfficeSourcingType: gameData.gameState?.arOfficeSourcingType ?? null,
           };
 
-          // Phase 3 PR-6: songs / releases / releaseSongs seeded into the query
-          // cache by fetchGameBundle above — no longer written into the store.
+          // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects seeded
+          // into the query cache by fetchGameBundle above — no longer written
+          // into the store.
           set({
             gameState: syncedGameState,
             artists: gameData.artists || [],
-            projects: gameData.projects || [],
             roles: gameData.roles || [],
             weeklyActions: gameData.weeklyActions || [],
             emails: emailList || [],
@@ -487,12 +508,13 @@ export const useGameStore = create<GameStore>()(
           // Phase 3 PR-6: seed the new game's release/song caches empty so the
           // hooks read [] rather than any stale prior-game data.
           seedReleaseAndSongCache(gameState.id, { songs: [], releases: [], releaseSongs: [] });
+          // Phase 3 PR-7: seed the new game's projects cache empty too.
+          seedProjectsCache(gameState.id, []);
 
           // Clear campaign results and set new state
           set({
             gameState: syncedGameState,
             artists: [],
-            projects: [],
             roles: [],
             weeklyActions: [],
             emails: [],
@@ -753,12 +775,12 @@ export const useGameStore = create<GameStore>()(
             musicLabel: gameData.musicLabel || (resultGameState as any)?.musicLabel || null,
           } as GameState;
 
-          // Phase 3 PR-6: songs / releases / releaseSongs seeded into the query
-          // cache by fetchGameBundle — no longer written into the store.
+          // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects seeded
+          // into the query cache by fetchGameBundle — no longer written into the
+          // store.
           set({
             gameState: syncedGameState,
             artists: gameData.artists || [], // Update artists to reflect mood changes
-            projects: gameData.projects || [], // Update projects with current state
             emails: emailList || [],
             executives: Array.isArray(executivesData) ? executivesData : [],
             moodEvents: Array.isArray(moodEventsData) ? moodEventsData : [],
@@ -957,7 +979,7 @@ export const useGameStore = create<GameStore>()(
 
       // Project management
       createProject: async (projectData: any) => {
-        const { gameState, projects } = get();
+        const { gameState } = get();
         if (!gameState) return;
 
         try {
@@ -966,10 +988,14 @@ export const useGameStore = create<GameStore>()(
             startWeek: gameState.currentWeek,
             stage: 'planning'
           });
-          const newProject = await response.json();
+          await response.json();
 
-          // Update projects array
-          set({ projects: [...projects, newProject] });
+          // Phase 3 PR-7: projects are cache-owned now. Invalidate the projects
+          // key so useProjects refetches the authoritative list (which includes
+          // the just-created project) instead of hand-splicing the store array.
+          await queryClient.invalidateQueries({
+            queryKey: projectsQueryKey(gameState.id),
+          });
 
           // CRITICAL: Immediately update gameState to reflect cost and creative capital deduction
           // The server has already deducted both the project cost and creative capital, so we need to sync our local state
@@ -994,14 +1020,16 @@ export const useGameStore = create<GameStore>()(
       },
 
       updateProject: async (projectId: string, updates: any) => {
-        const { projects } = get();
+        const { gameState } = get();
 
         try {
           const response = await apiRequest('PATCH', `/api/projects/${projectId}`, updates);
-          const updatedProject = await response.json();
-          
-          set({
-            projects: projects.map(p => p.id === projectId ? updatedProject : p)
+          await response.json();
+
+          // Phase 3 PR-7: invalidate the projects cache so useProjects refetches
+          // the updated project instead of mapping over a store-owned array.
+          await queryClient.invalidateQueries({
+            queryKey: projectsQueryKey(gameState?.id),
           });
         } catch (error) {
           console.error('Failed to update project:', error);
@@ -1011,32 +1039,33 @@ export const useGameStore = create<GameStore>()(
 
       // Cancel project with refund calculation
       cancelProject: async (projectId: string, cancellationData: { refundAmount: number }) => {
-        const { projects, gameState } = get();
+        const { gameState } = get();
         if (!gameState) return;
 
         try {
           console.log('[CANCEL PROJECT] Sending cancellation request:', { projectId, cancellationData });
-          
+
           // Call the real API endpoint
           const response = await apiRequest('DELETE', `/api/projects/${projectId}/cancel`, cancellationData);
           const result = await response.json();
-          
+
           console.log('[CANCEL PROJECT] API response:', result);
-          
-          // Remove project from local state
-          const updatedProjects = projects.filter(p => p.id !== projectId);
-          
-          // Update game state with new balance from server
+
+          // Update game state with new balance from server (optimistic delta
+          // UNTOUCHED — adopts result.newBalance verbatim, per PR-10 scope note).
           const updatedGameState = {
             ...gameState,
             money: result.newBalance
           };
-          
-          set({
-            projects: updatedProjects,
-            gameState: updatedGameState
+          set({ gameState: updatedGameState });
+
+          // Phase 3 PR-7: projects are cache-owned now. Invalidate the projects
+          // key so useProjects drops the cancelled project instead of filtering
+          // a store-owned array.
+          await queryClient.invalidateQueries({
+            queryKey: projectsQueryKey(gameState.id),
           });
-          
+
           console.log(`[CANCEL PROJECT] Project cancelled. Refund: $${result.refundAmount}, New balance: $${result.newBalance}`);
         } catch (error) {
           console.error('Failed to cancel project:', error);
@@ -1250,7 +1279,6 @@ export const useGameStore = create<GameStore>()(
         const {
           gameState,
           artists,
-          projects,
           roles,
           executives,
           moodEvents,
@@ -1259,14 +1287,16 @@ export const useGameStore = create<GameStore>()(
         } = get();
         if (!gameState) return;
 
-        // Phase 3 PR-6: songs / releases / releaseSongs are no longer store-owned.
-        // Source them from the TanStack Query cache (seeded by the fan-out) so the
-        // snapshot shape is byte-identical to before. Autosave runs right after
-        // advanceWeek's fan-out, so the cache is freshly populated here.
+        // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are no
+        // longer store-owned. Source them from the TanStack Query cache (seeded
+        // by the fan-out) so the snapshot shape is byte-identical to before.
+        // Autosave runs right after advanceWeek's fan-out, so the cache is
+        // freshly populated here.
         const songs = queryClient.getQueryData<any[]>(songsQueryKey(gameState.id)) ?? [];
         const releases = queryClient.getQueryData<any[]>(releasesQueryKey(gameState.id)) ?? [];
         const releaseSongs =
           queryClient.getQueryData<any[]>(releaseSongsQueryKey(gameState.id)) ?? [];
+        const projects = queryClient.getQueryData<any[]>(projectsQueryKey(gameState.id)) ?? [];
 
         try {
           const { emailSnapshot, releaseSongs: releaseSongsSnapshot, executives: executivesSnapshot, moodEvents: moodEventsSnapshot } =

--- a/tests/client/gameStore-actions.characterization.test.ts
+++ b/tests/client/gameStore-actions.characterization.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
 import { apiRequest, queryClient } from '@/lib/queryClient';
 import { songsQueryKey } from '@/hooks/useSongs';
 import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
+import { projectsQueryKey } from '@/hooks/useProjects';
 import { useGameStore } from '@/store/gameStore';
 import {
   routeApiRequest as routeApiRequestImpl,
@@ -85,10 +86,14 @@ describe('signArtist optimistic delta', () => {
 });
 
 describe('createProject optimistic delta', () => {
-  it('deducts totalCost from money and 1 from creativeCapital, appends project', async () => {
+  // Phase 3 PR-7 CHANGE: projects are cache-owned now. createProject no longer
+  // splices the returned project into a store `projects` array; it invalidates
+  // the projects query key so useProjects refetches the authoritative list. The
+  // money/creativeCapital optimistic math is UNTOUCHED (that's PR-10), so those
+  // pins stay identical — only the array-splice pin becomes an invalidation pin.
+  it('deducts totalCost from money and 1 from creativeCapital, invalidates projects', async () => {
     useGameStore.setState({
-      gameState: baseGameState({ money: 100000, creativeCapital: 4 }),
-      projects: [],
+      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }),
     });
     const newProject = { id: 'proj-1', title: 'EP' };
     routeApiRequest([{ match: (u) => u.includes('/projects'), body: newProject }]);
@@ -98,13 +103,16 @@ describe('createProject optimistic delta', () => {
     const state = useGameStore.getState();
     expect(state.gameState!.money).toBe(80000); // 100000 - 20000
     expect((state.gameState as any).creativeCapital).toBe(3); // 4 - 1
-    expect(state.projects).toEqual([newProject]);
+    // Projects no longer live in the store; the mutation invalidates the cache.
+    expect((state as any).projects).toBeUndefined();
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: projectsQueryKey('game-1'),
+    });
   });
 
   it('falls back to budgetPerSong when totalCost is absent', async () => {
     useGameStore.setState({
       gameState: baseGameState({ money: 50000, creativeCapital: 2 }),
-      projects: [],
     });
     routeApiRequest([{ match: (u) => u.includes('/projects'), body: { id: 'p2' } }]);
 
@@ -117,7 +125,6 @@ describe('createProject optimistic delta', () => {
   it('deducts creative capital even when cost is 0', async () => {
     useGameStore.setState({
       gameState: baseGameState({ money: 30000, creativeCapital: 3 }),
-      projects: [],
     });
     routeApiRequest([{ match: (u) => u.includes('/projects'), body: { id: 'p3' } }]);
 
@@ -156,10 +163,13 @@ describe('planRelease optimistic delta', () => {
 });
 
 describe('cancelProject adopts server balance', () => {
-  it('sets money to result.newBalance (NOT a local delta) and removes the project', async () => {
+  // Phase 3 PR-7 CHANGE: projects are cache-owned. cancelProject no longer
+  // filters the cancelled project out of a store `projects` array; it
+  // invalidates the projects query key so useProjects refetches. The money
+  // pin (adopts server newBalance verbatim) is UNTOUCHED.
+  it('sets money to result.newBalance (NOT a local delta) and invalidates projects', async () => {
     useGameStore.setState({
-      gameState: baseGameState({ money: 20000 }),
-      projects: [{ id: 'proj-1' } as any, { id: 'proj-2' } as any],
+      gameState: baseGameState({ id: 'game-1', money: 20000 }),
     });
     routeApiRequest([
       {
@@ -172,16 +182,22 @@ describe('cancelProject adopts server balance', () => {
 
     const state = useGameStore.getState();
     expect(state.gameState!.money).toBe(27500); // adopts server newBalance verbatim
-    expect(state.projects).toEqual([{ id: 'proj-2' }]);
+    // Projects no longer live in the store; the mutation invalidates the cache.
+    expect((state as any).projects).toBeUndefined();
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: projectsQueryKey('game-1'),
+    });
   });
 });
 
 describe('loadGame set(...) state shape', () => {
-  // Phase 3 PR-6 CHANGE: loadGame no longer writes songs / releases /
-  // releaseSongs into the store. It seeds those into the TanStack Query cache
-  // (via queryClient.setQueryData) so the useSongs/useReleases/useReleaseSongs
-  // hooks own them. The pins below assert the cache is seeded from the same
-  // fan-out bodies, and that the store set() no longer carries these arrays.
+  // Phase 3 PR-6/PR-7 CHANGE: loadGame no longer writes songs / releases /
+  // releaseSongs / projects into the store. It seeds those into the TanStack
+  // Query cache (via queryClient.setQueryData) so the useSongs/useReleases/
+  // useReleaseSongs/useProjects hooks own them. The pins below assert the cache
+  // is seeded from the same fan-out bodies, and that the store set() no longer
+  // carries these arrays. (projects is seeded from the base game payload's
+  // `projects` field — there is no dedicated projects endpoint.)
   it('writes exactly the collections loadGame owns and resets selectedActions', async () => {
     mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
       if (url.endsWith('/songs')) return jsonResponse([{ id: 's1' }]);
@@ -210,7 +226,6 @@ describe('loadGame set(...) state shape', () => {
     expect((state.gameState as any).musicLabel).toEqual({ name: 'Loaded Label' });
     expect((state.gameState as any).usedFocusSlots).toBe(0);
     expect(state.artists).toEqual([{ id: 'a1' }]);
-    expect(state.projects).toEqual([{ id: 'p1' }]);
     expect(state.roles).toEqual([{ id: 'role1' }]);
     expect(state.weeklyActions).toEqual([{ id: 'wa1' }]);
     expect(state.emails).toEqual([{ id: 'em1' }]);
@@ -218,15 +233,18 @@ describe('loadGame set(...) state shape', () => {
     expect(state.moodEvents).toEqual([{ id: 'm1' }]);
     expect(state.selectedActions).toEqual([]);
 
-    // PR-6: songs / releases / releaseSongs are seeded into the query cache, NOT
-    // the store. Assert the cache holds the fan-out bodies keyed by gameId.
+    // PR-6/PR-7: songs / releases / releaseSongs / projects are seeded into the
+    // query cache, NOT the store. Assert the cache holds the fan-out bodies
+    // keyed by gameId (projects from the base game payload's `projects` field).
     expect(queryClient.getQueryData(songsQueryKey('game-1'))).toEqual([{ id: 's1' }]);
     expect(queryClient.getQueryData(releasesQueryKey('game-1'))).toEqual([{ id: 'r1' }]);
     expect(queryClient.getQueryData(releaseSongsQueryKey('game-1'))).toEqual([{ id: 'rs1' }]);
+    expect(queryClient.getQueryData(projectsQueryKey('game-1'))).toEqual([{ id: 'p1' }]);
     // And the store no longer exposes them.
     expect((state as any).songs).toBeUndefined();
     expect((state as any).releases).toBeUndefined();
     expect((state as any).releaseSongs).toBeUndefined();
+    expect((state as any).projects).toBeUndefined();
   });
 });
 
@@ -267,7 +285,6 @@ describe('advanceWeek set(...) state shape', () => {
     const state = useGameStore.getState();
     expect((state.gameState as any).currentWeek).toBe(6);
     expect(state.artists).toEqual([{ id: 'a1' }]);
-    expect(state.projects).toEqual([{ id: 'p1' }]);
     expect(state.emails).toEqual([{ id: 'em1' }]);
     expect(state.executives).toEqual([{ id: 'e1' }]);
     expect(state.moodEvents).toEqual([{ id: 'm1' }]);
@@ -276,13 +293,16 @@ describe('advanceWeek set(...) state shape', () => {
     expect(state.selectedActions).toEqual([]);
     expect(state.isAdvancingWeek).toBe(false);
 
-    // PR-6: advanceWeek seeds songs / releases / releaseSongs into the query
-    // cache (via fetchGameBundle) instead of the store. Assert the seeded cache.
+    // PR-6/PR-7: advanceWeek seeds songs / releases / releaseSongs / projects
+    // into the query cache (via fetchGameBundle) instead of the store. Assert
+    // the seeded cache (projects from the base game payload's `projects` field).
     expect(queryClient.getQueryData(songsQueryKey('game-1'))).toEqual([{ id: 's1' }]);
     expect(queryClient.getQueryData(releasesQueryKey('game-1'))).toEqual([{ id: 'r1' }]);
     expect(queryClient.getQueryData(releaseSongsQueryKey('game-1'))).toEqual([{ id: 'rs1' }]);
+    expect(queryClient.getQueryData(projectsQueryKey('game-1'))).toEqual([{ id: 'p1' }]);
     expect((state as any).songs).toBeUndefined();
     expect((state as any).releases).toBeUndefined();
     expect((state as any).releaseSongs).toBeUndefined();
+    expect((state as any).projects).toBeUndefined();
   });
 });

--- a/tests/client/gameStore-harness.ts
+++ b/tests/client/gameStore-harness.ts
@@ -44,11 +44,11 @@ export function resetGameStore(useGameStore: Store) {
   useGameStore.setState({
     gameState: null,
     artists: [],
-    projects: [],
     roles: [],
     weeklyActions: [],
-    // Phase 3 PR-6: songs / releases / releaseSongs are no longer store-owned
-    // (they live in the TanStack Query cache), so they are not reset here.
+    // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are no
+    // longer store-owned (they live in the TanStack Query cache), so they are
+    // not reset here.
     emails: [],
     executives: [],
     moodEvents: [],

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -30,6 +30,7 @@ import {
   releaseSongsQueryKey,
 } from '@/hooks/useReleases';
 import { SONGS_SCOPE, songsQueryKey } from '@/hooks/useSongs';
+import { PROJECTS_SCOPE, projectsQueryKey } from '@/hooks/useProjects';
 
 const GAME_ID = 'game-1';
 const ARTIST_ID = 'artist-1';
@@ -58,6 +59,8 @@ const REAL_QUERY_KEYS: readonly unknown[][] = [
   [...releasesQueryKey(GAME_ID)],
   [...releaseSongsQueryKey(GAME_ID)],
   [...songsQueryKey(GAME_ID)],
+  // Projects (useProjects.ts, PR-7): [SCOPE, gameId]
+  [...projectsQueryKey(GAME_ID)],
   ['api', 'saves'],
 ];
 
@@ -137,6 +140,23 @@ describe('query-key contract: planRelease invalidations (PR-6)', () => {
     expect(releasesQueryKey(GAME_ID)).toEqual([RELEASES_SCOPE, GAME_ID]);
     expect(releaseSongsQueryKey(GAME_ID)).toEqual([RELEASE_SONGS_SCOPE, GAME_ID]);
     expect(songsQueryKey(GAME_ID)).toEqual([SONGS_SCOPE, GAME_ID]);
+  });
+});
+
+describe('query-key contract: project mutation invalidations (PR-7)', () => {
+  // createProject / updateProject / cancelProject invalidate the projects cache
+  // with the EXACT scoped key (client/src/store/gameStore.ts): projectsQueryKey
+  // == [PROJECTS_SCOPE, gameId]. Assert each matches the useProjects hook key.
+  it('project mutation invalidation matches the useProjects hook key', () => {
+    expect(someRealKeyMatchesInvalidationKey(projectsQueryKey(GAME_ID))).toBe(true);
+  });
+
+  it('the projects invalidation does NOT match a different game', () => {
+    expect(someRealKeyMatchesInvalidationKey(projectsQueryKey('other'))).toBe(false);
+  });
+
+  it('the projects scope constant and hook key agree element-for-element', () => {
+    expect(projectsQueryKey(GAME_ID)).toEqual([PROJECTS_SCOPE, GAME_ID]);
   });
 });
 

--- a/tests/client/useProjects.test.tsx
+++ b/tests/client/useProjects.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * useProjects hook test (Phase 3 PR-7).
+ *
+ * Mocks `apiRequest` and `useGameStore` to verify the projects hook fetches the
+ * base game endpoint, selects `.projects` from the payload, keys its query by
+ * the scoped [SCOPE, gameId] shape, and skips fetching when there's no active
+ * game. Unlike releases/songs (PR-6) there is NO dedicated projects endpoint —
+ * projects arrive inside `/api/game/:id`, so the queryFn selects them from there.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/queryClient', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/queryClient')>('@/lib/queryClient');
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: vi.fn(),
+}));
+
+import { apiRequest } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import { useProjects, PROJECTS_SCOPE, projectsQueryKey } from '@/hooks/useProjects';
+
+const mockedApiRequest = vi.mocked(apiRequest);
+const mockedUseGameStore = vi.mocked(useGameStore);
+
+function jsonResponse(body: unknown): Response {
+  return { json: async () => body } as unknown as Response;
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return queryClient;
+}
+
+function TestProjects() {
+  const { data, isLoading } = useProjects();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="projects">{JSON.stringify(data)}</div>;
+}
+
+describe('useProjects', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+    mockedUseGameStore.mockReset();
+  });
+
+  it('fetches the base game endpoint and selects the projects array', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(
+      jsonResponse({ gameState: { id: 'game-1' }, projects: [{ id: 'p1' }, { id: 'p2' }] }),
+    );
+
+    renderWithClient(<TestProjects />);
+
+    await waitFor(() => expect(screen.getByTestId('projects')).toBeTruthy());
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1');
+    expect(screen.getByTestId('projects').textContent).toBe(
+      JSON.stringify([{ id: 'p1' }, { id: 'p2' }]),
+    );
+  });
+
+  it('resolves [] when the payload has no projects field', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(jsonResponse({ gameState: { id: 'game-1' } }));
+
+    renderWithClient(<TestProjects />);
+
+    await waitFor(() => expect(screen.getByTestId('projects')).toBeTruthy());
+    expect(screen.getByTestId('projects').textContent).toBe('[]');
+  });
+
+  it('does not fetch when there is no active game', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: null }));
+
+    renderWithClient(<TestProjects />);
+
+    // Query stays disabled; no apiRequest call should ever fire.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('scope constant and key builder match the store invalidation shape', () => {
+    expect(PROJECTS_SCOPE).toBe('projects:list');
+    expect(projectsQueryKey('game-1')).toEqual(['projects:list', 'game-1']);
+  });
+});


### PR DESCRIPTION
Phase 3, PR-7 of the client-state-ownership plan (`docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md`, row 7). Moves the `projects` domain from Zustand onto the TanStack Query cache, mirroring PR-6 (releases/songs), which passed adversarial review with zero findings.

## Step-1 design choice
Unlike releases/songs, there is **no dedicated `GET /api/game/:id/projects` endpoint** — projects arrive inside the `/api/game/:id` payload as `data.projects` (see `server/routes/games.ts`), and Phase 3 is strictly client-only (no server changes). So `useProjects` keeps the same `[SCOPE, gameId]` convention and a real custom `queryFn`, but that queryFn fetches `/api/game/:id` and selects `.projects` — the exact source the store read before. In practice the loadGame/advanceWeek/loadGameFromSave fan-out **pre-seeds** the cache from the same already-fetched game body (zero extra GETs via `setQueryData`), so the queryFn only fires when a mutation invalidates the key. This is the smallest faithful client-only design: no duplicate endpoint, no behavior change, same server source of truth.

## Store changes
- `fetchGameBundle` seeds the projects cache from `gameData.projects` via a new `seedProjectsCache` helper (alongside the existing `seedReleaseAndSongCache`). `createNewGame` seeds `[]`; `loadGameFromSave` seeds from the snapshot.
- `projects` removed from the `GameStore` interface, initial state, and every `set(...)` fan-out write.
- `createProject` / `updateProject` / `cancelProject` stay in the store but **invalidate `projectsQueryKey(gameId)`** instead of hand-splicing the array. Their money / creativeCapital optimistic math is **UNTOUCHED** (that is PR-10 scope).
- `saveGame` sources `projects` from the cache (like PR-6 did for songs/releases).

## Consumers migrated (read via `useProjects()`)
`ActiveTours`, `ArtistRoster`, `ArtistCard`, `ArtistPage`, `ArtistsLandingPage`, `LivePerformancePage`, `MusicCalendar`. `Dashboard` and `ToastNotification` only had an unused `projects` destructure — dropped it. `SaveGameModal.handleExport` sources projects from the cache. Rendering is identical.

## Save snapshot
`buildGameSnapshot` already takes `projects` as a param — only the *source* changed (store → cache) in both `saveGame` and `handleExport`. The shape test stays green.

## Pin changes (deliberate, same style as PR-6 sanctioned changes)
- `query-key-contract.test.ts`: added the `projects:list` scope to the real-key set and a PR-7 describe block asserting the mutation invalidation matches the `useProjects` hook key (and not a different game).
- `gameStore-actions.characterization.test.ts`:
  - `createProject` / `cancelProject` pins previously asserted **array splicing** (`state.projects` append/filter). They now assert the mutation **invalidates `projectsQueryKey`** and that the store no longer exposes `projects`. The money/creativeCapital pins are unchanged.
  - `loadGame` / `advanceWeek` pins now assert the projects **cache is seeded** (from the base game payload) and `state.projects` is `undefined`, mirroring the PR-6 songs/releases/releaseSongs pins.
- `gameStore-harness.ts`: dropped the now-stale `projects: []` from `resetGameStore` (mirrors PR-6).
- New `tests/client/useProjects.test.tsx` (modeled on `useCharts.test.tsx`): verifies endpoint, `.projects` selection, `[]` fallback, disabled-without-game, and scope/key shape.
- `ArtistRoster.test.tsx`: mocks `useProjects` so the component test stays store-only with no QueryClient.

## Validation
- `npm run check` — clean.
- `npx vitest run tests/client/` — 54 tests pass (8 files, incl. new useProjects test).
- `client/src/components/__tests__/ArtistRoster.test.tsx` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)