### PR TITLE
refactor(client): Phase 3 PR-10 — server-canonical money/creativeCapital (drift fix)

### DIFF
--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -173,6 +173,44 @@ async function refetchDiscoveredArtistsCache(gameState: GameState | null) {
   }
 }
 
+// Phase 3 PR-10: adopt the SERVER-CANONICAL money + creativeCapital after a
+// mutation instead of doing optimistic client-side arithmetic on gameState.
+// signArtist / createProject / planRelease all recompute cost server-side (Phase
+// 1 hardening: artistService derives signingCost, projects.ts recomputes
+// totalCost, releasePlanningService validates the marketing budget) and none of
+// their mutation responses carry BOTH updated fields:
+//   - POST .../artists           -> res.json(artist)   (no money at all)
+//   - POST .../projects          -> res.json(project)  (no money/creativeCapital)
+//   - POST .../releases/plan     -> payload.updatedGameState.money only (no cc)
+// So the single correct source for both fields is one refetch of GET
+// /api/game/:id, whose gameState carries money AND creativeCapital. We merge
+// ONLY those two fields onto the current store gameState so the synced A&R
+// fields / musicLabel / usedFocusSlots already in the store are preserved
+// (cancelProject stays on its response-field path — result.newBalance — because
+// its response DOES carry the authoritative balance and it never touches
+// creativeCapital). Returns silently on failure so a transient GET error never
+// throws out of the mutation (the mutation itself already succeeded on the
+// server); the next full reload reconciles.
+async function adoptServerBalances(get: () => GameStore, gameId: string) {
+  try {
+    const response = await apiRequest('GET', `/api/game/${gameId}`);
+    const data = await response.json();
+    const serverGameState = data?.gameState;
+    if (!serverGameState) return;
+    const current = get().gameState;
+    if (!current) return;
+    useGameStore.setState({
+      gameState: {
+        ...current,
+        money: serverGameState.money,
+        creativeCapital: serverGameState.creativeCapital,
+      },
+    });
+  } catch (error) {
+    console.error('[PR-10] Failed to adopt server balances:', error);
+  }
+}
+
 // Internal helper to sync focus slots and A&R operation status to the server
 async function syncSlotsPatch(
   gameId: string,
@@ -1003,18 +1041,16 @@ export const useGameStore = create<GameStore>()(
           // Phase 3 PR-9: the roster is cache-owned now. Invalidate the artists
           // key so useArtists refetches the authoritative roster (which includes
           // the just-signed artist) instead of hand-appending to a store array.
-          // The money optimistic delta is UNTOUCHED (that's PR-10) — it stays as
-          // a client-side subtraction against gameState.money.
-          const signingCost = artistData.signingCost || 0;
-          set({
-            gameState: {
-              ...gameState,
-              money: Math.max(0, (gameState.money || 0) - signingCost)
-            }
-          });
           await queryClient.invalidateQueries({
             queryKey: artistsQueryKey(gameState.id),
           });
+
+          // Phase 3 PR-10: adopt the server-canonical money instead of the old
+          // optimistic `money -= signingCost` subtraction. The sign response is
+          // just the created artist row (no money field) and the signing cost is
+          // derived server-side (artistService), so the displayed balance must
+          // come from a refetch of GET /api/game/:id — not client arithmetic.
+          await adoptServerBalances(get, gameState.id);
 
           // Phase 3 PR-9: the discovered-artists list is cache-owned too. The
           // signed artist should drop out of it; the server's A&R read already
@@ -1067,22 +1103,13 @@ export const useGameStore = create<GameStore>()(
             queryKey: projectsQueryKey(gameState.id),
           });
 
-          // CRITICAL: Immediately update gameState to reflect cost and creative capital deduction
-          // The server has already deducted both the project cost and creative capital, so we need to sync our local state
-          const projectCost = projectData.totalCost || projectData.budgetPerSong || 0;
-          const currentCreativeCapital = gameState.creativeCapital || 0;
-          
-          const updatedGameState = {
-            ...gameState,
-            money: (gameState.money ?? 0) - projectCost,
-            creativeCapital: currentCreativeCapital - 1  // Deduct 1 creative capital
-          };
-          set({ gameState: updatedGameState });
-          
-          if (projectCost > 0) {
-            console.log(`[FRONTEND] Synced money deduction: -$${projectCost}, new balance: $${updatedGameState.money}`);
-          }
-          console.log(`[FRONTEND] Synced creative capital deduction: -1, new balance: ${updatedGameState.creativeCapital}`);
+          // Phase 3 PR-10: adopt the server-canonical money + creativeCapital
+          // instead of the old optimistic `money -= projectCost; cc -= 1` math.
+          // The create response is just the created project row (no money/cc) and
+          // the cost is recomputed server-side (projects.ts recomputes totalCost
+          // from budgetPerSong), so the displayed balances must come from a
+          // refetch of GET /api/game/:id — not client arithmetic.
+          await adoptServerBalances(get, gameState.id);
         } catch (error) {
           console.error('Failed to create project:', error);
           throw error;
@@ -1152,18 +1179,6 @@ export const useGameStore = create<GameStore>()(
           const response = await apiRequest('POST', `/api/game/${gameState.id}/releases/plan`, releaseData);
           const result = await response.json();
 
-          // Update game state to reflect marketing budget and creative capital deduction
-          const totalMarketingCost = releaseData.metadata?.totalInvestment || 0;
-          const currentCreativeCapital = gameState.creativeCapital || 0;
-          
-          const updatedGameState = {
-            ...gameState,
-            money: (gameState.money ?? 0) - totalMarketingCost,
-            creativeCapital: currentCreativeCapital - 1
-          };
-          
-          set({ gameState: updatedGameState });
-
           // Phase 3 PR-6: releases/releaseSongs/songs now live in the query cache
           // (formerly the store fan-out re-fetched them). Invalidate so the newly
           // planned release shows up without a full reload.
@@ -1171,7 +1186,14 @@ export const useGameStore = create<GameStore>()(
           await queryClient.invalidateQueries({ queryKey: releaseSongsQueryKey(gameState.id) });
           await queryClient.invalidateQueries({ queryKey: songsQueryKey(gameState.id) });
 
-          console.log(`[FRONTEND] Synced release planning: -$${totalMarketingCost}, -1 creative capital, new balances: $${updatedGameState.money}, ${updatedGameState.creativeCapital} creative capital`);
+          // Phase 3 PR-10: adopt the server-canonical money + creativeCapital
+          // instead of the old optimistic `money -= totalInvestment; cc -= 1`
+          // math. The plan response DOES carry `updatedGameState.money`, but it
+          // does NOT carry creativeCapital — so a single refetch of GET
+          // /api/game/:id is the one correct source for BOTH fields (adopting
+          // money from the response but refetching for cc would split one action
+          // across two sources). Server validates the marketing budget itself.
+          await adoptServerBalances(get, gameState.id);
 
           return result;
         } catch (error) {

--- a/tests/client/gameStore-actions.characterization.test.ts
+++ b/tests/client/gameStore-actions.characterization.test.ts
@@ -55,22 +55,29 @@ beforeEach(() => {
   resetGameStore();
 });
 
-describe('signArtist optimistic delta', () => {
-  // Phase 3 PR-9 CHANGE: the roster is cache-owned now. signArtist no longer
-  // appends the returned artist into a store `artists` array; it invalidates the
-  // artists query key (so useArtists refetches the authoritative roster) AND the
-  // discovered-artists key (so the signed artist drops out of the discovered
-  // list). The money optimistic math is UNTOUCHED (that's PR-10), so those pins
-  // stay identical — only the array-append pin becomes invalidation pins.
-  it('deducts signingCost from money and invalidates the artists + discovered caches', async () => {
+describe('signArtist adopts server-canonical money', () => {
+  // Phase 3 PR-10 CHANGE (drift fix): signArtist no longer does optimistic
+  // client-side `money -= signingCost` arithmetic. The POST .../artists response
+  // is just the created artist row (no money field) and the signing cost is
+  // derived server-side (artistService), so the displayed balance is adopted
+  // from a refetch of GET /api/game/:id. The mocked GET below returns a balance
+  // DIFFERENT from what client math would produce, proving no client arithmetic
+  // remains: client math on 100000 - 15000 would say 85000, but the server says
+  // 83000 and the store must show 83000. (Phase 3 PR-9 pins for the artists +
+  // discovered cache invalidations are unchanged.)
+  it('adopts the server balance from the refetch (NOT a client 100000-15000 delta)', async () => {
     useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 100000 }) });
     const newArtist = { id: 'artist-99', name: 'Signed One' };
-    routeApiRequest([{ match: (u) => u.includes('/artists'), body: newArtist }]);
+    routeApiRequest([
+      // GET /api/game/:id refetch — server is canonical (83000 != client's 85000).
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 4 } } },
+      { match: (u) => u.includes('/artists'), body: newArtist },
+    ]);
 
     await useGameStore.getState().signArtist({ name: 'Signed One', signingCost: 15000 });
 
     const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(85000); // 100000 - 15000
+    expect(state.gameState!.money).toBe(83000); // server-canonical, not 85000
     // Roster no longer lives in the store; the mutation invalidates the cache.
     expect((state as any).artists).toBeUndefined();
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -81,18 +88,36 @@ describe('signArtist optimistic delta', () => {
     });
   });
 
-  it('clamps money at 0 (Math.max floor) when signingCost exceeds balance', async () => {
-    useGameStore.setState({ gameState: baseGameState({ money: 5000 }) });
-    routeApiRequest([{ match: (u) => u.includes('/artists'), body: { id: 'a1' } }]);
+  it('double-firing signArtist cannot compound the balance (server number wins)', async () => {
+    // Guard the plan requires: two rapid calls must leave the displayed balance
+    // equal to the mocked server's LAST response, with no client arithmetic
+    // compounding. There is no in-flight guard in the store (a double-fire is two
+    // real server mutations — a server concern, out of scope), but the displayed
+    // balance must still be exactly the server's number, never 100000 - 15000 -
+    // 15000. The GET always returns 83000 here, so after two signs the store
+    // shows 83000, not a doubly-subtracted 70000.
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 100000 }) });
+    routeApiRequest([
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 4 } } },
+      { match: (u) => u.includes('/artists'), body: { id: 'a1' } },
+    ]);
 
