### PR TITLE
test(client): spine characterization net (Phase 3.5 PR-1)

### DIFF
--- a/tests/client/gameStore-spine.characterization.test.ts
+++ b/tests/client/gameStore-spine.characterization.test.ts
@@ -1,0 +1,798 @@
+/**
+ * gameStore SPINE characterization tests (Phase 3.5 PR-1).
+ *
+ * SAFETY NET for the Phase 3.5 gameState-spine → TanStack Query ownership
+ * refactor. These pins assert the CURRENT behavior of the real store's
+ * gameState spine EXACTLY — the synchronous focus-slot math, the
+ * `syncSlotsPatch` payloads, the `advanceWeek` merge (including its
+ * `{...resultGameState, ...serverGameState}` refetch-wins precedence quirk and
+ * the hardcoded `usedFocusSlots` reset), `adoptServerBalances`' two-field
+ * merge, `loadGame`'s `gameStateWithLabel` assembly, the orphan-cleanup path in
+ * `createNewGame`, and the snapshot-assembly input to `saveGame`.
+ *
+ * Do NOT "correct" these assertions to what looks right — they pin what the
+ * code DOES today so PRs 4–6 (the ownership flip) can prove behavior is
+ * unchanged. A later PR that deliberately changes behavior should update the
+ * pin with intent.
+ *
+ * Mirrors the mock/harness setup of `gameStore-actions.characterization.test.ts`.
+ * See: docs/01-planning/implementation-specs/[READY] phase-3.5-gamestate-tanstack-plan.md (PR-1).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the network + cache layer BEFORE the store import (vitest hoists these).
+// The mocked queryClient exposes a working in-memory cache because the store
+// seeds/reads several collections via setQueryData/getQueryData.
+const queryCache = new Map<string, unknown>();
+vi.mock('@/lib/queryClient', () => ({
+  apiRequest: vi.fn(),
+  queryClient: {
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    setQueryData: vi.fn((key: unknown, value: unknown) => {
+      queryCache.set(JSON.stringify(key), value);
+      return value;
+    }),
+    getQueryData: vi.fn((key: unknown) => queryCache.get(JSON.stringify(key))),
+  },
+}));
+vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import { apiRequest } from '@/lib/queryClient';
+import { songsQueryKey } from '@/hooks/useSongs';
+import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
+import { projectsQueryKey } from '@/hooks/useProjects';
+import { artistsQueryKey } from '@/hooks/useArtists';
+import { useGameStore } from '@/store/gameStore';
+import {
+  routeApiRequest as routeApiRequestImpl,
+  jsonResponse,
+  resetGameStore as resetGameStoreImpl,
+  baseGameState,
+} from './gameStore-harness';
+
+const mockedApiRequest = apiRequest as unknown as ReturnType<typeof vi.fn>;
+const routeApiRequest = (routes: Array<{ match: (url: string) => boolean; body: unknown }>) =>
+  routeApiRequestImpl(mockedApiRequest, routes);
+const resetGameStore = () => resetGameStoreImpl(useGameStore);
+
+/** Grab every PATCH /api/game/:id payload the store fired at syncSlotsPatch. */
+function slotPatchCalls() {
+  return mockedApiRequest.mock.calls
+    .filter(([method, url]) => method === 'PATCH' && /\/api\/game\/[^/]+$/.test(url))
+    .map(([, , payload]) => payload);
+}
+
+beforeEach(() => {
+  mockedApiRequest.mockReset();
+  queryCache.clear();
+  resetGameStore();
+  // Default: any request resolves to {} (slot ops fire a fire-and-forget PATCH).
+  mockedApiRequest.mockResolvedValue(jsonResponse({}));
+});
+
+// ---------------------------------------------------------------------------
+// (a) Synchronous focus-slot math + syncSlotsPatch payloads
+// ---------------------------------------------------------------------------
+
+describe('selectAction focus-slot math', () => {
+  it('increments usedFocusSlots synchronously and is visible on the SAME tick', () => {
+    useGameStore.setState({
+      gameState: baseGameState({ focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }),
+      selectedActions: [],
+    });
+
+    // Do NOT await: the local set() is synchronous; only syncSlotsPatch is async.
+    void useGameStore.getState().selectAction('action-A');
+
+    const state = useGameStore.getState();
+    expect(state.selectedActions).toEqual(['action-A']);
+    expect(state.gameState!.usedFocusSlots).toBe(1);
+  });
+
+  it('fires syncSlotsPatch with the new usedFocusSlots + A&R fields', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 3,
+        usedFocusSlots: 0,
+        arOfficeSlotUsed: false,
+        arOfficeSourcingType: null,
+      }),
+      selectedActions: [],
+    });
+
+    await useGameStore.getState().selectAction('action-A');
+
+    expect(slotPatchCalls()).toContainEqual({
+      usedFocusSlots: 1,
+      arOfficeSlotUsed: false,
+      arOfficeSourcingType: null,
+    });
+  });
+
+  it('adds the A&R-consumed slot on top of selected actions in usedFocusSlots', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 3,
+        usedFocusSlots: 1,
+        arOfficeSlotUsed: true,
+        arOfficeSourcingType: 'active',
+      }),
+      selectedActions: [],
+    });
+
+    await useGameStore.getState().selectAction('action-A');
+
+    const state = useGameStore.getState();
+    // 1 selected action + 1 A&R slot = 2.
+    expect(state.gameState!.usedFocusSlots).toBe(2);
+    expect(slotPatchCalls()).toContainEqual({
+      usedFocusSlots: 2,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'active',
+    });
+  });
+
+  it('does NOT select past the available slots (focusSlots minus A&R slot)', async () => {
+    // focusSlots 2, A&R slot used → only 1 action slot available.
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 2,
+        usedFocusSlots: 1,
+        arOfficeSlotUsed: true,
+        arOfficeSourcingType: 'active',
+      }),
+      selectedActions: [],
+    });
+
+    await useGameStore.getState().selectAction('action-A'); // fills the last slot
+    await useGameStore.getState().selectAction('action-B'); // should be rejected
+
+    const state = useGameStore.getState();
+    expect(state.selectedActions).toEqual(['action-A']);
+    expect(state.gameState!.usedFocusSlots).toBe(2);
+  });
+
+  it('ignores a duplicate action id (no double-count)', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }),
+      selectedActions: [],
+    });
+
+    await useGameStore.getState().selectAction('action-A');
+    await useGameStore.getState().selectAction('action-A');
+
+    const state = useGameStore.getState();
+    expect(state.selectedActions).toEqual(['action-A']);
+    expect(state.gameState!.usedFocusSlots).toBe(1);
+  });
+
+  it('is a no-op when gameState is null', async () => {
+    useGameStore.setState({ gameState: null, selectedActions: [] });
+    await useGameStore.getState().selectAction('action-A');
+    expect(useGameStore.getState().selectedActions).toEqual([]);
+  });
+});
+
+describe('removeAction focus-slot math', () => {
+  it('decrements usedFocusSlots synchronously and syncs the new count', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 3,
+        usedFocusSlots: 2,
+        arOfficeSlotUsed: false,
+        arOfficeSourcingType: null,
+      }),
+      selectedActions: ['action-A', 'action-B'],
+    });
+
+    await useGameStore.getState().removeAction('action-A');
+
+    const state = useGameStore.getState();
+    expect(state.selectedActions).toEqual(['action-B']);
+    expect(state.gameState!.usedFocusSlots).toBe(1);
+    expect(slotPatchCalls()).toContainEqual({
+      usedFocusSlots: 1,
+      arOfficeSlotUsed: false,
+      arOfficeSourcingType: null,
+    });
+  });
+
+  it('keeps the A&R slot counted when removing an action', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 3,
+        usedFocusSlots: 2,
+        arOfficeSlotUsed: true,
+        arOfficeSourcingType: 'active',
+      }),
+      selectedActions: ['action-A'],
+    });
+
+    await useGameStore.getState().removeAction('action-A');
+
+    // 0 actions + 1 A&R slot = 1.
+    expect(useGameStore.getState().gameState!.usedFocusSlots).toBe(1);
+  });
+
+  it('is a no-op for an action id that is not selected', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ usedFocusSlots: 1 }),
+      selectedActions: ['action-A'],
+    });
+
+    await useGameStore.getState().removeAction('not-selected');
+
+    expect(useGameStore.getState().selectedActions).toEqual(['action-A']);
+    expect(slotPatchCalls()).toHaveLength(0);
+  });
+});
+
+describe('clearActions focus-slot math', () => {
+  it('clears selectedActions and resets usedFocusSlots to the A&R slot count (no A&R)', () => {
+    useGameStore.setState({
+      gameState: baseGameState({ usedFocusSlots: 2, arOfficeSlotUsed: false }),
+      selectedActions: ['action-A', 'action-B'],
+    });
+
+    useGameStore.getState().clearActions();
+
+    const state = useGameStore.getState();
+    expect(state.selectedActions).toEqual([]);
+    expect(state.gameState!.usedFocusSlots).toBe(0);
+  });
+
+  it('preserves the A&R-consumed slot in usedFocusSlots after clearing', () => {
+    useGameStore.setState({
+      gameState: baseGameState({ usedFocusSlots: 3, arOfficeSlotUsed: true }),
+      selectedActions: ['action-A', 'action-B'],
+    });
+
+    useGameStore.getState().clearActions();
+
+    const state = useGameStore.getState();
+    expect(state.selectedActions).toEqual([]);
+    expect(state.gameState!.usedFocusSlots).toBe(1); // A&R slot only
+  });
+
+  it('does NOT fire a syncSlotsPatch (purely local reset)', () => {
+    useGameStore.setState({
+      gameState: baseGameState({ usedFocusSlots: 2 }),
+      selectedActions: ['action-A'],
+    });
+
+    useGameStore.getState().clearActions();
+
+    expect(slotPatchCalls()).toHaveLength(0);
+  });
+});
+
+describe('consumeAROfficeSlot focus-slot math', () => {
+  it('marks the A&R slot used and sets usedFocusSlots to selectedActions.length + 1', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 3,
+        usedFocusSlots: 1,
+        arOfficeSlotUsed: false,
+        arOfficeSourcingType: null,
+      }),
+      selectedActions: ['action-A'],
+    });
+
+    await useGameStore.getState().consumeAROfficeSlot('active');
+
+    const state = useGameStore.getState();
+    expect(state.gameState!.arOfficeSlotUsed).toBe(true);
+    expect(state.gameState!.arOfficeSourcingType).toBe('active');
+    expect(state.gameState!.usedFocusSlots).toBe(2); // 1 action + 1 A&R
+    expect(slotPatchCalls()).toContainEqual({
+      usedFocusSlots: 2,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'active',
+    });
+  });
+
+  it('is a no-op when the A&R slot is already used', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 3,
+        usedFocusSlots: 1,
+        arOfficeSlotUsed: true,
+        arOfficeSourcingType: 'passive',
+      }),
+      selectedActions: [],
+    });
+
+    await useGameStore.getState().consumeAROfficeSlot('active');
+
+    // sourcingType unchanged, no PATCH fired.
+    expect(useGameStore.getState().gameState!.arOfficeSourcingType).toBe('passive');
+    expect(slotPatchCalls()).toHaveLength(0);
+  });
+
+  it('is a no-op when all focus slots are already consumed', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 2,
+        usedFocusSlots: 2,
+        arOfficeSlotUsed: false,
+        arOfficeSourcingType: null,
+      }),
+      selectedActions: ['action-A', 'action-B'],
+    });
+
+    await useGameStore.getState().consumeAROfficeSlot('active');
+
+    expect(useGameStore.getState().gameState!.arOfficeSlotUsed).toBe(false);
+    expect(slotPatchCalls()).toHaveLength(0);
+  });
+});
+
+describe('releaseAROfficeSlot focus-slot math', () => {
+  it('clears the A&R slot and sets usedFocusSlots to selectedActions.length', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        focusSlots: 3,
+        usedFocusSlots: 2,
+        arOfficeSlotUsed: true,
+        arOfficeSourcingType: 'active',
+      }),
+      selectedActions: ['action-A'],
+    });
+
+    await useGameStore.getState().releaseAROfficeSlot();
+
+    const state = useGameStore.getState();
+    expect(state.gameState!.arOfficeSlotUsed).toBe(false);
+    expect(state.gameState!.arOfficeSourcingType).toBeNull();
+    expect(state.gameState!.usedFocusSlots).toBe(1); // just the 1 action
+    expect(slotPatchCalls()).toContainEqual({
+      usedFocusSlots: 1,
+      arOfficeSlotUsed: false,
+      arOfficeSourcingType: null,
+    });
+  });
+
+  it('is a no-op when no A&R slot is in use', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ arOfficeSlotUsed: false }),
+      selectedActions: [],
+    });
+
+    await useGameStore.getState().releaseAROfficeSlot();
+
+    expect(slotPatchCalls()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) advanceWeek gameState assembly — merge precedence + usedFocusSlots reset
+// ---------------------------------------------------------------------------
+
+describe('advanceWeek gameState merge precedence', () => {
+  function routeAdvance(advanceGameState: any, reloadGameState: any, reloadMusicLabel: any) {
+    mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
+      if (url.includes('/advance-week')) {
+        return jsonResponse({ gameState: advanceGameState, summary: { week: 6 }, campaignResults: null });
+      }
+      if (url.endsWith('/songs')) return jsonResponse([]);
+      if (url.endsWith('/releases')) return jsonResponse([]);
+      if (url.endsWith('/release-songs')) return jsonResponse([]);
+      if (url.endsWith('/executives')) return jsonResponse([]);
+      if (url.endsWith('/mood-events')) return jsonResponse([]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [], total: 0, unreadCount: 0 });
+      if (url.includes('/saves')) return jsonResponse({ ok: true });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      // GET /api/game/:id reload (the "refetch" side of the merge)
+      return jsonResponse({ gameState: reloadGameState, musicLabel: reloadMusicLabel, artists: [], projects: [] });
+    });
+  }
+
+  it('lets the refetch (serverGameState) WIN over the advance-week response on conflicting fields', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }),
+      selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
+    });
+
+    // advance-week says money 9000; the immediate refetch disagrees (money 12345).
+    // The merge is {...resultGameState, ...serverGameState} so the REFETCH wins.
+    routeAdvance(
+      { id: 'game-1', currentWeek: 6, money: 9000, reputation: 50 },
+      { id: 'game-1', currentWeek: 6, money: 12345 },
+      { name: 'Test Label' },
+    );
+
+    await useGameStore.getState().advanceWeek();
+
+    const gs = useGameStore.getState().gameState as any;
+    expect(gs.money).toBe(12345); // refetch wins over the advance-week 9000
+    // A field present ONLY in the advance-week response survives (not overwritten).
+    expect(gs.reputation).toBe(50);
+  });
+
+  it('hardcodes usedFocusSlots to (arOfficeSlotUsed ? 1 : 0) — 0 when no A&R slot', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 5 }),
+      selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
+    });
+    routeAdvance(
+      { id: 'game-1', currentWeek: 6, usedFocusSlots: 99, arOfficeSlotUsed: false },
+      { id: 'game-1', currentWeek: 6, usedFocusSlots: 99 },
+      { name: 'Test Label' },
+    );
+
+    await useGameStore.getState().advanceWeek();
+
+    expect((useGameStore.getState().gameState as any).usedFocusSlots).toBe(0);
+  });
+
+  it('resets usedFocusSlots to 1 when the advance response reports an A&R slot in use', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: true }),
+      selectedActions: [],
+    });
+    routeAdvance(
+      { id: 'game-1', currentWeek: 6, arOfficeSlotUsed: true, arOfficeSourcingType: 'active' },
+      { id: 'game-1', currentWeek: 6 }, // refetch omits the A&R fields
+      { name: 'Test Label' },
+    );
+
+    await useGameStore.getState().advanceWeek();
+
+    const gs = useGameStore.getState().gameState as any;
+    expect(gs.usedFocusSlots).toBe(1);
+    // arOfficeSlotUsed/SourcingType are coalesced result ?? server.
+    expect(gs.arOfficeSlotUsed).toBe(true);
+    expect(gs.arOfficeSourcingType).toBe('active');
+  });
+
+  it('sources musicLabel from the reload (gameData.musicLabel), embedded into gameState', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 5 }),
+      selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
+    });
+    routeAdvance(
+      { id: 'game-1', currentWeek: 6 },
+      { id: 'game-1', currentWeek: 6 },
+      { name: 'Reloaded Label' },
+    );
+
+    await useGameStore.getState().advanceWeek();
+
+    expect((useGameStore.getState().gameState as any).musicLabel).toEqual({ name: 'Reloaded Label' });
+  });
+
+  it('falls back to null musicLabel when neither reload nor advance response carries one', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 5 }),
+      selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
+    });
+    routeAdvance({ id: 'game-1', currentWeek: 6 }, { id: 'game-1', currentWeek: 6 }, null);
+
+    await useGameStore.getState().advanceWeek();
+
+    expect((useGameStore.getState().gameState as any).musicLabel).toBeNull();
+  });
+
+  it('is a no-op (never sets isAdvancingWeek) when there are no actions and no A&R slot', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', arOfficeSlotUsed: false }),
+      selectedActions: [],
+    });
+
+    await useGameStore.getState().advanceWeek();
+
+    expect(useGameStore.getState().isAdvancingWeek).toBe(false);
+    // advance-week endpoint was never hit.
+    const hitAdvance = mockedApiRequest.mock.calls.some(([, url]) => String(url).includes('/advance-week'));
+    expect(hitAdvance).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) adoptServerBalances — two-field merge preserving everything else
+// ---------------------------------------------------------------------------
+
+describe('adoptServerBalances two-field merge (via planRelease)', () => {
+  it('overwrites ONLY money + creativeCapital, preserving A&R fields and musicLabel', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        id: 'game-1',
+        money: 100000,
+        creativeCapital: 4,
+        arOfficeSlotUsed: true,
+        arOfficeSourcingType: 'active',
+        usedFocusSlots: 2,
+        musicLabel: { name: 'Preserve Me' },
+      }),
+    });
+    routeApiRequest([
+      // GET /api/game/:id refetch carries a DIFFERENT musicLabel + A&R fields, none
+      // of which must leak into the store (only money + creativeCapital merge).
+      {
+        match: (u) => /\/api\/game\/[^/]+$/.test(u),
+        body: {
+          gameState: {
+            money: 55000,
+            creativeCapital: 1,
+            arOfficeSlotUsed: false,
+            arOfficeSourcingType: null,
+            usedFocusSlots: 0,
+            musicLabel: { name: 'Server Label' },
+          },
+        },
+      },
+      { match: (u) => u.includes('/releases/plan'), body: { ok: true } },
+    ]);
+
+    await useGameStore.getState().planRelease({ metadata: { totalInvestment: 1000 } });
+
+    const gs = useGameStore.getState().gameState as any;
+    expect(gs.money).toBe(55000); // adopted
+    expect(gs.creativeCapital).toBe(1); // adopted
+    // Everything else is the PRE-EXISTING store value, NOT the server refetch's.
+    expect(gs.arOfficeSlotUsed).toBe(true);
+    expect(gs.arOfficeSourcingType).toBe('active');
+    expect(gs.usedFocusSlots).toBe(2);
+    expect(gs.musicLabel).toEqual({ name: 'Preserve Me' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) cancelProject adopts result.newBalance verbatim (complements the
+//     existing pin in gameStore-actions.characterization.test.ts)
+// ---------------------------------------------------------------------------
+
+describe('cancelProject balance adoption preserves the rest of the spine', () => {
+  it('sets money to result.newBalance while leaving other spine fields intact', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        id: 'game-1',
+        money: 20000,
+        creativeCapital: 3,
+        reputation: 12,
+        musicLabel: { name: 'Keep' },
+      }),
+    });
+    routeApiRequest([
+      { match: (u) => u.includes('/cancel'), body: { newBalance: 27500, refundAmount: 7500 } },
+    ]);
+
+    await useGameStore.getState().cancelProject('proj-1', { refundAmount: 7500 });
+
+    const gs = useGameStore.getState().gameState as any;
+    expect(gs.money).toBe(27500);
+    // creativeCapital is NOT touched by cancelProject (only money).
+    expect(gs.creativeCapital).toBe(3);
+    expect(gs.reputation).toBe(12);
+    expect(gs.musicLabel).toEqual({ name: 'Keep' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) loadGame gameStateWithLabel assembly
+// ---------------------------------------------------------------------------
+
+describe('loadGame gameStateWithLabel assembly', () => {
+  function routeLoad(baseGameStatePayload: any, musicLabel: any) {
+    mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
+      if (url.endsWith('/songs')) return jsonResponse([]);
+      if (url.endsWith('/releases')) return jsonResponse([]);
+      if (url.endsWith('/release-songs')) return jsonResponse([]);
+      if (url.endsWith('/executives')) return jsonResponse([]);
+      if (url.endsWith('/mood-events')) return jsonResponse([]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [], total: 0, unreadCount: 0 });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      return jsonResponse({
+        gameState: baseGameStatePayload,
+        musicLabel,
+        artists: [],
+        projects: [],
+        roles: [],
+        weeklyActions: [],
+      });
+    });
+  }
+
+  it('embeds musicLabel and derives usedFocusSlots=0 when no A&R slot is used', async () => {
+    routeLoad(
+      { id: 'game-1', currentWeek: 3, money: 5000, arOfficeSlotUsed: false, arOfficeSourcingType: null },
+      { name: 'Loaded Label' },
+    );
+
+    await useGameStore.getState().loadGame('game-1');
+
+    const gs = useGameStore.getState().gameState as any;
+    expect(gs.musicLabel).toEqual({ name: 'Loaded Label' });
+    expect(gs.usedFocusSlots).toBe(0);
+    expect(gs.arOfficeSlotUsed).toBe(false);
+    expect(gs.arOfficeSourcingType).toBeNull();
+  });
+
+  it('derives usedFocusSlots=1 when the loaded game has an A&R slot in use', async () => {
+    routeLoad(
+      { id: 'game-1', currentWeek: 3, money: 5000, arOfficeSlotUsed: true, arOfficeSourcingType: 'active' },
+      { name: 'Loaded Label' },
+    );
+
+    await useGameStore.getState().loadGame('game-1');
+
+    const gs = useGameStore.getState().gameState as any;
+    expect(gs.usedFocusSlots).toBe(1);
+    expect(gs.arOfficeSlotUsed).toBe(true);
+    expect(gs.arOfficeSourcingType).toBe('active');
+  });
+
+  it('embeds musicLabel as null when the payload has none', async () => {
+    routeLoad({ id: 'game-1', currentWeek: 3, arOfficeSlotUsed: false }, null);
+
+    await useGameStore.getState().loadGame('game-1');
+
+    expect((useGameStore.getState().gameState as any).musicLabel).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (f) Orphan-cleanup path in createNewGame
+// ---------------------------------------------------------------------------
+
+describe('createNewGame orphan-cleanup', () => {
+  /** Route the common new-game creation sequence; `savesBody` controls the /api/saves GET. */
+  function routeCreate(savesBody: any, opts: { newId?: string } = {}) {
+    const newId = opts.newId ?? 'game-2';
+    mockedApiRequest.mockImplementation(async (method: string, url: string) => {
+      if (method === 'GET' && url.endsWith('/api/saves')) return jsonResponse(savesBody);
+      if (method === 'DELETE' && /\/api\/game\/[^/]+$/.test(url)) return jsonResponse({ ok: true });
+      if (method === 'POST' && url.endsWith('/api/game')) return jsonResponse({ id: newId, currentWeek: 1 });
+      // Follow-up GET /api/game/:newId for the complete payload (incl. musicLabel)
+      if (method === 'GET' && /\/api\/game\/[^/]+$/.test(url)) {
+        return jsonResponse({ gameState: { id: newId, currentWeek: 1 }, musicLabel: null });
+      }
+      return jsonResponse({});
+    });
+  }
+
+  it('issues GET /api/saves then DELETE /api/game/:id for an unsaved current game', async () => {
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    routeCreate([]); // no saves belong to game-1 → orphaned
+
+    await useGameStore.getState().createNewGame('Balanced');
+
+    const calls = mockedApiRequest.mock.calls.map(([m, u]) => `${m} ${u}`);
+    expect(calls).toContain('GET /api/saves');
+    expect(calls).toContain('DELETE /api/game/game-1');
+  });
+
+  it('does NOT delete the current game when it has saves', async () => {
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    routeCreate([{ gameId: 'game-1', name: 'a save' }]);
+
+    await useGameStore.getState().createNewGame('Balanced');
+
+    const deletedCurrent = mockedApiRequest.mock.calls.some(
+      ([m, u]) => m === 'DELETE' && u === '/api/game/game-1',
+    );
+    expect(deletedCurrent).toBe(false);
+  });
+
+  it('filters saves by gameId — saves for OTHER games do not protect the current one', async () => {
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    routeCreate([{ gameId: 'some-other-game', name: 'unrelated save' }]);
+
+    await useGameStore.getState().createNewGame('Balanced');
+
+    const calls = mockedApiRequest.mock.calls.map(([m, u]) => `${m} ${u}`);
+    expect(calls).toContain('DELETE /api/game/game-1');
+  });
+
+  it('skips cleanup entirely when there is no current game', async () => {
+    useGameStore.setState({ gameState: null });
+    routeCreate([]);
+
+    await useGameStore.getState().createNewGame('Balanced');
+
+    const hitSaves = mockedApiRequest.mock.calls.some(([m, u]) => m === 'GET' && u === '/api/saves');
+    expect(hitSaves).toBe(false);
+  });
+
+  it('still creates the new game when the DELETE cleanup fails (non-fatal)', async () => {
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    mockedApiRequest.mockImplementation(async (method: string, url: string) => {
+      if (method === 'GET' && url.endsWith('/api/saves')) return jsonResponse([]);
+      if (method === 'DELETE' && /\/api\/game\/[^/]+$/.test(url)) throw new Error('delete failed');
+      if (method === 'POST' && url.endsWith('/api/game')) return jsonResponse({ id: 'game-2', currentWeek: 1 });
+      if (method === 'GET' && /\/api\/game\/[^/]+$/.test(url)) {
+        return jsonResponse({ gameState: { id: 'game-2', currentWeek: 1 }, musicLabel: null });
+      }
+      return jsonResponse({});
+    });
+
+    const result = await useGameStore.getState().createNewGame('Balanced');
+
+    expect(result.id).toBe('game-2');
+    expect((useGameStore.getState().gameState as any).id).toBe('game-2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (g) saveGame passes the store gameState (embedded musicLabel) into
+//     buildGameSnapshot verbatim — the snapshot POSTed keeps musicLabel a
+//     SIBLING of gameState (stripped out by buildGameSnapshot).
+// ---------------------------------------------------------------------------
+
+describe('saveGame snapshot-assembly input', () => {
+  /** Capture the POST /api/saves body. */
+  function routeSave() {
+    let saved: any = null;
+    mockedApiRequest.mockImplementation(async (method: string, url: string, body?: any) => {
+      if (method === 'POST' && url.endsWith('/api/saves')) {
+        saved = body;
+        return jsonResponse({ ok: true });
+      }
+      // fetchSnapshotCollections fan-out
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [], total: 0, unreadCount: 0 });
+      if (url.endsWith('/release-songs')) return jsonResponse([]);
+      if (url.endsWith('/executives')) return jsonResponse([]);
+      if (url.endsWith('/mood-events')) return jsonResponse([]);
+      return jsonResponse({});
+    });
+    return () => saved;
+  }
+
+  it('feeds gameState verbatim into buildGameSnapshot — musicLabel ends up a SIBLING, not nested', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({
+        id: 'game-1',
+        currentWeek: 7,
+        money: 42000,
+        musicLabel: { name: 'Snapshot Label' },
+      }),
+      roles: [{ id: 'role1' } as any],
+      weeklyActions: [{ id: 'wa1' } as any],
+      weeklyOutcome: { week: 7 },
+    });
+    const getSaved = routeSave();
+
+    await useGameStore.getState().saveGame('My Save');
+
+    const saved = getSaved();
+    expect(saved).toBeTruthy();
+    const snapshot = saved.gameState; // the snapshot object built by buildGameSnapshot
+    // musicLabel is a SIBLING of the inner gameState, and stripped OUT of it.
+    expect(snapshot.musicLabel).toEqual({ name: 'Snapshot Label' });
+    expect(snapshot.gameState.musicLabel).toBeUndefined();
+    // The rest of the spine is carried into the inner gameState verbatim.
+    expect(snapshot.gameState.id).toBe('game-1');
+    expect(snapshot.gameState.currentWeek).toBe(7);
+    expect(snapshot.gameState.money).toBe(42000);
+    // top-level save envelope reports the week from the store gameState.
+    expect(saved.week).toBe(7);
+  });
+
+  it('sources songs/releases/projects/artists from the query cache, not the store', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 2, musicLabel: null }),
+      roles: [],
+      weeklyActions: [],
+      weeklyOutcome: null,
+    });
+    // Seed the caches the snapshot reads from.
+    queryCache.set(JSON.stringify(songsQueryKey('game-1')), [{ id: 's1' }]);
+    queryCache.set(JSON.stringify(releasesQueryKey('game-1')), [{ id: 'r1' }]);
+    queryCache.set(JSON.stringify(releaseSongsQueryKey('game-1')), [{ id: 'rs1' }]);
+    queryCache.set(JSON.stringify(projectsQueryKey('game-1')), [{ id: 'p1' }]);
+    queryCache.set(JSON.stringify(artistsQueryKey('game-1')), [{ id: 'a1' }]);
+    const getSaved = routeSave();
+
+    await useGameStore.getState().saveGame('Cache Save');
+
+    const snapshot = getSaved().gameState;
+    // Collections are siblings of gameState (from the cache).
+    expect(snapshot.songs).toEqual([{ id: 's1' }]);
+    expect(snapshot.releases).toEqual([{ id: 'r1' }]);
+    expect(snapshot.projects).toEqual([{ id: 'p1' }]);
+    expect(snapshot.artists).toEqual([{ id: 'a1' }]);
+    // release-songs fan-out from fetchSnapshotCollections returns [] here, which
+    // takes precedence over the cached value (releaseSongsSnapshot ?? releaseSongs).
+    expect(snapshot.releaseSongs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3.5 **PR-1** — the characterization safety net for the upcoming `gameState`-spine → TanStack Query ownership migration. **Test-only, no production code changes.** All pins assert the *current* behavior of the Zustand store's spine so PRs 4–6 (the ownership flip) can prove behavior is unchanged.

Adds one file: `tests/client/gameStore-spine.characterization.test.ts` (35 tests), mirroring the mock/harness setup of the existing `gameStore-actions.characterization.test.ts` (mocked `apiRequest`/`queryClient` with an in-memory cache, `gameStore-harness.ts` helpers).

## What is pinned (per plan §3 PR-1)

- **(a) Focus-slot math + `syncSlotsPatch` payloads** — `selectAction` / `removeAction` / `clearActions` / `consumeAROfficeSlot` / `releaseAROfficeSlot`: synchronous same-tick `usedFocusSlots` visibility, the `selectedActions.length + (arOfficeSlotUsed ? 1 : 0)` invariant, availability guards, and the exact PATCH payloads (incl. `clearActions` firing NO patch).
- **(b) `advanceWeek` gameState assembly** — the `{...resultGameState, ...serverGameState}` **refetch-wins precedence quirk** (advance-week says `money: 9000`, refetch says `12345` → store shows `12345`; a field only in the advance response survives), the hardcoded `usedFocusSlots: arUsed ? 1 : 0` reset, `musicLabel` sourced from the reload, and the no-op guard.
- **(c) `adoptServerBalances`** — a `money`+`creativeCapital`-only merge; A&R fields, `usedFocusSlots`, and `musicLabel` in the store are preserved even when the server refetch carries different values.
- **(d) `cancelProject`** — adopts `result.newBalance` verbatim, leaves the rest of the spine intact.
- **(e) `loadGame`** — `gameStateWithLabel` assembly: embedded `musicLabel` (incl. null), `usedFocusSlots` derived from `arOfficeSlotUsed`.
- **(f) `createNewGame` orphan-cleanup** — `GET /api/saves` then `DELETE /api/game/:id` for an unsaved current game; gameId filtering; skip-when-saved; skip-when-no-current-game; non-fatal DELETE failure still creates the new game.
- **(g) `saveGame` snapshot input** — store `gameState` (with embedded `musicLabel`) fed verbatim into `buildGameSnapshot`; snapshot keeps `musicLabel` a **sibling** of the inner gameState; collections sourced from the query cache.

## Test list

`selectAction` (6), `removeAction` (3), `clearActions` (3), `consumeAROfficeSlot` (3), `releaseAROfficeSlot` (2), `advanceWeek` merge precedence (6), `adoptServerBalances` (1), `cancelProject` (1), `loadGame` assembly (3), `createNewGame` orphan-cleanup (5), `saveGame` snapshot input (2) — **35 total**.

## Verification

- `npm run check` — clean.
- New file: **35/35 green** against unmodified `main`. `tests/client/` in isolation: 96 passed / 6 skipped.
- All pins assert observed current behavior; **no production changes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
