### PR TITLE
refactor(client): useGameState facade + migrate hooks/components (Phase 3.5 PR-3a)

### DIFF
--- a/client/src/components/ActiveReleases.tsx
+++ b/client/src/components/ActiveReleases.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useReleases } from '@/hooks/useReleases';
 import { useSongs } from '@/hooks/useSongs';
 import { useArtists } from '@/hooks/useArtists';
@@ -16,7 +16,7 @@ import {
 } from '../../../shared/utils/chartUtils';
 
 export function ActiveReleases() {
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
   // Phase 3 PR-6/PR-9: releases / songs / artists read from the TanStack Query
   // cache, not Zustand.
   const { data: releases = [] } = useReleases();

--- a/client/src/components/ActiveTours.tsx
+++ b/client/src/components/ActiveTours.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useProjects } from '@/hooks/useProjects';
 import { useArtists } from '@/hooks/useArtists';
 import { useLocation } from 'wouter';
@@ -262,7 +263,8 @@ function CompletedToursTable({ completedTours, getArtistName }: { completedTours
 }
 
 export function ActiveTours() {
-  const { cancelProject, gameState } = useGameStore();
+  const { cancelProject } = useGameStore();
+  const gameState = useGameState();
   // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
   const { data: artists = [] } = useArtists();

--- a/client/src/components/CommandDock.tsx
+++ b/client/src/components/CommandDock.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter';
 import { UserButton, useUser } from '@clerk/clerk-react';
 import { useIsAdmin } from '@/auth/useCurrentUser';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useGameContext } from '@/contexts/GameContext';
 import {
   Tooltip,
@@ -110,7 +111,8 @@ function DockItem({
  */
 export function CommandDock({ onShowSaveModal }: CommandDockProps) {
   const [location, setLocation] = useLocation();
-  const { gameState, weeklyOutcome } = useGameStore();
+  const gameState = useGameState();
+  const { weeklyOutcome } = useGameStore();
   const { gameId } = useGameContext();
   const { user } = useUser();
   const { isAdmin } = useIsAdmin();

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -11,6 +11,7 @@ import { MusicCalendar } from './MusicCalendar';
 import { InboxWidget } from './InboxWidget';
 import { TextScramble } from './motion-primitives/text-scramble';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useState, useEffect } from 'react';
 import { useLocation } from 'wouter';
 
@@ -23,7 +24,8 @@ export function Dashboard({
   showSaveModal = false,
   setShowSaveModal = () => {}
 }: DashboardProps) {
-  const { gameState, isAdvancingWeek, advanceWeek, weeklyOutcome, createProject } = useGameStore();
+  const gameState = useGameState();
+  const { isAdvancingWeek, advanceWeek, weeklyOutcome, createProject } = useGameStore();
   const [, setLocation] = useLocation();
   const [showWeekSummary, setShowWeekSummary] = useState(false);
   const [lastProcessedWeek, setLastProcessedWeek] = useState<number | null>(null);

--- a/client/src/components/GameHeader.tsx
+++ b/client/src/components/GameHeader.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useGameContext } from '@/contexts/GameContext';
 import { fetchExecutives, fetchRoleMeetings } from '@/services/executiveService';
 import {
@@ -21,7 +22,8 @@ import { Coins, ChevronsRight, Zap } from 'lucide-react';
  * (migrated from the old GameSidebar).
  */
 export function GameHeader() {
-  const { gameState, selectedActions, isAdvancingWeek, advanceWeek, selectAction } =
+  const gameState = useGameState();
+  const { selectedActions, isAdvancingWeek, advanceWeek, selectAction } =
     useGameStore();
   const { gameId } = useGameContext();
   const [isAutoSelecting, setIsAutoSelecting] = useState(false);

--- a/client/src/components/MetricsDashboard.tsx
+++ b/client/src/components/MetricsDashboard.tsx
@@ -1,4 +1,5 @@
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, TrendingDown, Clock, Zap, BarChart3 } from 'lucide-react';
@@ -20,7 +21,8 @@ interface ImpactPreview {
 }
 
 export function MetricsDashboard() {
-  const { gameState, selectedActions } = useGameStore();
+  const gameState = useGameState();
+  const { selectedActions } = useGameStore();
   const [impactPreview, setImpactPreview] = useState<ImpactPreview>({
     immediate: {},
     delayed: {},

--- a/client/src/components/MusicCalendar.tsx
+++ b/client/src/components/MusicCalendar.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Plus, Music, Mic2, Clock } from 'lucide-react';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useReleases } from '@/hooks/useReleases';
 import { useProjects } from '@/hooks/useProjects';
 import { useArtists } from '@/hooks/useArtists';
@@ -45,7 +45,7 @@ export function MusicCalendar({
   minWeek = 1,
   weekPickerMode = false
 }: MusicCalendarProps) {
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
   // Phase 3 PR-6/PR-7/PR-9: releases / projects / artists read from the TanStack
   // Query cache, not Zustand.
   const { data: artists = [] } = useArtists();

--- a/client/src/components/SelectionSummary.tsx
+++ b/client/src/components/SelectionSummary.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { TrendingUp, TrendingDown, Clock, Zap, BarChart3, X, Rocket, Loader2, Search, Crown, Music, Megaphone, Palette, Truck, type LucideIcon } from 'lucide-react';
 import logger from '@/lib/logger';
 
@@ -86,7 +87,8 @@ export function SelectionSummary({
   isAdvancing,
   impactPreview
 }: SelectionSummaryProps) {
-  const { gameState, cancelAROfficeOperation } = useGameStore();
+  const { cancelAROfficeOperation } = useGameStore();
+  const gameState = useGameState();
   const totalSlots = gameState?.focusSlots || 3;
   const usedSlots = gameState?.usedFocusSlots || 0;
   const availableSlots = totalSlots - usedSlots;

--- a/client/src/components/SongCatalog.tsx
+++ b/client/src/components/SongCatalog.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Music, Calendar, TrendingUp, DollarSign, PlayCircle, Award, Target } from 'lucide-react';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 import {
   getChartPositionColor,
@@ -53,7 +53,7 @@ export function SongCatalog({ artistId, gameId, className = '' }: SongCatalogPro
   const [retryCount, setRetryCount] = useState(0);
   
   // Subscribe to gameState to detect week changes
-  const currentWeek = useGameStore((state) => state.gameState?.currentWeek);
+  const currentWeek = useGameState((gameState) => gameState?.currentWeek);
 
   useEffect(() => {
     if (artistId && gameId) {

--- a/client/src/components/ToastNotification.tsx
+++ b/client/src/components/ToastNotification.tsx
@@ -2,11 +2,13 @@ import { Toaster } from '@/components/ui/toaster';
 import { ToastAction } from '@/components/ui/toast';
 import { useToast } from '@/hooks/use-toast';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useEffect, useRef, useState } from 'react';
 
 export function ToastNotification() {
   const { toast, dismiss } = useToast();
-  const { gameState, weeklyOutcome } = useGameStore();
+  const gameState = useGameState();
+  const { weeklyOutcome } = useGameStore();
   const prevGameState = useRef(gameState);
   const prevWeeklyOutcome = useRef(weeklyOutcome);
   const [recentToasts, setRecentToasts] = useState<Set<string>>(new Set());

--- a/client/src/components/Top100ChartDisplay.tsx
+++ b/client/src/components/Top100ChartDisplay.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Trophy, BarChart3 } from 'lucide-react';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useTop100Chart } from '@/hooks/useCharts';
 import { ChartDataTable } from '@/components/chart/ChartDataTable';
 import { ChartEntry, chartColumns } from '@/components/chart/chartColumns';
@@ -14,7 +14,7 @@ type Top100Entry = ChartEntry;
 export function Top100ChartDisplay() {
   console.log('🚀 Top100ChartDisplay component rendering...');
 
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
   console.log('🎮 GameState from store:', { id: gameState?.id, currentWeek: gameState?.currentWeek });
 
   const [showAll, setShowAll] = useState(false);

--- a/client/src/components/Top10ChartDisplay.tsx
+++ b/client/src/components/Top10ChartDisplay.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Trophy, BarChart3 } from 'lucide-react';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useTop10Chart } from '@/hooks/useCharts';
 import { ChartDataTable } from '@/components/chart/ChartDataTable';
 import { ChartEntry, chartColumns } from '@/components/chart/chartColumns';
@@ -15,7 +15,7 @@ type Top10Entry = ChartEntry;
 export function Top10ChartDisplay() {
   logger.debug('🚀 Top10ChartDisplay component rendering...');
 
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
   logger.debug('🎮 GameState from store:', { id: gameState?.id, currentWeek: gameState?.currentWeek });
 
   const {

--- a/client/src/components/TourVarianceTester.tsx
+++ b/client/src/components/TourVarianceTester.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
 import { Badge } from '@/components/ui/badge';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useArtists } from '@/hooks/useArtists';
 import { apiRequest } from '@/lib/queryClient';
 import { Calculator, TrendingUp, TrendingDown, Target } from 'lucide-react';
@@ -44,7 +44,7 @@ interface ActualResult {
 }
 
 export function TourVarianceTester() {
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
   // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
   const { data: artists = [] } = useArtists();
   const [selectedArtist, setSelectedArtist] = useState<string>('');

--- a/client/src/hooks/useAnalytics.ts
+++ b/client/src/hooks/useAnalytics.ts
@@ -6,15 +6,14 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { apiPaths } from '@/lib/apiPaths';
 
 /**
  * Hook to fetch ROI metrics for a specific artist
  */
 export function useArtistROI(artistId: string | undefined) {
-  const gameState = useGameStore((state) => state.gameState);
-  const gameId = gameState?.id ?? null;
+  const gameId = useGameId();
   const url = gameId && artistId
     ? apiPaths.analytics.artistRoi(gameId, artistId)
     : null;
@@ -34,8 +33,7 @@ export function useArtistROI(artistId: string | undefined) {
  * Hook to fetch ROI metrics for a specific project
  */
 export function useProjectROI(projectId: string | undefined) {
-  const gameState = useGameStore((state) => state.gameState);
-  const gameId = gameState?.id ?? null;
+  const gameId = useGameId();
   const url = gameId && projectId
     ? apiPaths.analytics.projectRoi(gameId, projectId)
     : null;
@@ -55,8 +53,7 @@ export function useProjectROI(projectId: string | undefined) {
  * Hook to fetch ROI metrics for a specific release
  */
 export function useReleaseROI(releaseId: string | undefined) {
-  const gameState = useGameStore((state) => state.gameState);
-  const gameId = gameState?.id ?? null;
+  const gameId = useGameId();
   const url = gameId && releaseId
     ? apiPaths.analytics.releaseRoi(gameId, releaseId)
     : null;
@@ -76,8 +73,7 @@ export function useReleaseROI(releaseId: string | undefined) {
  * Hook to fetch portfolio-wide ROI metrics
  */
 export function usePortfolioROI() {
-  const gameState = useGameStore((state) => state.gameState);
-  const gameId = gameState?.id ?? null;
+  const gameId = useGameId();
   const url = gameId ? apiPaths.analytics.portfolioRoi(gameId) : null;
 
   return useQuery<PortfolioROIMetrics>({

--- a/client/src/hooks/useArtists.ts
+++ b/client/src/hooks/useArtists.ts
@@ -23,7 +23,7 @@
  */
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 import type { Artist } from '@shared/schema';
 
@@ -34,7 +34,7 @@ export function artistsQueryKey(gameId: string | null | undefined) {
 }
 
 export function useArtists() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(() => artistsQueryKey(gameId), [gameId]);
 

--- a/client/src/hooks/useCharts.ts
+++ b/client/src/hooks/useCharts.ts
@@ -7,7 +7,7 @@
  */
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 import type { ChartEntry } from '@/components/chart/chartColumns';
 
@@ -27,7 +27,7 @@ export interface Top100ChartData {
 }
 
 export function useTop10Chart() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(
     () => [CHART_TOP10_SCOPE, gameId ?? null] as const,
@@ -45,7 +45,7 @@ export function useTop10Chart() {
 }
 
 export function useTop100Chart() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(
     () => [CHART_TOP100_SCOPE, gameId ?? null] as const,

--- a/client/src/hooks/useDiscoveredArtists.ts
+++ b/client/src/hooks/useDiscoveredArtists.ts
@@ -26,7 +26,7 @@
  */
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState, useGameId } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 
 export const DISCOVERED_ARTISTS_SCOPE = 'discovered-artists:list';
@@ -74,9 +74,9 @@ export async function fetchDiscoveredArtists(
 }
 
 export function useDiscoveredArtists() {
-  const gameId = useGameStore((state) => state.gameState?.id);
-  const flags = useGameStore((state) => (state.gameState as any)?.flags);
-  const arOfficeSlotUsed = useGameStore((state) => state.gameState?.arOfficeSlotUsed);
+  const gameId = useGameId();
+  const flags = useGameState((gameState) => (gameState as any)?.flags);
+  const arOfficeSlotUsed = useGameState((gameState) => gameState?.arOfficeSlotUsed);
 
   const queryKey = useMemo(() => discoveredArtistsQueryKey(gameId), [gameId]);
 

--- a/client/src/hooks/useEmails.ts
+++ b/client/src/hooks/useEmails.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 import { apiPaths, type EmailListQueryParams } from '@/lib/apiPaths';
 import logger from '@/lib/logger';
@@ -59,7 +59,7 @@ function normalizeEmail(email: any): EmailRecord<Record<string, unknown>> {
 }
 
 export function useEmails(params: EmailListQuery = {}) {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const limitFilter = typeof params.limit === 'number' ? params.limit : null;
   const offsetFilter = typeof params.offset === 'number' ? params.offset : null;
@@ -125,7 +125,7 @@ export function useEmails(params: EmailListQuery = {}) {
 }
 
 export function useUnreadEmailCount() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(
     () => [EMAIL_UNREAD_SCOPE, gameId ?? null] as const,
@@ -150,7 +150,7 @@ export function useUnreadEmailCount() {
 }
 
 export function useMarkEmailRead() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -184,7 +184,7 @@ export function useMarkEmailRead() {
 }
 
 export function useDeleteEmail() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/client/src/hooks/useExecutives.ts
+++ b/client/src/hooks/useExecutives.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { fetchExecutives } from '@/services/executiveService';
 import type { Executive } from '@shared/types/gameTypes';
 
@@ -49,7 +49,7 @@ export function makeCachedFetchExecutives(
 }
 
 export function useExecutives() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(() => executivesQueryKey(gameId), [gameId]);
 

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -1,0 +1,40 @@
+/**
+ * gameState spine façade (Phase 3.5 PR-3a).
+ *
+ * `gameState` (week, money, reputation, creativeCapital, focusSlots, access
+ * tiers, flags, A&R fields, embedded `musicLabel`) is still owned by the
+ * Zustand store today. This hook is the READ façade the rest of the app goes
+ * through so the eventual ownership flip onto the TanStack Query cache
+ * (Phase 3.5 PRs 4-6) is a one-file change (`useGameState.ts` only) instead of
+ * a 25-file rewrite.
+ *
+ * Right now `useGameState()` is LITERALLY `useGameStore((s) => s.gameState)`
+ * — zero behavior change, same Zustand subscription, same re-render
+ * granularity. Do not add `isLoading`/query-object semantics here; callers
+ * null-check the returned value exactly like they did against the store.
+ *
+ * `useGameState` accepts an optional selector so call sites can keep
+ * selector-level subscription granularity (e.g. `useGameState((gs) =>
+ * gs?.money)`) instead of subscribing to the whole spine object.
+ *
+ * See docs/01-planning/implementation-specs/[READY] phase-3.5-gamestate-tanstack-plan.md
+ * (§1 "synchronized copy first, wholesale flip second", §3 PR-3).
+ */
+import { useGameStore } from '@/store/gameStore';
+import type { GameState } from '@shared/types/gameTypes';
+
+export function useGameState(): GameState | null;
+export function useGameState<T>(selector: (gameState: GameState | null) => T): T;
+export function useGameState<T>(
+  selector?: (gameState: GameState | null) => T,
+): GameState | null | T {
+  return useGameStore((state) =>
+    selector ? selector(state.gameState) : state.gameState,
+  );
+}
+
+/** Convenience selector: the current game id, or null. Mirrors the 9 domain
+ * hooks' `useGameStore((state) => state.gameState?.id)` derivation. */
+export function useGameId(): string | null {
+  return useGameState((gameState) => gameState?.id ?? null);
+}

--- a/client/src/hooks/useProjects.ts
+++ b/client/src/hooks/useProjects.ts
@@ -21,7 +21,7 @@
  */
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 
 export const PROJECTS_SCOPE = 'projects:list';
@@ -31,7 +31,7 @@ export function projectsQueryKey(gameId: string | null | undefined) {
 }
 
 export function useProjects() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(() => projectsQueryKey(gameId), [gameId]);
 

--- a/client/src/hooks/useReleases.ts
+++ b/client/src/hooks/useReleases.ts
@@ -14,7 +14,7 @@
  */
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 
 export const RELEASES_SCOPE = 'releases:list';
@@ -29,7 +29,7 @@ export function releaseSongsQueryKey(gameId: string | null | undefined) {
 }
 
 export function useReleases() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(() => releasesQueryKey(gameId), [gameId]);
 
@@ -47,7 +47,7 @@ export function useReleases() {
 }
 
 export function useReleaseSongs() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(() => releaseSongsQueryKey(gameId), [gameId]);
 

--- a/client/src/hooks/useSongs.ts
+++ b/client/src/hooks/useSongs.ts
@@ -12,7 +12,7 @@
  */
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useGameStore } from '@/store/gameStore';
+import { useGameId } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 
 export const SONGS_SCOPE = 'songs:list';
@@ -22,7 +22,7 @@ export function songsQueryKey(gameId: string | null | undefined) {
 }
 
 export function useSongs() {
-  const gameId = useGameStore((state) => state.gameState?.id);
+  const gameId = useGameId();
 
   const queryKey = useMemo(() => songsQueryKey(gameId), [gameId]);
 


### PR DESCRIPTION
## Summary

Phase 3.5 **PR-3a** (per `docs/01-planning/implementation-specs/[READY] phase-3.5-gamestate-tanstack-plan.md` sec3 PR-3) -- the first half of the reader-migration PR, split per the plan's own guidance ("Split into 3a (hooks + components) and 3b (pages) if the diff exceeds ~15 files").

Adds `client/src/hooks/useGameState.ts`: `useGameState()` / `useGameState(selector)` / `useGameId()`. Today it is literally `useGameStore((s) => s.gameState)` under the hood -- **zero behavior change**, same Zustand subscription, same re-render granularity. The selector overload preserves selector-level subscription granularity (e.g. `useGameState((gs) => gs?.currentWeek)`) so call sites that only needed one field don't start re-rendering on the whole spine.

This façade is what makes the eventual ownership flip onto the TanStack Query cache (PRs 4-6) a one-file diff instead of a 25-file rewrite.

## Migrated (23 files + new hook)

**Domain hooks (9)** -- `gameId` derivation only:
- `useSongs.ts`, `useExecutives.ts`, `useCharts.ts` (both `useTop10Chart`/`useTop100Chart`), `useReleases.ts` (both `useReleases`/`useReleaseSongs`), `useEmails.ts` (all 4: `useEmails`/`useUnreadEmailCount`/`useMarkEmailRead`/`useDeleteEmail`), `useArtists.ts`, `useProjects.ts`, `useDiscoveredArtists.ts` (`gameId` + `flags` + `arOfficeSlotUsed`), `useAnalytics.ts` (all 4 ROI hooks)

**Components (14, plan sec0.1-A)**:
- `GameHeader.tsx`, `MetricsDashboard.tsx`, `Dashboard.tsx`, `CommandDock.tsx`, `MusicCalendar.tsx`, `SongCatalog.tsx`, `ToastNotification.tsx`, `SelectionSummary.tsx`, `ActiveReleases.tsx`, `ActiveTours.tsx`, `Top10ChartDisplay.tsx`, `Top100ChartDisplay.tsx`, `TourVarianceTester.tsx`

Mixed files (spine reads alongside action calls or session/UI state) keep the non-spine destructure on `useGameStore()` and split only the `gameState` read onto `useGameState()`: `GameHeader` (selectedActions/isAdvancingWeek/advanceWeek/selectAction stay), `MetricsDashboard` (selectedActions), `Dashboard` (isAdvancingWeek/advanceWeek/weeklyOutcome/createProject), `CommandDock` (weeklyOutcome), `ToastNotification` (weeklyOutcome), `ActiveTours` (cancelProject), `SelectionSummary` (cancelAROfficeOperation).

`ar-office/AROffice.tsx` (component, listed in plan sec0.1-A) intentionally **untouched**: it only reads actions (`startAROfficeOperation`/`cancelAROfficeOperation`); `gameState` fields arrive via props, so it isn't a spine reader.

## Remaining for PR-3b (11 pages, plan sec0.1-A)

`AROffice.tsx`, `ArtistPage.tsx`, `ArtistsLandingPage.tsx`, `ExecutiveSuitePage.tsx` (also feeds `SYNC_SLOTS`/`SYNC_WEEK` into XState from `gameState`), `GamePage.tsx`, `LivePerformancePage.tsx`, `MainMenuPage.tsx`, `PlanReleasePage.tsx`, `RecordingSessionPage.tsx`, `StreamingDecayTester.tsx`, `Top100ChartPage.tsx` -- all under `client/src/pages/`.

Not touched (out of scope for PR-3, per plan): the 13 writers in `gameStore.ts` (PR-4/PR-6 scope), `SaveGameModal.tsx`'s two imperative `getState()` sites (PR-6 scope), prop-drilled components (`AccessTierBadges.tsx`, `ArtistDiscoveryModal.tsx`, `ar-office/ArtistDiscoveryTable.tsx`).

## Verification

- `npm run check` -- clean.
- `npx vitest run tests/client` -- 11 files, **102 tests passed**.
- Full suite intentionally not run locally (shared Docker test DB on 5433 may be contended by concurrent agents); CI is the merge gate.

Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)