-    await useGameStore.getState().signArtist({ signingCost: 15000 });
+    await Promise.all([
+      useGameStore.getState().signArtist({ signingCost: 15000 }),
+      useGameStore.getState().signArtist({ signingCost: 15000 }),
+    ]);
 
-    expect(useGameStore.getState().gameState!.money).toBe(0);
+    expect(useGameStore.getState().gameState!.money).toBe(83000); // not 70000
   });
 
-  it('treats a missing signingCost as 0 (no money change)', async () => {
-    useGameStore.setState({ gameState: baseGameState({ money: 42000 }) });
-    routeApiRequest([{ match: (u) => u.includes('/artists'), body: { id: 'a1' } }]);
+  it('leaves money unchanged when the refetch yields no gameState (transient GET failure)', async () => {
+    // adoptServerBalances returns silently if the GET has no gameState; the store
+    // keeps its prior balance rather than throwing or zeroing out.
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 42000 }) });
+    routeApiRequest([
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: {} }, // no gameState field
+      { match: (u) => u.includes('/artists'), body: { id: 'a1' } },
+    ]);
 
     await useGameStore.getState().signArtist({ name: 'No Cost' });
 
@@ -100,24 +125,32 @@ describe('signArtist optimistic delta', () => {
   });
 });
 
-describe('createProject optimistic delta', () => {
-  // Phase 3 PR-7 CHANGE: projects are cache-owned now. createProject no longer
-  // splices the returned project into a store `projects` array; it invalidates
-  // the projects query key so useProjects refetches the authoritative list. The
-  // money/creativeCapital optimistic math is UNTOUCHED (that's PR-10), so those
-  // pins stay identical — only the array-splice pin becomes an invalidation pin.
-  it('deducts totalCost from money and 1 from creativeCapital, invalidates projects', async () => {
+describe('createProject adopts server-canonical money + creativeCapital', () => {
+  // Phase 3 PR-10 CHANGE (drift fix): createProject no longer does optimistic
+  // client-side `money -= projectCost; creativeCapital -= 1` arithmetic. The
+  // POST .../projects response is just the created project row (no money/cc) and
+  // the cost is recomputed server-side (projects.ts recomputes totalCost), so
+  // BOTH balances are adopted from a refetch of GET /api/game/:id. The mocked GET
+  // returns numbers DIFFERENT from what client math would produce, proving no
+  // client arithmetic remains: client math would say money 80000 / cc 3, but the
+  // server says 83000 / 2 and the store must show 83000 / 2. (Phase 3 PR-7 pin
+  // for the projects cache invalidation is unchanged.)
+  it('adopts server money + cc from the refetch (NOT client 80000/3 deltas)', async () => {
     useGameStore.setState({
       gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }),
     });
     const newProject = { id: 'proj-1', title: 'EP' };
-    routeApiRequest([{ match: (u) => u.includes('/projects'), body: newProject }]);
+    routeApiRequest([
+      // GET /api/game/:id refetch — server canonical (83000/2 != client 80000/3).
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 2 } } },
+      { match: (u) => u.includes('/projects'), body: newProject },
+    ]);
 
     await useGameStore.getState().createProject({ totalCost: 20000 });
 
     const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(80000); // 100000 - 20000
-    expect((state.gameState as any).creativeCapital).toBe(3); // 4 - 1
+    expect(state.gameState!.money).toBe(83000); // server-canonical, not 80000
+    expect((state.gameState as any).creativeCapital).toBe(2); // server-canonical, not 3
     // Projects no longer live in the store; the mutation invalidates the cache.
     expect((state as any).projects).toBeUndefined();
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -125,55 +158,70 @@ describe('createProject optimistic delta', () => {
     });
   });
 
-  it('falls back to budgetPerSong when totalCost is absent', async () => {
+  it('double-firing createProject cannot compound the balances (server numbers win)', async () => {
+    // Two rapid creates leave the displayed balances equal to the mocked server's
+    // response, with no client arithmetic compounding. No in-flight guard exists
+    // (a double-fire is two real server mutations — out of scope); the point is
+    // the displayed balances equal the server's numbers, never a doubly-
+    // subtracted 60000 / cc 2.
     useGameStore.setState({
-      gameState: baseGameState({ money: 50000, creativeCapital: 2 }),
+      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }),
     });
-    routeApiRequest([{ match: (u) => u.includes('/projects'), body: { id: 'p2' } }]);
+    routeApiRequest([
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 2 } } },
+      { match: (u) => u.includes('/projects'), body: { id: 'p1' } },
+    ]);
 
