### PR TITLE
chore(client): delete dead updateGameState three-way fallback

### DIFF
--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -257,8 +257,7 @@ interface GameStore {
   loadGame: (gameId: string) => Promise<void>;
   loadGameFromSave: (saveId: string, snapshot: GameSaveSnapshot, mode?: 'overwrite' | 'fork') => Promise<string>;
   createNewGame: (campaignType: string, labelData?: LabelData) => Promise<GameState>;
-  updateGameState: (updates: Partial<GameState>) => Promise<void>;
-  
+
   // Weekly actions
   selectAction: (actionId: string) => Promise<void>;
   removeAction: (actionId: string) => Promise<void>;
@@ -633,70 +632,6 @@ export const useGameStore = create<GameStore>()(
         } catch (error) {
           console.error('Failed to create game:', error);
           throw error;
-        }
-      },
-
-      // Update game state
-      updateGameState: async (updates: Partial<GameState>) => {
-        const { gameState } = get();
-        if (!gameState) return;
-
-        try {
-          const response = await apiRequest('PATCH', `/api/game/${gameState.id}`, updates);
-          
-          // Clone response to safely read the body
-          const clonedResponse = response.clone();
-          let responseText;
-          try {
-            responseText = await clonedResponse.text();
-          } catch (e) {
-            console.error('[updateGameState] Failed to read response text:', e);
-            responseText = '';
-          }
-          
-          // If response body is empty or not valid JSON, merge updates locally
-          if (!responseText || responseText.trim() === '') {
-            console.warn('[updateGameState] Empty response from server, applying updates locally');
-            // Apply updates to local state
-            const updatedState = { ...gameState, ...updates };
-            set({ gameState: updatedState });
-            
-            // Try to sync with server in background
-            setTimeout(async () => {
-              try {
-                const syncResponse = await apiRequest('GET', `/api/game/${gameState.id}`);
-                const serverState = await syncResponse.json();
-                set({ gameState: serverState });
-                console.log('[updateGameState] Synced with server state');
-              } catch (syncError) {
-                console.error('[updateGameState] Failed to sync with server:', syncError);
-              }
-            }, 1000);
-            
-            return;
-          }
-          
-          // Try to parse the response
-          try {
-            const updatedState = JSON.parse(responseText);
-            set({ gameState: updatedState });
-          } catch (parseError) {
-            console.error('[updateGameState] Failed to parse response:', parseError);
-            // Apply updates locally as fallback
-            const updatedState = { ...gameState, ...updates };
-            set({ gameState: updatedState });
-          }
-        } catch (error) {
-          console.error('Failed to update game state:', error);
-          // If it's a 404, the game doesn't exist in the database
-          if ((error as any).status === 404) {
-            console.error('Game not found in database. You may need to create a new game.');
-            // Don't throw - just apply updates locally
-            const updatedState = { ...gameState, ...updates };
-            set({ gameState: updatedState });
-          } else {
-            throw error;
-          }
         }
       },
 


### PR DESCRIPTION
## Summary
- Phase 3.5 PR-2 (per docs/01-planning/implementation-specs/[READY] phase-3.5-gamestate-tanstack-plan.md §0.3): deletes the dead `updateGameState` method from `client/src/store/gameStore.ts` — the interface declaration (was ~line 260) and the three-way fallback implementation (was ~lines 640-701).
- Zero-call-sites evidence: a repo-wide grep for `updateGameState` under `client/` returned only the method's own declaration, implementation, and its internal `console.log`/`console.error`/`console.warn` tag strings — no external callers anywhere in the client codebase.
- Deletion also removes a latent musicLabel-clobber bug: the local-merge fallback paths (empty-response branch and 404 branch) did `{ ...gameState, ...updates }`, which does not preserve `musicLabel` as a sibling of `gameState` per the documented save-snapshot shape — a caller hitting either fallback branch could have silently dropped `musicLabel` from state.

## Test plan
- [x] `npm run check` — clean (proves no remaining callers/type errors)
- [x] `npx vitest run tests/client` — 10 files, 67 tests passed
- Full suite intentionally not run locally (shared Docker test DB on 5433 may be contended by concurrent agents); CI is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)