### PR TITLE
feat(client): Phase 4 PR-1 - AnimatedNumber motion primitive

### DIFF
--- a/client/src/components/MetricsDashboard.tsx
+++ b/client/src/components/MetricsDashboard.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { TrendingUp, TrendingDown, Clock, Zap, BarChart3 } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { fetchMeetingDialogue } from '@/services/executiveService';
+import { AnimatedNumber } from '@/components/motion-primitives/animated-number';
 
 interface SelectedChoice {
   executiveName: string;
@@ -407,9 +408,11 @@ export function MetricsDashboard() {
                   </Tooltip>
                 </div>
                 <div>
-                  <div className={`font-mono font-semibold text-xl leading-none ${netProfitLoss >= 0 ? 'text-positive' : 'text-negative'}`}>
-                    {formatSignedMoney(netProfitLoss)}
-                  </div>
+                  <AnimatedNumber
+                    value={netProfitLoss}
+                    format={formatSignedMoney}
+                    className={`block font-mono font-semibold text-xl leading-none ${netProfitLoss >= 0 ? 'text-positive' : 'text-negative'}`}
+                  />
                   <div className="text-[11.5px] text-text-muted mt-1.5">{netProfitLoss >= 0 ? 'Profit' : 'Loss'}</div>
                 </div>
               </div>

--- a/client/src/components/motion-primitives/animated-number.tsx
+++ b/client/src/components/motion-primitives/animated-number.tsx
@@ -1,0 +1,88 @@
+'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  useReducedMotion,
+  useSpring,
+  type SpringOptions,
+} from 'motion/react';
+
+export type AnimatedNumberProps = {
+  /** The target numeric value to display. */
+  value: number;
+  /** Formats the (possibly fractional, mid-animation) number for display. Defaults to a plain integer via toLocaleString. */
+  format?: (n: number) => string;
+  /** Spring configuration passed to motion's useSpring. */
+  spring?: SpringOptions;
+  /** When true, renders the final formatted value with no animation. */
+  skipAnimation?: boolean;
+  className?: string;
+};
+
+const defaultFormat = (n: number) => Math.round(n).toLocaleString();
+
+const defaultSpring: SpringOptions = {
+  stiffness: 120,
+  damping: 20,
+  mass: 1,
+};
+
+/**
+ * Count-up/count-down number display. On first mount it renders the final
+ * value statically (no animation) so page load never triggers a count-up.
+ * On subsequent value changes it animates from the previous value to the
+ * new one via a motion spring. Honors `skipAnimation` and
+ * `prefers-reduced-motion` by rendering the final value immediately.
+ */
+export function AnimatedNumber({
+  value,
+  format = defaultFormat,
+  spring: springOptions,
+  skipAnimation = false,
+  className,
+}: AnimatedNumberProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const shouldSkip = skipAnimation || !!prefersReducedMotion;
+
+  const safeValue = Number.isFinite(value) ? value : 0;
+
+  const hasMounted = useRef(false);
+  const springValue = useSpring(safeValue, springOptions ?? defaultSpring);
+  const [displayText, setDisplayText] = useState(() => format(safeValue));
+
+  // Keep the spring's target in sync with the incoming value.
+  useEffect(() => {
+    if (!hasMounted.current) {
+      // First mount: render statically, don't animate from 0.
+      hasMounted.current = true;
+      springValue.jump(safeValue);
+      setDisplayText(format(safeValue));
+      return;
+    }
+
+    if (shouldSkip) {
+      springValue.jump(safeValue);
+      setDisplayText(format(safeValue));
+      return;
+    }
+
+    springValue.set(safeValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [safeValue, shouldSkip]);
+
+  useEffect(() => {
+    const unsubscribe = springValue.on('change', (latest) => {
+      const safeLatest = Number.isFinite(latest) ? latest : safeValue;
+      setDisplayText(format(safeLatest));
+    });
+    return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [format, springValue]);
+
+  if (shouldSkip) {
+    return <span className={className}>{format(safeValue)}</span>;
+  }
+
+  return <span className={className}>{displayText}</span>;
+}
+
+export default AnimatedNumber;

--- a/tests/client/animated-number.test.tsx
+++ b/tests/client/animated-number.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * AnimatedNumber motion primitive test (Phase 4 PR-1).
+ *
+ * jsdom can't verify motion/spring animation quality, so these tests assert
+ * observable states: the final formatted value renders, `skipAnimation` and
+ * reduced-motion bypass animation entirely, value changes eventually settle
+ * on the new formatted value, and no NaN ever renders across an
+ * undefined-ish -> number transition.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Mock motion/react's useReducedMotion so we can flip it per-test, while
+// keeping the real useSpring behavior (jsdom can run its rAF-driven updates).
+const mockUseReducedMotion = vi.fn(() => false);
+vi.mock('motion/react', async () => {
+  const actual = await vi.importActual<typeof import('motion/react')>('motion/react');
+  return {
+    ...actual,
+    useReducedMotion: () => mockUseReducedMotion(),
+  };
+});
+
+import { AnimatedNumber } from '@/components/motion-primitives/animated-number';
+
+describe('AnimatedNumber', () => {
+  beforeEach(() => {
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the formatted final value on mount (no count-up on first render)', () => {
+    render(<AnimatedNumber value={1234} />);
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+  });
+
+  it('uses the provided format function', () => {
+    const format = (n: number) => `$${Math.round(n).toLocaleString()}`;
+    render(<AnimatedNumber value={5000} format={format} />);
+    expect(screen.getByText('$5,000')).toBeInTheDocument();
+  });
+
+  it('skipAnimation renders the final value immediately with no intermediate frames', () => {
+    const { container } = render(<AnimatedNumber value={9999} skipAnimation />);
+    expect(container.textContent).toBe('9,999');
+  });
+
+  it('reduced motion renders the final value immediately', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    const { container } = render(<AnimatedNumber value={42} />);
+    expect(container.textContent).toBe('42');
+  });
+
+  it('eventually settles on the new formatted value after a value change', async () => {
+    const { rerender } = render(<AnimatedNumber value={100} />);
+    expect(screen.getByText('100')).toBeInTheDocument();
+
+    rerender(<AnimatedNumber value={500} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('500')).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+
+  it('settles instantly on value change when skipAnimation is true', () => {
+    const { rerender, container } = render(<AnimatedNumber value={100} skipAnimation />);
+    expect(container.textContent).toBe('100');
+
+    rerender(<AnimatedNumber value={750} skipAnimation />);
+    expect(container.textContent).toBe('750');
+  });
+
+  it('never renders NaN when the value is NaN/undefined-ish then becomes a number', async () => {
+    const { rerender, container } = render(
+      <AnimatedNumber value={Number.NaN} />
+    );
+    expect(container.textContent).not.toContain('NaN');
+    expect(container.textContent).toBe('0');
+
+    rerender(<AnimatedNumber value={250} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('250')).toBeInTheDocument();
+    });
+    expect(container.textContent).not.toContain('NaN');
+  });
+
+  it('handles undefined-like (0) to number transitions without NaN, skip mode', () => {
+    const { rerender, container } = render(<AnimatedNumber value={0} skipAnimation />);
+    expect(container.textContent).toBe('0');
+
+    rerender(<AnimatedNumber value={1500} skipAnimation />);
+    expect(container.textContent).toBe('1,500');
+    expect(container.textContent).not.toContain('NaN');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `client/src/components/motion-primitives/animated-number.tsx`: a count-up/count-down number primitive built on `motion`'s `useSpring`, matching the house style of `border-trail.tsx` / `glow-effect.tsx` / `text-scramble.tsx`.
- On first mount, renders the final formatted value statically (no count-up on page load). On subsequent value changes it animates via a spring from the previous value to the new one.
- Honors `skipAnimation` prop and `prefers-reduced-motion` (via `useReducedMotion`) — both bypass animation and render the final value immediately.
- Guards against NaN/undefined by coercing non-finite values to `0` before formatting.
- Adopted in ONE place to prove it live: `MetricsDashboard.tsx`'s desktop "Weekly Performance" net income/loss hero figure, reusing the existing `formatSignedMoney` formatter and identical `font-mono text-xl leading-none` classes (added `block` since `AnimatedNumber` renders a `<span>` instead of the prior `<div>` — visual output when idle is unchanged).

Part of `docs/01-planning/implementation-specs/[READY] phase-4-game-feel-plan.md`, PR-1 (row 1 of the PR sequence in section 3), following the design principles in section 1 (skippable, reduced-motion = instant, no gameplay/visual redesign).

## Test plan
- [x] `npm run check` — clean, no errors
- [x] `npx vitest run tests/client/animated-number.test.tsx` — 8/8 passed (renders final value, custom format, skipAnimation, reduced-motion, settles on value change, skip-mode instant settle, no-NaN across NaN→number and 0→number transitions)
- [x] `npx vitest run tests/client` — 11 files / 75 tests passed (full existing client suite unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)