### PR TITLE
feat(client): Phase 3 PR-9 — useArtists + useDiscoveredArtists; store stops owning rosters

### DIFF
--- a/client/src/components/ActiveReleases.tsx
+++ b/client/src/components/ActiveReleases.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { useGameStore } from '@/store/gameStore';
 import { useReleases } from '@/hooks/useReleases';
 import { useSongs } from '@/hooks/useSongs';
+import { useArtists } from '@/hooks/useArtists';
 import { useState, useEffect } from 'react';
 import { AlertTriangle, Clock, CheckCircle, BarChart3 } from 'lucide-react';
 import { ReleaseWorkflowCard } from './ReleaseWorkflowCard';
@@ -15,10 +16,12 @@ import {
 } from '../../../shared/utils/chartUtils';
 
 export function ActiveReleases() {
-  const { artists, gameState } = useGameStore();
-  // Phase 3 PR-6: releases / songs read from the TanStack Query cache, not Zustand.
+  const { gameState } = useGameStore();
+  // Phase 3 PR-6/PR-9: releases / songs / artists read from the TanStack Query
+  // cache, not Zustand.
   const { data: releases = [] } = useReleases();
   const { data: songs = [] } = useSongs();
+  const { data: artists = [] } = useArtists();
   const [activeTab, setActiveTab] = useState<'upcoming' | 'released'>('upcoming');
   const [stateSync, setStateSync] = useState<'synced' | 'syncing' | 'error'>('synced');
   

--- a/client/src/components/ActiveTours.tsx
+++ b/client/src/components/ActiveTours.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useGameStore } from '@/store/gameStore';
 import { useProjects } from '@/hooks/useProjects';