-    await useGameStore.getState().createProject({ budgetPerSong: 8000 });
+    await Promise.all([
+      useGameStore.getState().createProject({ totalCost: 20000 }),
+      useGameStore.getState().createProject({ totalCost: 20000 }),
+    ]);
 
-    expect(useGameStore.getState().gameState!.money).toBe(42000); // 50000 - 8000
-    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(1);
-  });
-
-  it('deducts creative capital even when cost is 0', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ money: 30000, creativeCapital: 3 }),
-    });
-    routeApiRequest([{ match: (u) => u.includes('/projects'), body: { id: 'p3' } }]);
-
-    await useGameStore.getState().createProject({});
-
-    expect(useGameStore.getState().gameState!.money).toBe(30000);
-    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(2);
+    const state = useGameStore.getState();
+    expect(state.gameState!.money).toBe(83000); // not 60000
+    expect((state.gameState as any).creativeCapital).toBe(2); // not a compounded value
   });
 });
 
-describe('planRelease optimistic delta', () => {
-  it('deducts metadata.totalInvestment from money and 1 from creativeCapital', async () => {
+describe('planRelease adopts server-canonical money + creativeCapital', () => {
+  // Phase 3 PR-10 CHANGE (drift fix): planRelease no longer does optimistic
+  // client-side `money -= totalInvestment; creativeCapital -= 1` arithmetic. The
+  // POST .../releases/plan response carries `updatedGameState.money` but NOT
+  // creativeCapital, so a single refetch of GET /api/game/:id is the one correct
+  // source for BOTH fields. The mocked GET returns numbers DIFFERENT from what
+  // client math would produce, proving no client arithmetic remains: client math
+  // would say money 88000 / cc 3, but the server says 83000 / 2 and the store
+  // must show 83000 / 2.
+  it('adopts server money + cc from the refetch (NOT client 88000/3 deltas)', async () => {
     useGameStore.setState({
-      gameState: baseGameState({ money: 100000, creativeCapital: 4 }),
+      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }),
     });
-    routeApiRequest([{ match: (u) => u.includes('/releases/plan'), body: { ok: true } }]);
+    routeApiRequest([
+      // GET /api/game/:id refetch — server canonical (83000/2 != client 88000/3).
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 2 } } },
+      { match: (u) => u.includes('/releases/plan'), body: { ok: true } },
+    ]);
 
     await useGameStore.getState().planRelease({ metadata: { totalInvestment: 12000 } });
 
     const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(88000); // 100000 - 12000
-    expect((state.gameState as any).creativeCapital).toBe(3);
+    expect(state.gameState!.money).toBe(83000); // server-canonical, not 88000
+    expect((state.gameState as any).creativeCapital).toBe(2); // server-canonical, not 3
   });
 
-  it('treats a missing totalInvestment as 0 for money but still deducts creative capital', async () => {
+  it('leaves balances unchanged when the refetch yields no gameState (transient GET failure)', async () => {
     useGameStore.setState({
-      gameState: baseGameState({ money: 60000, creativeCapital: 2 }),
+      gameState: baseGameState({ id: 'game-1', money: 60000, creativeCapital: 2 }),
     });
-    routeApiRequest([{ match: (u) => u.includes('/releases/plan'), body: {} }]);
+    routeApiRequest([
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: {} }, // no gameState field
+      { match: (u) => u.includes('/releases/plan'), body: {} },
+    ]);
 
     await useGameStore.getState().planRelease({});
 
     expect(useGameStore.getState().gameState!.money).toBe(60000);
-    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(1);
+    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Phase 3 PR-10 — server-canonical money/creativeCapital (drift fix)

Final PR of Phase 3 (client state ownership). Removes the **optimistic dual-write drift class**: `signArtist`, `createProject`, and `planRelease` did client-side arithmetic on `gameState.money` (and `creativeCapital` for the latter two) and never re-read the server's number, so the displayed balance could diverge from the DB until the next full reload. `cancelProject` was already the correct model (adopts `result.newBalance`).

Ref: `docs/01-planning/implementation-specs/[READY] phase-3-client-state-ownership-plan.md` row 10 + §6 "gameState is entangled" risk note.

### Per-endpoint source choice (with response-shape evidence)

I investigated each mutation's actual response before choosing a source. **No server changes** (Phase 3 is client-only).

| Action | Response shape (evidence) | Source chosen |
|---|---|---|
| `signArtist` | `POST /api/game/:gameId/artists` → `res.json(artist)` — the created artist row only, **no money field** (`server/routes/artists.ts:187`, `server/services/artistService.ts` returns `artist`). Signing cost is derived server-side (B1 hardening). | **Refetch** `GET /api/game/:id`, adopt `gameState.money`. |
| `createProject` | `POST /api/game/:gameId/projects` → `res.json(project)` — the project row only, **no money/creativeCapital** (`server/routes/projects.ts:286`). Cost is recomputed server-side from `budgetPerSong` (B2). | **Refetch**, adopt `gameState.money` + `gameState.creativeCapital`. |
| `planRelease` | `POST /api/game/:gameId/releases/plan` → `payload` carries `updatedGameState.money` **but NOT creativeCapital** (`server/services/releasePlanningService.ts:280-296`). | **Refetch** (single correct source for **both** fields — adopting money from the response but refetching for cc would split one action across two sources). |
| `cancelProject` | unchanged — `DELETE .../cancel` returns `{ newBalance, refundAmount }`, already adopted verbatim. | **Response field** (unchanged). |

`GET /api/game/:id` returns `{ gameState, musicLabel, artists, projects, roles, weeklyActions, releases }` where `gameState` carries both `money` and `creativeCapital` (`server/routes/games.ts:44-52`). The new `adoptServerBalances(get, gameId)` helper merges **only** those two fields onto the current store `gameState`, preserving the synced A&R fields / `musicLabel` / `usedFocusSlots` already in the store. It returns silently on a GET failure (the mutation already succeeded server-side; next reload reconciles).

Per the plan (§6): I accept the single balance update from the refetch and did **not** add TanStack `onMutate` optimism preemptively.

### Pin rewrites (deliberate, per PR-10 mandate)

`tests/client/gameStore-actions.characterization.test.ts` — the optimistic-delta pins become post-adoption assertions. Each mock's `GET /api/game/:id` returns a balance **different from what client math would produce**, proving no client arithmetic remains:

- **signArtist**: was `money === 85000` (100000 − 15000). Now `money === 83000` (server-canonical; client math would say 85000). The clamp-at-0 and missing-cost pins are replaced by a "transient GET failure leaves balance unchanged" pin (the old `Math.max(0, …)` / delta behavior no longer exists).
- **createProject**: was `money === 80000, cc === 3`. Now `money === 83000, cc === 2` (server says both; client math would say 80000/3). The budgetPerSong-fallback and cc-even-when-cost-0 pins are dropped — those exercised client arithmetic that no longer runs.
- **planRelease**: was `money === 88000, cc === 3`. Now `money === 83000, cc === 2`. Missing-totalInvestment pin replaced by a transient-GET-failure pin.
- **cancelProject pin unchanged** (still `money === result.newBalance === 27500`).

### Double-fire regression tests

The plan requires proving a double-click can't double-deduct the **displayed** balance. There is no in-flight guard in the store (a double-fire is two real server mutations — a server-side concern, out of scope). The added tests fire two rapid `signArtist` / `createProject` calls via `Promise.all` and assert the store balance equals the mocked server's number (83000 / cc 2), **never** a compounded 70000 / 60000. Because `adoptServerBalances` overwrites `money`/`cc` with the server number (not a delta), the result is deterministic regardless of interleaving.

### Other actions checked (step 6)

Grepped all store actions for the optimistic-balance pattern. Only the three fixed here plus `cancelProject` (correct model, unchanged) touch `money`/`creativeCapital`. `updateArtist` / `updateProject` do no money math (invalidate-only). The A&R/slot actions touch `usedFocusSlots`, not balances. **No follow-up needed.**

### Validation

- `npm run check` — clean
- `npx vitest run tests/client/` — **67 passed (10 files)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