+import { useArtists } from '@/hooks/useArtists';
 import { useLocation } from 'wouter';
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, DollarSign, Users, Calculator } from 'lucide-react';
@@ -261,9 +262,10 @@ function CompletedToursTable({ completedTours, getArtistName }: { completedTours
 }
 
 export function ActiveTours() {
-  const { artists, cancelProject, gameState } = useGameStore();
-  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { cancelProject, gameState } = useGameStore();
+  // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
+  const { data: artists = [] } = useArtists();
   const [, setLocation] = useLocation();
   const [activeTab, setActiveTab] = useState<'active' | 'completed'>('active');
   const [showCancelModal, setShowCancelModal] = useState(false);

--- a/client/src/components/ArtistRoster.tsx
+++ b/client/src/components/ArtistRoster.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/menubar';
 import { useGameStore } from '@/store/gameStore';
 import { useProjects } from '@/hooks/useProjects';
+import { useArtists } from '@/hooks/useArtists';
 import { ArtistDiscoveryModal } from './ArtistDiscoveryModal';
 import { ArtistDashboardCard } from './ArtistDashboardCard';
 import { ArtistDialogueModal } from './artist-dialogue/ArtistDialogueModal';
@@ -46,9 +47,10 @@ const toGameArtist = (artist: DbArtist | (DbArtist & { loyalty?: number | null }
 };
 
 export function ArtistRoster() {
-  const { gameState, artists, signArtist, loadGame } = useGameStore();
-  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { gameState, signArtist, loadGame } = useGameStore();
+  // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
+  const { data: artists = [] } = useArtists();
   const [showDiscoveryModal, setShowDiscoveryModal] = useState(false);
   const [isDialogueModalOpen, setIsDialogueModalOpen] = useState(false);
   const [selectedArtistForDialogue, setSelectedArtistForDialogue] = useState<DbArtist | null>(null);

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -23,7 +23,7 @@ export function Dashboard({
   showSaveModal = false,
   setShowSaveModal = () => {}
 }: DashboardProps) {
-  const { gameState, isAdvancingWeek, advanceWeek, weeklyOutcome, artists, createProject } = useGameStore();
+  const { gameState, isAdvancingWeek, advanceWeek, weeklyOutcome, createProject } = useGameStore();
   const [, setLocation] = useLocation();
   const [showWeekSummary, setShowWeekSummary] = useState(false);
   const [lastProcessedWeek, setLastProcessedWeek] = useState<number | null>(null);

--- a/client/src/components/MusicCalendar.tsx
+++ b/client/src/components/MusicCalendar.tsx
@@ -7,6 +7,7 @@ import { Plus, Music, Mic2, Clock } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
 import { useReleases } from '@/hooks/useReleases';
 import { useProjects } from '@/hooks/useProjects';
+import { useArtists } from '@/hooks/useArtists';
 import { cn } from '@/lib/utils';
 import { getCompletedCities, getTourMetadata } from '@/utils/tourHelpers';
 import { getWeekDateRange, getWeekDates as getWeekDatesForYear, formatWeekEndDate } from '@shared/utils/seasonalCalculations';
@@ -44,9 +45,10 @@ export function MusicCalendar({
   minWeek = 1,
   weekPickerMode = false
 }: MusicCalendarProps) {
-  const { gameState, artists } = useGameStore();
-  // Phase 3 PR-6/PR-7: releases / projects read from the TanStack Query cache,
-  // not Zustand.
+  const { gameState } = useGameStore();
+  // Phase 3 PR-6/PR-7/PR-9: releases / projects / artists read from the TanStack
+  // Query cache, not Zustand.
+  const { data: artists = [] } = useArtists();
   const { data: releases = [] } = useReleases();
   const { data: projects = [] } = useProjects();
 

--- a/client/src/components/SaveGameModal.tsx
+++ b/client/src/components/SaveGameModal.tsx
@@ -23,6 +23,7 @@ import { buildGameSnapshot } from '@/utils/buildGameSnapshot';
 import { songsQueryKey } from '@/hooks/useSongs';
 import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { projectsQueryKey } from '@/hooks/useProjects';
+import { artistsQueryKey } from '@/hooks/useArtists';
 import { useToast } from '@/hooks/use-toast';
 
 type SaveSummary = {
@@ -218,7 +219,6 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
       // list (and emailMetadata shape, incl. `truncated`) stays identical to
       // manual saves / autosaves and validates against gameSaveSnapshotSchema.
       const {
-        artists,
         roles,
         executives,
         moodEvents,
@@ -226,13 +226,15 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
         weeklyOutcome
       } = useGameStore.getState();
 
-      // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are no
-      // longer store-owned. Source them from the TanStack Query cache so the
-      // export snapshot shape stays byte-identical to manual saves / autosaves.
+      // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /
+      // artists are no longer store-owned. Source them from the TanStack Query
+      // cache so the export snapshot shape stays byte-identical to manual saves /
+      // autosaves.
       const songs = queryClient.getQueryData<any[]>(songsQueryKey(gameState.id)) ?? [];
       const releases = queryClient.getQueryData<any[]>(releasesQueryKey(gameState.id)) ?? [];
       const releaseSongs = queryClient.getQueryData<any[]>(releaseSongsQueryKey(gameState.id)) ?? [];
       const projects = queryClient.getQueryData<any[]>(projectsQueryKey(gameState.id)) ?? [];
+      const artists = queryClient.getQueryData<any[]>(artistsQueryKey(gameState.id)) ?? [];
 
       const snapshotCandidate = buildGameSnapshot({
         gameState,

--- a/client/src/components/TourVarianceTester.tsx
+++ b/client/src/components/TourVarianceTester.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Slider } from '@/components/ui/slider';
 import { Badge } from '@/components/ui/badge';
 import { useGameStore } from '@/store/gameStore';
+import { useArtists } from '@/hooks/useArtists';
 import { apiRequest } from '@/lib/queryClient';
 import { Calculator, TrendingUp, TrendingDown, Target } from 'lucide-react';
 
@@ -43,7 +44,9 @@ interface ActualResult {
 }
 
 export function TourVarianceTester() {
-  const { gameState, artists } = useGameStore();
+  const { gameState } = useGameStore();
+  // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
+  const { data: artists = [] } = useArtists();
   const [selectedArtist, setSelectedArtist] = useState<string>('');
   const [cities, setCities] = useState(3);
   const [budgetPerCity, setBudgetPerCity] = useState(2000);

--- a/client/src/components/__tests__/ArtistRoster.test.tsx
+++ b/client/src/components/__tests__/ArtistRoster.test.tsx
@@ -19,6 +19,13 @@ vi.mock('@/hooks/useProjects', () => ({
   useProjects: () => ({ data: [] }),
 }));
 
+// Phase 3 PR-9: ArtistRoster now reads the roster via useArtists (TanStack).
+// Mock it so this component test stays store-only and needs no QueryClient.
+const { mockUseArtists } = vi.hoisted(() => ({ mockUseArtists: vi.fn() }));
+vi.mock('@/hooks/useArtists', () => ({
+  useArtists: mockUseArtists,
+}));
+
 vi.mock('wouter', () => ({
   useLocation: () => [null, setLocationMock],
 }));
@@ -63,10 +70,10 @@ describe('ArtistRoster', () => {
     modalRenderSpy.mockClear();
     setLocationMock.mockClear();
     mockUseGameStore.mockReset();
+    mockUseArtists.mockReset();
 
-    mockUseGameStore.mockReturnValue({
-      gameState: { id: 'game-1', currentWeek: 12 },
-      artists: [
+    mockUseArtists.mockReturnValue({
+      data: [
         {
           id: 'artist-1',
           name: 'Nova Sterling',
@@ -78,8 +85,11 @@ describe('ArtistRoster', () => {
           workEthic: 75,
         },
       ],
+    });
+
+    mockUseGameStore.mockReturnValue({
+      gameState: { id: 'game-1', currentWeek: 12 },
       signArtist: vi.fn(),
-      projects: [],
       loadGame: vi.fn().mockResolvedValue(undefined),
     });
   });

--- a/client/src/components/ar-office/AROffice.tsx
+++ b/client/src/components/ar-office/AROffice.tsx
@@ -7,6 +7,8 @@ import { Music } from 'lucide-react';
 import type { Artist as SharedArtist } from '@shared/schema';
 import type { GameState } from '@shared/types/gameTypes';
 import { useGameStore } from '@/store/gameStore';
+import { useDiscoveredArtists, discoveredArtistsQueryKey } from '@/hooks/useDiscoveredArtists';
+import { useQueryClient } from '@tanstack/react-query';
 import type { SourcingTypeString } from '@shared/types/gameTypes';
 import { SourcingModeSelector } from './SourcingModeSelector';
 import { ArtistDiscoveryTable, type UIArtist } from './ArtistDiscoveryTable';
@@ -113,7 +115,22 @@ export function AROffice({ gameId, gameState, signedArtists, focusSlots, onSignA
   const [sourcingMode, setSourcingMode] = useState<SourcingType | null>(null);
 
   // Store methods to manage A&R slot usage
-  const { startAROfficeOperation, cancelAROfficeOperation, discoveredArtists, loadDiscoveredArtists } = useGameStore();
+  const { startAROfficeOperation, cancelAROfficeOperation } = useGameStore();
+
+  // Phase 3 PR-9: discovered artists are cache-owned (useDiscoveredArtists). The
+  // hook fetches + synthesizes the same list the store action used to. We keep a
+  // `loadDiscoveredArtists` shim that force-refetches through the hook and THROWS
+  // on error so the existing retry-with-backoff / mount / onRetry call sites work
+  // byte-for-byte (they expect a rejected promise to drive retries).
+  const queryClient = useQueryClient();
+  const { data: discoveredArtists = [], refetch: refetchDiscoveredArtists } = useDiscoveredArtists();
+  const loadDiscoveredArtists = useMemo(
+    () => async () => {
+      const result = await refetchDiscoveredArtists({ throwOnError: true });
+      if (result.error) throw result.error;
+    },
+    [refetchDiscoveredArtists],
+  );
 
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedArchetype, setSelectedArchetype] = useState<string>('All');
@@ -362,8 +379,12 @@ export function AROffice({ gameId, gameState, signedArtists, focusSlots, onSignA
     setSigningArtist(artist.id || artist.name);
     try {
       await onSignArtist(artist);
-      // Optimistically remove from local discovered list and refresh from server
-      try { useGameStore.getState().removeDiscoveredArtist(artist.id as string); } catch {}
+      // Phase 3 PR-9: signArtist already invalidates the discovered-artists cache
+      // (the server's A&R read filters signed-by-name), so refetch to reflect the
+      // reduced list. Invalidate first as a belt-and-suspenders against staleTime.
+      await queryClient.invalidateQueries({
+        queryKey: discoveredArtistsQueryKey(gameId),
+      });
       loadDiscoveredArtists();
       toast({
         title: "Artist signed successfully",

--- a/client/src/components/executive-meetings/ExecutiveMeetings.tsx
+++ b/client/src/components/executive-meetings/ExecutiveMeetings.tsx
@@ -12,6 +12,7 @@ import { Badge } from '../ui/badge';
 import { ArrowLeft, Loader2, Zap } from 'lucide-react';
 import { fetchRoleMeetings, fetchMeetingDialogue, fetchAllRoles } from '../../services/executiveService';
 import { useGameStore } from '../../store/gameStore';
+import { useArtists } from '../../hooks/useArtists';
 
 interface ExecutiveMeetingsProps {
   gameId: string;
@@ -49,7 +50,9 @@ export function ExecutiveMeetings({
 }: ExecutiveMeetingsProps) {
   const [roleSalaries, setRoleSalaries] = useState<Record<string, number>>({});
 
-  const { getAROfficeStatus, selectedActions, artists } = useGameStore();
+  const { getAROfficeStatus, selectedActions } = useGameStore();
+  // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
+  const { data: artists = [] } = useArtists();
 
   // Phase 3 PR-8: route the machine's executives fetch through the TanStack
   // Query cache (key ['executives', gameId]) so the meeting flow and any

--- a/client/src/hooks/useArtists.ts
+++ b/client/src/hooks/useArtists.ts
@@ -1,0 +1,54 @@
+/**
+ * Artists roster query hook (Phase 3 PR-9).
+ *
+ * The signed-artist roster for the current game. Formerly mirrored into the
+ * Zustand store by the loadGame/advanceWeek/loadGameFromSave fan-out; Phase 3
+ * PR-9 moves ownership onto the TanStack Query cache. The fan-out seeds this key
+ * via `queryClient.setQueryData` (zero extra requests) and mutations invalidate
+ * it.
+ *
+ * Endpoint note: like projects (PR-7) and unlike releases/songs (PR-6), there is
+ * NO dedicated `GET /api/game/:id/artists` route on the server, and Phase 3 is
+ * client-only (no server changes). Artists arrive inside the `/api/game/:id`
+ * payload as `data.artists` — the exact same source the store read before. So the
+ * queryFn fetches `/api/game/:id` and selects `.artists`. In practice the fan-out
+ * pre-seeds the cache from the same body, so this queryFn only fires when a
+ * mutation invalidates the key (signArtist/updateArtist), faithfully re-reading
+ * the server's authoritative roster.
+ *
+ * Key convention mirrors `useProjects`/`useSongs`/`useReleases`: `[SCOPE, gameId]`.
+ * The scope constant and key builder are exported so `gameStore.ts` can
+ * seed/invalidate the exact same key and the query-key contract test can assert
+ * they match.
+ */
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { apiRequest } from '@/lib/queryClient';
+import type { Artist } from '@shared/schema';
+
+export const ARTISTS_SCOPE = 'artists:list';
+
+export function artistsQueryKey(gameId: string | null | undefined) {
+  return [ARTISTS_SCOPE, gameId ?? null] as const;
+}
+
+export function useArtists() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+
+  const queryKey = useMemo(() => artistsQueryKey(gameId), [gameId]);
+
+  return useQuery<Artist[]>({
+    queryKey,
+    enabled: Boolean(gameId),
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) return [];
+      // No dedicated artists endpoint (client-only PR): read the artists
+      // collection off the base game payload, matching the store's old source.
+      const response = await apiRequest('GET', `/api/game/${gameId}`);
+      const data = await response.json();
+      return Array.isArray(data?.artists) ? data.artists : [];
+    },
+  });
+}

--- a/client/src/hooks/useDiscoveredArtists.ts
+++ b/client/src/hooks/useDiscoveredArtists.ts
@@ -1,0 +1,94 @@
+/**
+ * Discovered A&R artists query hook (Phase 3 PR-9).
+ *
+ * The pool of artists surfaced by A&R sourcing operations. Formerly owned by the
+ * Zustand store (`discoveredArtists`, loaded by `loadDiscoveredArtists` via a raw
+ * `apiRequest` + a flags-fallback synthesis block). Phase 3 PR-9 moves the READ
+ * PATH onto the TanStack Query cache.
+ *
+ * Persistence note (plan step 4): the client `persist` partialize NEVER included
+ * `discoveredArtists` (only `gameState.id`, `selectedActions`, `isAdvancingWeek`
+ * — see gameStore.ts). Discovered artists survive a reload via the SERVER: the
+ * A&R GET reads the canonical `flags.ar_office_discovered_artists` array persisted
+ * in game state (server/routes/arOffice.ts, a pure read since Phase 2). So moving
+ * the read path behind this hook loses nothing across reloads — no client-side
+ * persistence is load-bearing here.
+ *
+ * The flags-fallback synthesis (the subtle part the plan calls out) is preserved
+ * VERBATIM below — byte-identical to the former `gameStore.loadDiscoveredArtists`
+ * body — so a legacy-only save (singular `ar_office_discovered_artist_id` flag
+ * set, array absent) still surfaces the singular artist locally.
+ *
+ * Key convention: scoped string at element 0, gameId at element 1
+ * (`[SCOPE, gameId]`), matching useEmails/useProjects. This hook supplies its own
+ * explicit queryFn (it does not route through the default getQueryFn that keys on
+ * the request URL at element 0).
+ */
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useGameStore } from '@/store/gameStore';
+import { apiRequest } from '@/lib/queryClient';
+
+export const DISCOVERED_ARTISTS_SCOPE = 'discovered-artists:list';
+
+export function discoveredArtistsQueryKey(gameId: string | null | undefined) {
+  return [DISCOVERED_ARTISTS_SCOPE, gameId ?? null] as const;
+}
+
+/**
+ * Fetch + synthesize discovered artists for a game. Exported so the store can
+ * seed/refetch this key through the same code path (e.g. after an A&R operation
+ * completes) and the query cache stays the single source of truth.
+ *
+ * The `flags` argument carries `gameState.flags` for the legacy singular-key
+ * fallback synthesis, preserved byte-identically from the former store action.
+ */
+export async function fetchDiscoveredArtists(
+  gameId: string,
+  flags: Record<string, any> | null | undefined,
+): Promise<any[]> {
+  const res = await apiRequest('GET', `/api/game/${gameId}/ar-office/artists`);
+  const data = await res.json();
+
+  let artists = Array.isArray(data.artists) ? data.artists : [];
+
+  // Enhanced fallback with better error messages
+  if ((!artists || artists.length === 0) && flags) {
+    const discoveredId = flags?.ar_office_discovered_artist_id;
+    const info = flags?.ar_office_discovered_artist_info || {};
+    if (discoveredId) {
+      const synthesized = {
+        id: discoveredId,
+        name: info.name ?? 'Unknown Artist',
+        archetype: info.archetype ?? 'Unknown',
+        talent: info.talent ?? 0,
+        popularity: info.popularity ?? 0,
+        genre: info.genre ?? null,
+        signed: false,
+      } as any;
+      artists = [synthesized];
+    }
+  }
+
+  return artists;
+}
+
+export function useDiscoveredArtists() {
+  const gameId = useGameStore((state) => state.gameState?.id);
+  const flags = useGameStore((state) => (state.gameState as any)?.flags);
+  const arOfficeSlotUsed = useGameStore((state) => state.gameState?.arOfficeSlotUsed);
+
+  const queryKey = useMemo(() => discoveredArtistsQueryKey(gameId), [gameId]);
+
+  return useQuery<any[]>({
+    queryKey,
+    // Mirror the store's old guard: only load when no A&R operation is active
+    // (an active operation always returns an empty list from the server).
+    enabled: Boolean(gameId) && !arOfficeSlotUsed,
+    staleTime: 30_000,
+    queryFn: async () => {
+      if (!gameId) return [];
+      return fetchDiscoveredArtists(gameId, flags);
+    },
+  });
+}

--- a/client/src/pages/AROffice.tsx
+++ b/client/src/pages/AROffice.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import GameLayout from '@/layouts/GameLayout';
 import { useGameContext } from '@/contexts/GameContext';
 import { useGameStore } from '@/store/gameStore';
+import { useArtists } from '@/hooks/useArtists';
 import { AROffice as AROfficeComponent } from '@/components/ar-office/AROffice';
 import type { GameState, Artist } from '@shared/schema';
 
 export default function AROffice() {
   const { gameId } = useGameContext();
-  const { gameState, artists, signArtist } = useGameStore();
+  const { gameState, signArtist } = useGameStore();
+  // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
+  const { data: artists = [] } = useArtists();
 
   if (!gameId || !gameState) {
     return null;

--- a/client/src/pages/ArtistPage.tsx
+++ b/client/src/pages/ArtistPage.tsx
@@ -21,6 +21,7 @@ import { useGameStore } from '@/store/gameStore';
 import { useReleases } from '@/hooks/useReleases';
 import { useSongs } from '@/hooks/useSongs';
 import { useProjects } from '@/hooks/useProjects';
+import { useArtists } from '@/hooks/useArtists';
 import { useLocation, useParams } from 'wouter';
 import { apiRequest } from '@/lib/queryClient';
 import { useArtistROI } from '@/hooks/useAnalytics';
@@ -36,12 +37,13 @@ export default function ArtistPage() {
   const params = useParams();
   const artistParam = params.artistParam; // Can be either ID or slug
   const [, setLocation] = useLocation();
-  const { gameState, artists } = useGameStore();
-  // Phase 3 PR-6/PR-7: releases / songs / projects read from the TanStack Query
-  // cache, not Zustand.
+  const { gameState } = useGameStore();
+  // Phase 3 PR-6/PR-7/PR-9: releases / songs / projects / artists read from the
+  // TanStack Query cache, not Zustand.
   const { data: releases = [] } = useReleases();
   const { data: storeSongs = [] } = useSongs();
   const { data: projects = [] } = useProjects();
+  const { data: artists = [] } = useArtists();
 
   // Find the actual artist first to get ID for ROI
   const foundArtist = artists ? findArtistBySlugOrId(artists, artistParam || '') : null;

--- a/client/src/pages/ArtistsLandingPage.tsx
+++ b/client/src/pages/ArtistsLandingPage.tsx
@@ -9,6 +9,7 @@ import { ArtistDialogueModal } from '../components/artist-dialogue/ArtistDialogu
 import { ArtistCard as RichArtistCard, getArchetypeInfo, getRelationshipStatus } from '../components/ArtistCard';
 import { useGameStore } from '../store/gameStore';
 import { useProjects } from '../hooks/useProjects';
+import { useArtists } from '../hooks/useArtists';
 import { usePortfolioROI, useArtistROI } from '../hooks/useAnalytics';
 import { generateArtistSlug } from '../utils/artistSlug';
 import { Card, CardContent } from '../components/ui/card';
@@ -50,9 +51,10 @@ const ArtistsLandingPage: React.FC = () => {
   const [expandedArtist, setExpandedArtist] = useState<string | null>(null);
   const [isDialogueModalOpen, setIsDialogueModalOpen] = useState(false);
   const [selectedArtistForDialogue, setSelectedArtistForDialogue] = useState<Artist | null>(null);
-  const { gameState, artists, signArtist, loadGame } = useGameStore();
-  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { gameState, signArtist, loadGame } = useGameStore();
+  // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
+  const { data: artists = [] } = useArtists();
   const { data: portfolioROI, isLoading: portfolioLoading, error: portfolioError } = usePortfolioROI();
 
   const signedArtists = artists || [];

--- a/client/src/pages/LivePerformancePage.tsx
+++ b/client/src/pages/LivePerformancePage.tsx
@@ -12,6 +12,7 @@ import type { GameState } from '@shared/schema';
 import { apiRequest } from '@/lib/queryClient';
 import { useGameStore } from '@/store/gameStore';
 import { useProjects } from '@/hooks/useProjects';
+import { useArtists } from '@/hooks/useArtists';
 import GameLayout from '@/layouts/GameLayout';
 
 
@@ -111,9 +112,10 @@ const PERFORMANCE_TYPES = [
 
 export default function LivePerformancePage() {
   const [, setLocation] = useLocation();
-  const { gameState, artists, createProject } = useGameStore();
-  // Phase 3 PR-7: projects are cache-owned; read via useProjects.
+  const { gameState, createProject } = useGameStore();
+  // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
+  const { data: artists = [] } = useArtists();
   const [isCreating, setIsCreating] = useState(false);
 
   const [selectedType, setSelectedType] = useState<'single_show' | 'mini_tour' | null>(null);

--- a/client/src/pages/MainMenuPage.tsx
+++ b/client/src/pages/MainMenuPage.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter';
 import { UserButton, useUser } from '@clerk/clerk-react';
 import { Button } from '@/components/ui/button';
 import { useGameStore } from '@/store/gameStore';
+import { useArtists } from '@/hooks/useArtists';
 import { useGameContext } from '@/contexts/GameContext';
 import { LabelCreationModal } from '@/components/LabelCreationModal';
 import { SaveGameModal } from '@/components/SaveGameModal';
@@ -15,7 +16,9 @@ export default function MainMenuPage() {
   const [, setLocation] = useLocation();
   const { user } = useUser();
   const { gameId, setGameId } = useGameContext();
-  const { gameState, createNewGame, artists } = useGameStore();
+  const { gameState, createNewGame } = useGameStore();
+  // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
+  const { data: artists = [] } = useArtists();
   const { isAdmin } = useIsAdmin();
   const [showLabelModal, setShowLabelModal] = useState(false);
   const [showLoadGameModal, setShowLoadGameModal] = useState(false);

--- a/client/src/pages/RecordingSessionPage.tsx
+++ b/client/src/pages/RecordingSessionPage.tsx
@@ -10,6 +10,7 @@ import { Plus, Music, Disc, MapPin, Star, Clock, Zap, Award, Loader2, AlertCircl
 import type { GameState } from '@shared/schema';
 import { apiRequest } from '@/lib/queryClient';
 import { useGameStore } from '@/store/gameStore';
+import { useArtists } from '@/hooks/useArtists';
 import GameLayout from '@/layouts/GameLayout';
 
 
@@ -137,7 +138,9 @@ interface ProjectTypeAPI {
 
 export default function RecordingSessionPage() {
   const [, setLocation] = useLocation();
-  const { gameState, artists, createProject } = useGameStore();
+  const { gameState, createProject } = useGameStore();
+  // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
+  const { data: artists = [] } = useArtists();
   const [isCreating, setIsCreating] = useState(false);
   const [selectedType, setSelectedType] = useState<'Single' | 'EP' | null>(null);
 

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -150,12 +150,27 @@ async function primeDiscoveredArtistsCache(gameState: GameState | null) {
 // Phase 3 PR-9: throwing variant used by advanceWeek's retry-with-backoff loop
 // (which relies on a rejected promise to trigger the next attempt). Seeds the
 // cache on success and RE-THROWS on failure so the retry logic is preserved
-// byte-for-byte from the former gameStore.loadDiscoveredArtists behavior.
+// byte-for-byte from the former gameStore.loadDiscoveredArtists behavior —
+// including its 404 short-circuit: a 404 is an immediately-accepted empty
+// result (seed [], no throw, no retries), matching the old
+// `if (status === 404) { set({ discoveredArtists: [] }); return; }` branch.
+// Any other failure seeds [] and re-throws so the backoff loop retries.
 async function refetchDiscoveredArtistsCache(gameState: GameState | null) {
   if (!gameState?.id) return;
   const flags = (gameState as any)?.flags;
-  const artists = await fetchDiscoveredArtists(gameState.id, flags);
-  queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), artists);
+  try {
+    const artists = await fetchDiscoveredArtists(gameState.id, flags);
+    queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), artists);
+  } catch (error) {
+    const status = (error as any)?.status;
+    if (status === 404) {
+      console.warn('[A&R] No discovered artists found (404) - treating as empty result');
+      queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), []);
+      return;
+    }
+    queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), []);
+    throw error; // Re-throw to allow retry logic to handle it
+  }
 }
 
 // Internal helper to sync focus slots and A&R operation status to the server

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { Artist, Role, WeeklyAction, MusicLabel, GameSaveSnapshot } from '@shared/schema';
+import type { Role, WeeklyAction, MusicLabel, GameSaveSnapshot } from '@shared/schema';
 import type { GameState, LabelData, SourcingTypeString } from '@shared/types/gameTypes';
 // Game engine moved to shared - client no longer calculates outcomes
 import { apiRequest, queryClient } from '@/lib/queryClient';
@@ -14,6 +14,11 @@ import { CHART_TOP10_SCOPE, CHART_TOP100_SCOPE } from '@/hooks/useCharts';
 import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { songsQueryKey } from '@/hooks/useSongs';
 import { projectsQueryKey } from '@/hooks/useProjects';
+import { artistsQueryKey } from '@/hooks/useArtists';
+import {
+  discoveredArtistsQueryKey,
+  fetchDiscoveredArtists,
+} from '@/hooks/useDiscoveredArtists';
 
 // Internal helper: the shared 6-endpoint + email-snapshot parallel reload used
 // identically by loadGame / loadGameFromSave / advanceWeek. Fans out the same
@@ -71,6 +76,12 @@ async function fetchGameBundle(gameId: string): Promise<GameBundle> {
   // reads this key; callers no longer write `projects` into the store.
   seedProjectsCache(gameId, gameData?.projects);
 
+  // Phase 3 PR-9: the artists roster is cache-owned too. Like projects, there is
+  // no dedicated artists endpoint — artists arrive inside the base game payload
+  // (`gameData.artists`), so seed from there (zero extra GETs). useArtists reads
+  // this key; callers no longer write `artists` into the store.
+  seedArtistsCache(gameId, gameData?.artists);
+
   return { gameData, songs, releases, releaseSongs, executives, moodEvents, emails };
 }
 
@@ -106,6 +117,47 @@ function seedProjectsCache(gameId: string, projects: unknown) {
   );
 }
 
+// Phase 3 PR-9: seed the artists query cache from an already-fetched game
+// payload (or a save snapshot) so useArtists reads fresh data with no extra
+// round-trip. Coerced to [] to match the hook's queryFn contract (it always
+// resolves an array).
+function seedArtistsCache(gameId: string, artists: unknown) {
+  queryClient.setQueryData(
+    artistsQueryKey(gameId),
+    Array.isArray(artists) ? artists : [],
+  );
+}
+
+// Phase 3 PR-9: prime the discovered-artists query cache through the same
+// fetch+synthesis code path useDiscoveredArtists uses. Replaces the former
+// gameStore.loadDiscoveredArtists store write — the read path now lives entirely
+// in the query cache (hooks/useDiscoveredArtists.ts). Best-effort: on failure it
+// seeds [] (mirroring the old action's catch-and-empty for 404s) so a transient
+// A&R read error never surfaces stale data. Errors are swallowed here because
+// UI-driven retries (AROffice) invalidate the key and let the hook refetch.
+async function primeDiscoveredArtistsCache(gameState: GameState | null) {
+  if (!gameState?.id) return;
+  const flags = (gameState as any)?.flags;
+  try {
+    const artists = await fetchDiscoveredArtists(gameState.id, flags);
+    queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), artists);
+  } catch (error) {
+    console.error('[A&R] Failed to prime discovered artists cache:', error);
+    queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), []);
+  }
+}
+
+// Phase 3 PR-9: throwing variant used by advanceWeek's retry-with-backoff loop
+// (which relies on a rejected promise to trigger the next attempt). Seeds the
+// cache on success and RE-THROWS on failure so the retry logic is preserved
+// byte-for-byte from the former gameStore.loadDiscoveredArtists behavior.
+async function refetchDiscoveredArtistsCache(gameState: GameState | null) {
+  if (!gameState?.id) return;
+  const flags = (gameState as any)?.flags;
+  const artists = await fetchDiscoveredArtists(gameState.id, flags);
+  queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), artists);
+}
+
 // Internal helper to sync focus slots and A&R operation status to the server
 async function syncSlotsPatch(
   gameId: string,
@@ -125,7 +177,6 @@ async function syncSlotsPatch(
 interface GameStore {
   // Game state
   gameState: GameState | null;
-  artists: Artist[];
   roles: Role[];
   weeklyActions: WeeklyAction[];
   // Phase 3 PR-6: songs / releases / releaseSongs are no longer owned by the
@@ -135,13 +186,13 @@ interface GameStore {
   // Phase 3 PR-7: `projects` is likewise cache-owned (hooks/useProjects.ts).
   // Consumers read it via useProjects; the fan-out seeds the cache and the
   // createProject/updateProject/cancelProject mutations invalidate it.
+  // Phase 3 PR-9: `artists` (roster) and `discoveredArtists` are cache-owned too
+  // (hooks/useArtists.ts, hooks/useDiscoveredArtists.ts). Consumers read them via
+  // useArtists / useDiscoveredArtists; the fan-out seeds the artists cache and
+  // signArtist/updateArtist invalidate it.
   emails: any[]; // Email system support
   executives: any[];
   moodEvents: any[];
-
-  // Discovered A&R artists (persisted client-side)
-  discoveredArtists: Artist[];
-  loadingDiscoveredArtists?: boolean;
 
   // UI state
   selectedActions: string[];
@@ -173,11 +224,6 @@ interface GameStore {
   startAROfficeOperation: (sourcingType: SourcingTypeString, primaryGenre?: string, secondaryGenre?: string) => Promise<void>;
   cancelAROfficeOperation: () => Promise<void>;
 
-  // Discovered artists lifecycle
-  loadDiscoveredArtists: () => Promise<void>;
-  clearDiscoveredArtists: () => void;
-  removeDiscoveredArtist: (artistId: string) => void;
-  
   // Artist management
   signArtist: (artistData: any) => Promise<void>;
   updateArtist: (artistId: string, updates: any) => Promise<void>;
@@ -199,13 +245,11 @@ export const useGameStore = create<GameStore>()(
     (set, get) => ({
       // Initial state
       gameState: null,
-      artists: [],
       roles: [],
       weeklyActions: [],
       emails: [],
       executives: [],
       moodEvents: [],
-      discoveredArtists: [],
       selectedActions: [],
       isAdvancingWeek: false,
       weeklyOutcome: null,
@@ -249,12 +293,11 @@ export const useGameStore = create<GameStore>()(
             musicLabel: data.musicLabel || null
           };
 
-          // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are
-          // seeded into the TanStack Query cache by fetchGameBundle — no longer
-          // written here.
+          // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /
+          // artists are seeded into the TanStack Query cache by fetchGameBundle —
+          // no longer written here.
           set({
             gameState: gameStateWithLabel,
-            artists: data.artists,
             roles: data.roles,
             weeklyActions: data.weeklyActions,
             emails: emailList,
@@ -263,9 +306,11 @@ export const useGameStore = create<GameStore>()(
             selectedActions: []
           });
 
-          // After loading game, try to load discovered artists if no active operation
+          // Phase 3 PR-9: discovered artists are cache-owned (useDiscoveredArtists).
+          // After loading game, prime the discovered-artists cache if no active
+          // operation, so consumers see them without a separate store load.
           if (!arOfficeSlotUsed) {
-            await get().loadDiscoveredArtists();
+            await primeDiscoveredArtistsCache(gameStateWithLabel);
           }
         } catch (error) {
           console.error('Failed to load game:', error);
@@ -319,10 +364,13 @@ export const useGameStore = create<GameStore>()(
           // projects show immediately; the post-restore fetchGameBundle below
           // re-seeds with the server's authoritative copy.
           seedProjectsCache(baseGameState.id, snapshot.projects || []);
+          // Phase 3 PR-9: seed the artists cache from the snapshot so the restored
+          // roster shows immediately; the post-restore fetchGameBundle re-seeds
+          // with the server's authoritative copy.
+          seedArtistsCache(baseGameState.id, snapshot.artists || []);
 
           set({
             gameState: interimGameState,
-            artists: (snapshot.artists || []) as unknown as Artist[],
             roles: (snapshot.roles || []) as unknown as Role[],
             emails: snapshot.emails || [],
             executives: snapshot.executives || [],
@@ -357,12 +405,11 @@ export const useGameStore = create<GameStore>()(
             arOfficeSourcingType: gameData.gameState?.arOfficeSourcingType ?? null,
           };
 
-          // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects seeded
-          // into the query cache by fetchGameBundle above — no longer written
-          // into the store.
+          // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /
+          // artists seeded into the query cache by fetchGameBundle above — no
+          // longer written into the store.
           set({
             gameState: syncedGameState,
-            artists: gameData.artists || [],
             roles: gameData.roles || [],
             weeklyActions: gameData.weeklyActions || [],
             emails: emailList || [],
@@ -374,7 +421,7 @@ export const useGameStore = create<GameStore>()(
           });
 
           if (!syncedGameState.arOfficeSlotUsed) {
-            await get().loadDiscoveredArtists();
+            await primeDiscoveredArtistsCache(syncedGameState);
           }
 
           // Invalidate email cache so the inbox reflects the restored save immediately
@@ -510,11 +557,14 @@ export const useGameStore = create<GameStore>()(
           seedReleaseAndSongCache(gameState.id, { songs: [], releases: [], releaseSongs: [] });
           // Phase 3 PR-7: seed the new game's projects cache empty too.
           seedProjectsCache(gameState.id, []);
+          // Phase 3 PR-9: seed the new game's artists + discovered-artists caches
+          // empty so the hooks read [] rather than any stale prior-game data.
+          seedArtistsCache(gameState.id, []);
+          queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), []);
 
           // Clear campaign results and set new state
           set({
             gameState: syncedGameState,
-            artists: [],
             roles: [],
             weeklyActions: [],
             emails: [],
@@ -775,12 +825,12 @@ export const useGameStore = create<GameStore>()(
             musicLabel: gameData.musicLabel || (resultGameState as any)?.musicLabel || null,
           } as GameState;
 
-          // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects seeded
-          // into the query cache by fetchGameBundle — no longer written into the
-          // store.
+          // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /
+          // artists seeded into the query cache by fetchGameBundle — no longer
+          // written into the store. The artists seed reflects post-week mood
+          // changes (formerly `artists: gameData.artists`).
           set({
             gameState: syncedGameState,
-            artists: gameData.artists || [], // Update artists to reflect mood changes
             emails: emailList || [],
             executives: Array.isArray(executivesData) ? executivesData : [],
             moodEvents: Array.isArray(moodEventsData) ? moodEventsData : [],
@@ -818,7 +868,7 @@ export const useGameStore = create<GameStore>()(
             // Enhanced retry logic with exponential backoff
             const loadWithRetry = async (attempt = 1): Promise<void> => {
               try {
-                await get().loadDiscoveredArtists();
+                await refetchDiscoveredArtistsCache(get().gameState);
                 console.log(`[A&R] Successfully loaded discovered artists (attempt ${attempt})`);
               } catch (error) {
                 console.error(`[A&R] Failed to load discovered artists (attempt ${attempt}):`, error);
@@ -925,36 +975,40 @@ export const useGameStore = create<GameStore>()(
 
       // Artist management
       signArtist: async (artistData: any) => {
-        const { gameState, artists, removeDiscoveredArtist } = get();
+        const { gameState } = get();
         if (!gameState) return;
 
         try {
-          const response = await apiRequest('POST', `/api/game/${gameState.id}/artists`, {
+          await apiRequest('POST', `/api/game/${gameState.id}/artists`, {
             ...artistData,
             signedWeek: gameState.currentWeek,
             signed: true
           });
-          const newArtist = await response.json();
-          
-          // Update both artists and game state (to reflect money deduction)
+
+          // Phase 3 PR-9: the roster is cache-owned now. Invalidate the artists
+          // key so useArtists refetches the authoritative roster (which includes
+          // the just-signed artist) instead of hand-appending to a store array.
+          // The money optimistic delta is UNTOUCHED (that's PR-10) — it stays as
+          // a client-side subtraction against gameState.money.
           const signingCost = artistData.signingCost || 0;
-          set({ 
-            artists: [...artists, newArtist],
+          set({
             gameState: {
               ...gameState,
               money: Math.max(0, (gameState.money || 0) - signingCost)
             }
           });
+          await queryClient.invalidateQueries({
+            queryKey: artistsQueryKey(gameState.id),
+          });
 
-          // If this artist was in discovered list, remove using the discovered (content) ID or name
-          if (artistData?.id) {
-            removeDiscoveredArtist(artistData.id);
-          } else if (artistData?.name) {
-            // Fallback: remove by name match if ID is unavailable
-            const current = get().discoveredArtists;
-            const toRemove = current.find(a => (a as any).name?.toLowerCase() === String(artistData.name).toLowerCase());
-            if (toRemove?.id) removeDiscoveredArtist(toRemove.id);
-          }
+          // Phase 3 PR-9: the discovered-artists list is cache-owned too. The
+          // signed artist should drop out of it; the server's A&R read already
+          // filters signed-by-name, so invalidating the discovered key refetches
+          // the correct (reduced) list. Replaces the former removeDiscoveredArtist
+          // splice by id/name.
+          await queryClient.invalidateQueries({
+            queryKey: discoveredArtistsQueryKey(gameState.id),
+          });
         } catch (error) {
           console.error('Failed to sign artist:', error);
           throw error;
@@ -962,14 +1016,15 @@ export const useGameStore = create<GameStore>()(
       },
 
       updateArtist: async (artistId: string, updates: any) => {
-        const { artists } = get();
+        const { gameState } = get();
 
         try {
-          const response = await apiRequest('PATCH', `/api/artists/${artistId}`, updates);
-          const updatedArtist = await response.json();
-          
-          set({
-            artists: artists.map(a => a.id === artistId ? updatedArtist : a)
+          await apiRequest('PATCH', `/api/artists/${artistId}`, updates);
+
+          // Phase 3 PR-9: invalidate the artists cache so useArtists refetches the
+          // updated artist instead of mapping over a store-owned array.
+          await queryClient.invalidateQueries({
+            queryKey: artistsQueryKey(gameState?.id),
           });
         } catch (error) {
           console.error('Failed to update artist:', error);
@@ -1200,85 +1255,19 @@ export const useGameStore = create<GameStore>()(
       },
 
       // Save game
-      // Discovered artists lifecycle
-      loadDiscoveredArtists: async () => {
-        const { gameState } = get();
-        if (!gameState) {
-          console.warn('[A&R] No game state available for loading discovered artists');
-          return;
-        }
-
-        // Check if already loading to prevent concurrent requests
-        const loadingFlag = get().loadingDiscoveredArtists;
-        if (loadingFlag) {
-          console.log('[A&R] Already loading discovered artists, skipping duplicate request');
-          return;
-        }
-
-        try {
-          // Set loading flag
-          set({ loadingDiscoveredArtists: true });
-
-          const res = await apiRequest('GET', `/api/game/${gameState.id}/ar-office/artists`);
-          const data = await res.json();
-
-          let artists = Array.isArray(data.artists) ? data.artists : [];
-
-          // Enhanced fallback with better error messages
-          if ((!artists || artists.length === 0) && (gameState as any)?.flags) {
-            const flags: any = (gameState as any).flags;
-            const discoveredId = flags?.ar_office_discovered_artist_id;
-            const info = flags?.ar_office_discovered_artist_info || {};
-            if (discoveredId) {
-              const synthesized = {
-                id: discoveredId,
-                name: info.name ?? 'Unknown Artist',
-                archetype: info.archetype ?? 'Unknown',
-                talent: info.talent ?? 0,
-                popularity: info.popularity ?? 0,
-                genre: info.genre ?? null,
-                signed: false,
-              } as any;
-              artists = [synthesized];
-            }
-          }
-
-          set({ discoveredArtists: artists });
-        } catch (error) {
-          console.error('[A&R] Failed to load discovered artists:', error);
-
-          // Provide more specific error information
-          const status = (error as any)?.status;
-          if (status === 404) {
-            console.warn('[A&R] No discovered artists found (404) - treating as empty result');
-            set({ discoveredArtists: [] });
-            return;
-          }
-
-          if (error instanceof Error && error.message.includes('500')) {
-            console.error('[A&R] Server error while loading discovered artists');
-          }
-
-          set({ discoveredArtists: [] });
-          throw error; // Re-throw to allow retry logic to handle it
-        } finally {
-          // Clear loading flag
-          set({ loadingDiscoveredArtists: false });
-        }
-      },
-      clearDiscoveredArtists: () => {
-        console.log('[A&R] Clearing discovered artists list');
-        set({ discoveredArtists: [] });
-      },
-      removeDiscoveredArtist: (artistId: string) => {
-        const { discoveredArtists } = get();
-        set({ discoveredArtists: discoveredArtists.filter((a: any) => a.id !== artistId) });
-      },
-
+      //
+      // Phase 3 PR-9: the discovered-artists lifecycle (loadDiscoveredArtists /
+      // clearDiscoveredArtists / removeDiscoveredArtist) was removed from the
+      // store. The READ path now lives in the TanStack Query cache via
+      // hooks/useDiscoveredArtists.ts. loadGame/loadGameFromSave prime the cache
+      // (primeDiscoveredArtistsCache); advanceWeek refetches it on A&R completion
+      // (refetchDiscoveredArtistsCache); signArtist invalidates the discovered key
+      // so a signed artist drops out. The A&R server GET is a pure read (Phase 2),
+      // so discovered artists survive a reload via the server — no client-side
+      // persistence was load-bearing (they were never in the persist partialize).
       saveGame: async (name: string, options?: { isAutosave?: boolean }) => {
         const {
           gameState,
-          artists,
           roles,
           executives,
           moodEvents,
@@ -1287,16 +1276,17 @@ export const useGameStore = create<GameStore>()(
         } = get();
         if (!gameState) return;
 
-        // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are no
-        // longer store-owned. Source them from the TanStack Query cache (seeded
-        // by the fan-out) so the snapshot shape is byte-identical to before.
-        // Autosave runs right after advanceWeek's fan-out, so the cache is
+        // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /
+        // artists are no longer store-owned. Source them from the TanStack Query
+        // cache (seeded by the fan-out) so the snapshot shape is byte-identical to
+        // before. Autosave runs right after advanceWeek's fan-out, so the cache is
         // freshly populated here.
         const songs = queryClient.getQueryData<any[]>(songsQueryKey(gameState.id)) ?? [];
         const releases = queryClient.getQueryData<any[]>(releasesQueryKey(gameState.id)) ?? [];
         const releaseSongs =
           queryClient.getQueryData<any[]>(releaseSongsQueryKey(gameState.id)) ?? [];
         const projects = queryClient.getQueryData<any[]>(projectsQueryKey(gameState.id)) ?? [];
+        const artists = queryClient.getQueryData<any[]>(artistsQueryKey(gameState.id)) ?? [];
 
         try {
           const { emailSnapshot, releaseSongs: releaseSongsSnapshot, executives: executivesSnapshot, moodEvents: moodEventsSnapshot } =

--- a/tests/client/gameStore-actions.characterization.test.ts
+++ b/tests/client/gameStore-actions.characterization.test.ts
@@ -34,6 +34,8 @@ import { apiRequest, queryClient } from '@/lib/queryClient';
 import { songsQueryKey } from '@/hooks/useSongs';
 import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { projectsQueryKey } from '@/hooks/useProjects';
+import { artistsQueryKey } from '@/hooks/useArtists';
+import { discoveredArtistsQueryKey } from '@/hooks/useDiscoveredArtists';
 import { useGameStore } from '@/store/gameStore';
 import {
   routeApiRequest as routeApiRequestImpl,
@@ -54,8 +56,14 @@ beforeEach(() => {
 });
 
 describe('signArtist optimistic delta', () => {
-  it('deducts signingCost from money and appends the returned artist', async () => {
-    useGameStore.setState({ gameState: baseGameState({ money: 100000 }), artists: [] });
+  // Phase 3 PR-9 CHANGE: the roster is cache-owned now. signArtist no longer
+  // appends the returned artist into a store `artists` array; it invalidates the
+  // artists query key (so useArtists refetches the authoritative roster) AND the
+  // discovered-artists key (so the signed artist drops out of the discovered
+  // list). The money optimistic math is UNTOUCHED (that's PR-10), so those pins
+  // stay identical — only the array-append pin becomes invalidation pins.
+  it('deducts signingCost from money and invalidates the artists + discovered caches', async () => {
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 100000 }) });
     const newArtist = { id: 'artist-99', name: 'Signed One' };
     routeApiRequest([{ match: (u) => u.includes('/artists'), body: newArtist }]);
 
@@ -63,11 +71,18 @@ describe('signArtist optimistic delta', () => {
 
     const state = useGameStore.getState();
     expect(state.gameState!.money).toBe(85000); // 100000 - 15000
-    expect(state.artists).toEqual([newArtist]);
+    // Roster no longer lives in the store; the mutation invalidates the cache.
+    expect((state as any).artists).toBeUndefined();
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: artistsQueryKey('game-1'),
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: discoveredArtistsQueryKey('game-1'),
+    });
   });
 
   it('clamps money at 0 (Math.max floor) when signingCost exceeds balance', async () => {
-    useGameStore.setState({ gameState: baseGameState({ money: 5000 }), artists: [] });
+    useGameStore.setState({ gameState: baseGameState({ money: 5000 }) });
     routeApiRequest([{ match: (u) => u.includes('/artists'), body: { id: 'a1' } }]);
 
     await useGameStore.getState().signArtist({ signingCost: 15000 });
@@ -76,7 +91,7 @@ describe('signArtist optimistic delta', () => {
   });
 
   it('treats a missing signingCost as 0 (no money change)', async () => {
-    useGameStore.setState({ gameState: baseGameState({ money: 42000 }), artists: [] });
+    useGameStore.setState({ gameState: baseGameState({ money: 42000 }) });
     routeApiRequest([{ match: (u) => u.includes('/artists'), body: { id: 'a1' } }]);
 
     await useGameStore.getState().signArtist({ name: 'No Cost' });
@@ -225,7 +240,8 @@ describe('loadGame set(...) state shape', () => {
     expect(state.gameState!.id).toBe('game-1');
     expect((state.gameState as any).musicLabel).toEqual({ name: 'Loaded Label' });
     expect((state.gameState as any).usedFocusSlots).toBe(0);
-    expect(state.artists).toEqual([{ id: 'a1' }]);
+    // PR-9: artists are seeded into the query cache, not the store.
+    expect((state as any).artists).toBeUndefined();
     expect(state.roles).toEqual([{ id: 'role1' }]);
     expect(state.weeklyActions).toEqual([{ id: 'wa1' }]);
     expect(state.emails).toEqual([{ id: 'em1' }]);
@@ -240,11 +256,14 @@ describe('loadGame set(...) state shape', () => {
     expect(queryClient.getQueryData(releasesQueryKey('game-1'))).toEqual([{ id: 'r1' }]);
     expect(queryClient.getQueryData(releaseSongsQueryKey('game-1'))).toEqual([{ id: 'rs1' }]);
     expect(queryClient.getQueryData(projectsQueryKey('game-1'))).toEqual([{ id: 'p1' }]);
+    // PR-9: artists seeded from the base game payload's `artists` field.
+    expect(queryClient.getQueryData(artistsQueryKey('game-1'))).toEqual([{ id: 'a1' }]);
     // And the store no longer exposes them.
     expect((state as any).songs).toBeUndefined();
     expect((state as any).releases).toBeUndefined();
     expect((state as any).releaseSongs).toBeUndefined();
     expect((state as any).projects).toBeUndefined();
+    expect((state as any).artists).toBeUndefined();
   });
 });
 
@@ -284,7 +303,8 @@ describe('advanceWeek set(...) state shape', () => {
 
     const state = useGameStore.getState();
     expect((state.gameState as any).currentWeek).toBe(6);
-    expect(state.artists).toEqual([{ id: 'a1' }]);
+    // PR-9: artists are seeded into the query cache, not the store.
+    expect((state as any).artists).toBeUndefined();
     expect(state.emails).toEqual([{ id: 'em1' }]);
     expect(state.executives).toEqual([{ id: 'e1' }]);
     expect(state.moodEvents).toEqual([{ id: 'm1' }]);
@@ -300,9 +320,13 @@ describe('advanceWeek set(...) state shape', () => {
     expect(queryClient.getQueryData(releasesQueryKey('game-1'))).toEqual([{ id: 'r1' }]);
     expect(queryClient.getQueryData(releaseSongsQueryKey('game-1'))).toEqual([{ id: 'rs1' }]);
     expect(queryClient.getQueryData(projectsQueryKey('game-1'))).toEqual([{ id: 'p1' }]);
+    // PR-9: artists seeded from the base game payload's `artists` field (reflects
+    // post-week mood changes).
+    expect(queryClient.getQueryData(artistsQueryKey('game-1'))).toEqual([{ id: 'a1' }]);
     expect((state as any).songs).toBeUndefined();
     expect((state as any).releases).toBeUndefined();
     expect((state as any).releaseSongs).toBeUndefined();
     expect((state as any).projects).toBeUndefined();
+    expect((state as any).artists).toBeUndefined();
   });
 });

--- a/tests/client/gameStore-harness.ts
+++ b/tests/client/gameStore-harness.ts
@@ -43,22 +43,19 @@ export function routeApiRequest(
 export function resetGameStore(useGameStore: Store) {
   useGameStore.setState({
     gameState: null,
-    artists: [],
     roles: [],
     weeklyActions: [],
-    // Phase 3 PR-6/PR-7: songs / releases / releaseSongs / projects are no
-    // longer store-owned (they live in the TanStack Query cache), so they are
-    // not reset here.
+    // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects / artists
+    // / discoveredArtists are no longer store-owned (they live in the TanStack
+    // Query cache), so they are not reset here.
     emails: [],
     executives: [],
     moodEvents: [],
-    discoveredArtists: [],
-    loadingDiscoveredArtists: false,
     selectedActions: [],
     isAdvancingWeek: false,
     weeklyOutcome: null,
     campaignResults: null,
-  });
+  } as any);
 }
 
 /** A representative full-ish GameState fixture for optimistic-delta pins. */

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -31,6 +31,11 @@ import {
 } from '@/hooks/useReleases';
 import { SONGS_SCOPE, songsQueryKey } from '@/hooks/useSongs';
 import { PROJECTS_SCOPE, projectsQueryKey } from '@/hooks/useProjects';
+import { ARTISTS_SCOPE, artistsQueryKey } from '@/hooks/useArtists';
+import {
+  DISCOVERED_ARTISTS_SCOPE,
+  discoveredArtistsQueryKey,
+} from '@/hooks/useDiscoveredArtists';
 
 const GAME_ID = 'game-1';
 const ARTIST_ID = 'artist-1';
@@ -61,6 +66,10 @@ const REAL_QUERY_KEYS: readonly unknown[][] = [
   [...songsQueryKey(GAME_ID)],
   // Projects (useProjects.ts, PR-7): [SCOPE, gameId]
   [...projectsQueryKey(GAME_ID)],
+  // Artists / discovered artists (useArtists.ts, useDiscoveredArtists.ts, PR-9):
+  // [SCOPE, gameId]
+  [...artistsQueryKey(GAME_ID)],
+  [...discoveredArtistsQueryKey(GAME_ID)],
   ['api', 'saves'],
 ];
 
@@ -157,6 +166,31 @@ describe('query-key contract: project mutation invalidations (PR-7)', () => {
 
   it('the projects scope constant and hook key agree element-for-element', () => {
     expect(projectsQueryKey(GAME_ID)).toEqual([PROJECTS_SCOPE, GAME_ID]);
+  });
+});
+
+describe('query-key contract: artist mutation invalidations (PR-9)', () => {
+  // signArtist / updateArtist invalidate the artists cache with the EXACT scoped
+  // key (client/src/store/gameStore.ts): artistsQueryKey == [ARTISTS_SCOPE,
+  // gameId]. signArtist additionally invalidates the discovered-artists cache
+  // (discoveredArtistsQueryKey == [DISCOVERED_ARTISTS_SCOPE, gameId]) so the
+  // signed artist drops out of the discovered list. Assert each matches its hook.
+  it('artist mutation invalidation matches the useArtists hook key', () => {
+    expect(someRealKeyMatchesInvalidationKey(artistsQueryKey(GAME_ID))).toBe(true);
+  });
+
+  it('signArtist discovered invalidation matches the useDiscoveredArtists hook key', () => {
+    expect(someRealKeyMatchesInvalidationKey(discoveredArtistsQueryKey(GAME_ID))).toBe(true);
+  });
+
+  it('the artist invalidations do NOT match a different game', () => {
+    expect(someRealKeyMatchesInvalidationKey(artistsQueryKey('other'))).toBe(false);
+    expect(someRealKeyMatchesInvalidationKey(discoveredArtistsQueryKey('other'))).toBe(false);
+  });
+
+  it('the artist scope constants and hook keys agree element-for-element', () => {
+    expect(artistsQueryKey(GAME_ID)).toEqual([ARTISTS_SCOPE, GAME_ID]);
+    expect(discoveredArtistsQueryKey(GAME_ID)).toEqual([DISCOVERED_ARTISTS_SCOPE, GAME_ID]);
   });
 });
 

--- a/tests/client/useArtists.test.tsx
+++ b/tests/client/useArtists.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * useArtists hook test (Phase 3 PR-9).
+ *
+ * Mocks `apiRequest` and `useGameStore` to verify the artists hook fetches the
+ * base game endpoint, selects `.artists` from the payload, keys its query by the
+ * scoped [SCOPE, gameId] shape, and skips fetching when there's no active game.
+ * Like projects (PR-7) and unlike releases/songs (PR-6) there is NO dedicated
+ * artists endpoint — artists arrive inside `/api/game/:id`, so the queryFn selects
+ * them from there.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/queryClient', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/queryClient')>('@/lib/queryClient');
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: vi.fn(),
+}));
+
+import { apiRequest } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import { useArtists, ARTISTS_SCOPE, artistsQueryKey } from '@/hooks/useArtists';
+
+const mockedApiRequest = vi.mocked(apiRequest);
+const mockedUseGameStore = vi.mocked(useGameStore);
+
+function jsonResponse(body: unknown): Response {
+  return { json: async () => body } as unknown as Response;
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return queryClient;
+}
+
+function TestArtists() {
+  const { data, isLoading } = useArtists();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="artists">{JSON.stringify(data)}</div>;
+}
+
+describe('useArtists', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+    mockedUseGameStore.mockReset();
+  });
+
+  it('fetches the base game endpoint and selects the artists array', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(
+      jsonResponse({ gameState: { id: 'game-1' }, artists: [{ id: 'a1' }, { id: 'a2' }] }),
+    );
+
+    renderWithClient(<TestArtists />);
+
+    await waitFor(() => expect(screen.getByTestId('artists')).toBeTruthy());
+
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1');
+    expect(screen.getByTestId('artists').textContent).toBe(
+      JSON.stringify([{ id: 'a1' }, { id: 'a2' }]),
+    );
+  });
+
+  it('resolves [] when the payload has no artists field', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: { id: 'game-1' } }));
+    mockedApiRequest.mockResolvedValue(jsonResponse({ gameState: { id: 'game-1' } }));
+
+    renderWithClient(<TestArtists />);
+
+    await waitFor(() => expect(screen.getByTestId('artists')).toBeTruthy());
+    expect(screen.getByTestId('artists').textContent).toBe('[]');
+  });
+
+  it('does not fetch when there is no active game', async () => {
+    mockedUseGameStore.mockImplementation((selector: any) => selector({ gameState: null }));
+
+    renderWithClient(<TestArtists />);
+
+    // Query stays disabled; no apiRequest call should ever fire.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('scope constant and key builder match the store invalidation shape', () => {
+    expect(ARTISTS_SCOPE).toBe('artists:list');
+    expect(artistsQueryKey('game-1')).toEqual(['artists:list', 'game-1']);
+  });
+});

--- a/tests/client/useDiscoveredArtists.test.tsx
+++ b/tests/client/useDiscoveredArtists.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * useDiscoveredArtists hook test (Phase 3 PR-9).
+ *
+ * Mocks `apiRequest` and `useGameStore` to verify the discovered-artists hook:
+ *  - fetches the A&R endpoint and returns `data.artists`,
+ *  - preserves the flags-fallback SYNTHESIS verbatim (legacy singular
+ *    `ar_office_discovered_artist_id` -> a synthesized artist) when the server
+ *    returns an empty list,
+ *  - stays disabled while an A&R operation is active (arOfficeSlotUsed),
+ *  - keys its query by the scoped [SCOPE, gameId] shape.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/queryClient', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/queryClient')>('@/lib/queryClient');
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
+
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: vi.fn(),
+}));
+
+import { apiRequest } from '@/lib/queryClient';
+import { useGameStore } from '@/store/gameStore';
+import {
+  useDiscoveredArtists,
+  fetchDiscoveredArtists,
+  DISCOVERED_ARTISTS_SCOPE,
+  discoveredArtistsQueryKey,
+} from '@/hooks/useDiscoveredArtists';
+
+const mockedApiRequest = vi.mocked(apiRequest);
+const mockedUseGameStore = vi.mocked(useGameStore);
+
+function jsonResponse(body: unknown): Response {
+  return { json: async () => body } as unknown as Response;
+}
+
+/** Drive the three separate selectors the hook reads off a single state object. */
+function mockStore(state: any) {
+  mockedUseGameStore.mockImplementation((selector: any) => selector(state));
+}
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return queryClient;
+}
+
+function TestDiscovered() {
+  const { data, isLoading } = useDiscoveredArtists();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="discovered">{JSON.stringify(data)}</div>;
+}
+
+describe('useDiscoveredArtists', () => {
+  beforeEach(() => {
+    mockedApiRequest.mockReset();
+    mockedUseGameStore.mockReset();
+  });
+
+  it('fetches the A&R endpoint and returns data.artists', async () => {
+    mockStore({ gameState: { id: 'game-1', arOfficeSlotUsed: false, flags: {} } });
+    mockedApiRequest.mockResolvedValue(jsonResponse({ artists: [{ id: 'd1' }, { id: 'd2' }] }));
+
+    renderWithClient(<TestDiscovered />);
+
+    await waitFor(() => expect(screen.getByTestId('discovered')).toBeTruthy());
+    expect(mockedApiRequest).toHaveBeenCalledWith('GET', '/api/game/game-1/ar-office/artists');
+    expect(screen.getByTestId('discovered').textContent).toBe(
+      JSON.stringify([{ id: 'd1' }, { id: 'd2' }]),
+    );
+  });
+
+  it('synthesizes the legacy singular flag artist when the server list is empty', async () => {
+    mockStore({
+      gameState: {
+        id: 'game-1',
+        arOfficeSlotUsed: false,
+        flags: {
+          ar_office_discovered_artist_id: 'legacy-1',
+          ar_office_discovered_artist_info: {
+            name: 'Legacy Star',
+            archetype: 'Visionary',
+            talent: 77,
+            popularity: 12,
+            genre: 'pop',
+          },
+        },
+      },
+    });
+    mockedApiRequest.mockResolvedValue(jsonResponse({ artists: [] }));
+
+    renderWithClient(<TestDiscovered />);
+
+    await waitFor(() => expect(screen.getByTestId('discovered')).toBeTruthy());
+    expect(screen.getByTestId('discovered').textContent).toBe(
+      JSON.stringify([
+        {
+          id: 'legacy-1',
+          name: 'Legacy Star',
+          archetype: 'Visionary',
+          talent: 77,
+          popularity: 12,
+          genre: 'pop',
+          signed: false,
+        },
+      ]),
+    );
+  });
+
+  it('does not fetch while an A&R operation is active', async () => {
+    mockStore({ gameState: { id: 'game-1', arOfficeSlotUsed: true, flags: {} } });
+
+    renderWithClient(<TestDiscovered />);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when there is no active game', async () => {
+    mockStore({ gameState: null });
+
+    renderWithClient(<TestDiscovered />);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(mockedApiRequest).not.toHaveBeenCalled();
+  });
+
+  it('fetchDiscoveredArtists synthesizes verbatim with default fields for a bare legacy id', async () => {
+    // No info object: every field falls back to the synthesis defaults, matching
+    // the former gameStore.loadDiscoveredArtists block byte-for-byte.
+    mockedApiRequest.mockResolvedValue(jsonResponse({ artists: [] }));
+    const result = await fetchDiscoveredArtists('game-1', {
+      ar_office_discovered_artist_id: 'legacy-2',
+    });
+    expect(result).toEqual([
+      {
+        id: 'legacy-2',
+        name: 'Unknown Artist',
+        archetype: 'Unknown',
+        talent: 0,
+        popularity: 0,
+        genre: null,
+        signed: false,
+      },
+    ]);
+  });
+
+  it('scope constant and key builder match the store invalidation shape', () => {
+    expect(DISCOVERED_ARTISTS_SCOPE).toBe('discovered-artists:list');
+    expect(discoveredArtistsQueryKey('game-1')).toEqual(['discovered-artists:list', 'game-1']);
+  });
+});


### PR DESCRIPTION
## Phase 3 PR-9 — `useArtists` + `useDiscoveredArtists`; store stops owning rosters

Moves the `artists` roster and `discoveredArtists` domains off the Zustand store onto the TanStack Query cache, following the PR-6 (`useReleases`/`useSongs`) and PR-7 (`useProjects`) precedents. See the plan row 9 in `docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md`.

### Endpoint findings
- **No dedicated `GET /api/game/:id/artists` route** exists in `server/routes/artists.ts` (only sign/patch/mood-events + dialogue). So `useArtists` uses the **PR-7 pattern**: `queryFn` fetches `/api/game/:id` and selects `data.artists` — the exact source the store read before. The fan-out pre-seeds the cache (`seedArtistsCache`), so the queryFn only fires when `signArtist`/`updateArtist` invalidate.
- **Discovered artists** use `GET /api/game/:id/ar-office/artists` (verified URL). `useDiscoveredArtists` wraps that read.

### Synthesis preservation
The flags-fallback synthesis (legacy singular `ar_office_discovered_artist_id`/`_info` → a synthesized `{ id, name, archetype, talent, popularity, genre, signed:false }` when the server list is empty) is preserved **byte-identically** inside `fetchDiscoveredArtists` in `hooks/useDiscoveredArtists.ts`, lifted verbatim from the former `gameStore.loadDiscoveredArtists`. A hook test pins both the info-populated and bare-id (all-defaults) cases.

### Step-4 persistence call
**Kept the read path behind the hook; no store field or client persistence retained.** Investigated: `discoveredArtists` was **never** in the zustand `persist` partialize (only `gameState.id`, `selectedActions`, `isAdvancingWeek` — `gameStore.ts`). The client/CLAUDE.md "persisted: discoveredArtists" note is stale. The server's A&R GET is a **pure read** (Phase 2) of the canonical `flags.ar_office_discovered_artists` array persisted in game state (`server/routes/arOffice.ts`), so discovered artists survive a reload via the server. No client-side persistence was load-bearing → safe to drop the store field entirely. `loadGame`/`loadGameFromSave` prime the discovered cache; `advanceWeek` refetches on A&R completion (throwing variant preserves the retry-with-backoff loop); `signArtist` invalidates it so a signed artist drops out.

### Machine check
`arOfficeMachine.ts` is injection-only (callbacks; no store reads, no `apiRequest`) — it does **not** depend on the removed discovered-artist actions. `executiveMeetingMachine` is untouched. No store shims were needed.

### `signArtist`
Money optimistic delta **untouched** (deferred to PR-10). Roster-append → `invalidateQueries(artistsQueryKey)`; discovered-list removal → `invalidateQueries(discoveredArtistsQueryKey)`. `updateArtist` invalidates instead of splicing (it has no live callers today).

### Consumers migrated to hooks
`ArtistRoster`, `ActiveReleases`, `ActiveTours`, `MusicCalendar`, `TourVarianceTester`, `ExecutiveMeetings`, `AROffice` (page + `ar-office/AROffice` component), `ArtistsLandingPage`, `ArtistPage`, `MainMenuPage`, `LivePerformancePage`, `RecordingSessionPage`, plus `Dashboard` (dropped a dead `artists` destructure). `saveGame` (`gameStore`) and `handleExport` (`SaveGameModal`) source `artists` from the cache — snapshot shape unchanged.

### Pin changes
- `gameStore-actions.characterization.test.ts`: `signArtist` money/clamp pins unchanged; the roster-append pin becomes an **invalidation** pin (asserts `artistsQueryKey` + `discoveredArtistsQueryKey` invalidated, store no longer exposes `artists`). `loadGame`/`advanceWeek` artists assertions become **cache-seed** assertions.
- `query-key-contract.test.ts`: added `artists:list` + `discovered-artists:list` to the real-key set and a new describe block asserting the artist mutation invalidations match the hook keys.
- `gameStore-harness.ts`: `resetGameStore` no longer resets `artists`/`discoveredArtists`.
- New: `useArtists.test.tsx`, `useDiscoveredArtists.test.tsx`. Updated `ArtistRoster.test.tsx` to mock `useArtists`.

### Validation
- `npm run check` — clean.
- `npx vitest run tests/client/` — **68 passed** (10 files).
- `ArtistRoster.test.tsx` — passed.

Does **not** touch docs, server, or XState machines. Money/creativeCapital math left for PR-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
