### PR TITLE
refactor(client): migrate remaining pages to useGameState facade (Phase 3.5 PR-3b)

### DIFF
--- a/client/src/components/ArtistRoster.tsx
+++ b/client/src/components/ArtistRoster.tsx
@@ -10,6 +10,7 @@ import {
   MenubarTrigger,
 } from '@/components/ui/menubar';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useProjects } from '@/hooks/useProjects';
 import { useArtists } from '@/hooks/useArtists';
 import { ArtistDiscoveryModal } from './ArtistDiscoveryModal';
@@ -47,7 +48,8 @@ const toGameArtist = (artist: DbArtist | (DbArtist & { loyalty?: number | null }
 };
 
 export function ArtistRoster() {
-  const { gameState, signArtist, loadGame } = useGameStore();
+  const gameState = useGameState();
+  const { signArtist, loadGame } = useGameStore();
   // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
   const { data: artists = [] } = useArtists();

--- a/client/src/components/SaveGameModal.tsx
+++ b/client/src/components/SaveGameModal.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useGameContext } from '@/contexts/GameContext';
@@ -50,7 +51,8 @@ interface SaveGameModalProps {
 }
 
 export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
-  const { gameState, saveGame, loadGameFromSave } = useGameStore();
+  const gameState = useGameState();
+  const { saveGame, loadGameFromSave } = useGameStore();
   const { setGameId } = useGameContext();
   const [newSaveName, setNewSaveName] = useState('');
   const [saving, setSaving] = useState(false);

--- a/client/src/components/__tests__/ArtistRoster.test.tsx
+++ b/client/src/components/__tests__/ArtistRoster.test.tsx
@@ -87,11 +87,17 @@ describe('ArtistRoster', () => {
       ],
     });
 
-    mockUseGameStore.mockReturnValue({
+    // The store mock must honor zustand's selector-style calls: useGameState()
+    // (the spine facade) calls useGameStore((s) => s.gameState), while the
+    // component's action destructure calls useGameStore() with no selector.
+    const fakeState = {
       gameState: { id: 'game-1', currentWeek: 12 },
       signArtist: vi.fn(),
       loadGame: vi.fn().mockResolvedValue(undefined),
-    });
+    };
+    mockUseGameStore.mockImplementation((selector?: (state: typeof fakeState) => unknown) =>
+      selector ? selector(fakeState) : fakeState,
+    );
   });
 
   it('opens the artist dialogue modal when selecting the meet action', async () => {

--- a/client/src/pages/AROffice.tsx
+++ b/client/src/pages/AROffice.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import GameLayout from '@/layouts/GameLayout';
 import { useGameContext } from '@/contexts/GameContext';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useArtists } from '@/hooks/useArtists';
 import { AROffice as AROfficeComponent } from '@/components/ar-office/AROffice';
 import type { GameState, Artist } from '@shared/schema';
 
 export default function AROffice() {
   const { gameId } = useGameContext();
-  const { gameState, signArtist } = useGameStore();
+  const gameState = useGameState();
+  const { signArtist } = useGameStore();
   // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
   const { data: artists = [] } = useArtists();
 

--- a/client/src/pages/ArtistPage.tsx
+++ b/client/src/pages/ArtistPage.tsx
@@ -20,7 +20,7 @@ import {
   Users,
   CircleCheck
 } from 'lucide-react';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useReleases } from '@/hooks/useReleases';
 import { useSongs } from '@/hooks/useSongs';
 import { useProjects } from '@/hooks/useProjects';
@@ -40,7 +40,7 @@ export default function ArtistPage() {
   const params = useParams();
   const artistParam = params.artistParam; // Can be either ID or slug
   const [, setLocation] = useLocation();
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
   // Phase 3 PR-6/PR-7/PR-9: releases / songs / projects / artists read from the
   // TanStack Query cache, not Zustand.
   const { data: releases = [] } = useReleases();

--- a/client/src/pages/ArtistsLandingPage.tsx
+++ b/client/src/pages/ArtistsLandingPage.tsx
@@ -8,6 +8,7 @@ import { ArtistDiscoveryModal } from '../components/ArtistDiscoveryModal';
 import { ArtistDialogueModal } from '../components/artist-dialogue/ArtistDialogueModal';
 import { ArtistCard as RichArtistCard, getArchetypeInfo, getRelationshipStatus } from '../components/ArtistCard';
 import { useGameStore } from '../store/gameStore';
+import { useGameState } from '../hooks/useGameState';
 import { useProjects } from '../hooks/useProjects';
 import { useArtists } from '../hooks/useArtists';
 import { usePortfolioROI, useArtistROI } from '../hooks/useAnalytics';
@@ -51,7 +52,8 @@ const ArtistsLandingPage: React.FC = () => {
   const [expandedArtist, setExpandedArtist] = useState<string | null>(null);
   const [isDialogueModalOpen, setIsDialogueModalOpen] = useState(false);
   const [selectedArtistForDialogue, setSelectedArtistForDialogue] = useState<Artist | null>(null);
-  const { gameState, signArtist, loadGame } = useGameStore();
+  const gameState = useGameState();
+  const { signArtist, loadGame } = useGameStore();
   // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
   const { data: artists = [] } = useArtists();

--- a/client/src/pages/ExecutiveSuitePage.tsx
+++ b/client/src/pages/ExecutiveSuitePage.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { AlertCircle, Loader2, Briefcase } from 'lucide-react';
 import { SelectionSummary } from '../components/SelectionSummary';
 import { ExecutiveMeetings } from '../components/executive-meetings/ExecutiveMeetings';
@@ -36,7 +37,8 @@ export default function ExecutiveSuitePage({
   onAdvanceWeek,
   isAdvancing,
 }: ExecutiveSuitePageProps = {}) {
-  const { gameState, selectedActions, removeAction, reorderActions, selectAction, getAROfficeStatus, advanceWeek, isAdvancingWeek } = useGameStore();
+  const gameState = useGameState();
+  const { selectedActions, removeAction, reorderActions, selectAction, getAROfficeStatus, advanceWeek, isAdvancingWeek } = useGameStore();
   const { gameId } = useGameContext();
   const [impactPreview, setImpactPreview] = useState<ImpactPreview>({
     immediate: {},

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -4,6 +4,7 @@ import { CampaignResultsModal } from '../components/CampaignResultsModal';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import GameLayout from '@/layouts/GameLayout';
 import { useGameStore } from '../store/gameStore';
+import { useGameState } from '../hooks/useGameState';
 import { useGameContext } from '../contexts/GameContext';
 import { Button } from '@/components/ui/button';
 import { apiRequest } from '@/lib/queryClient';
@@ -22,7 +23,8 @@ export default function GamePage() {
   const [showLabelModal, setShowLabelModal] = useState(false);
   const [isCreatingGameWithLabel, setIsCreatingGameWithLabel] = useState(false);
 
-  const { gameState, campaignResults, createNewGame, isAdvancingWeek, loadGame } = useGameStore();
+  const gameState = useGameState();
+  const { campaignResults, createNewGame, isAdvancingWeek, loadGame } = useGameStore();
   const { setGameId } = useGameContext();
   const { toast } = useToast();
   

--- a/client/src/pages/LivePerformancePage.tsx
+++ b/client/src/pages/LivePerformancePage.tsx
@@ -11,6 +11,7 @@ import { MapPin, Music, Calendar, Users, DollarSign, AlertCircle, Info, Target, 
 import type { GameState } from '@shared/schema';
 import { apiRequest } from '@/lib/queryClient';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useProjects } from '@/hooks/useProjects';
 import { useArtists } from '@/hooks/useArtists';
 import GameLayout from '@/layouts/GameLayout';
@@ -112,7 +113,8 @@ const PERFORMANCE_TYPES = [
 
 export default function LivePerformancePage() {
   const [, setLocation] = useLocation();
-  const { gameState, createProject } = useGameStore();
+  const gameState = useGameState();
+  const { createProject } = useGameStore();
   // Phase 3 PR-7/PR-9: projects and artists are cache-owned; read via hooks.
   const { data: projects = [] } = useProjects();
   const { data: artists = [] } = useArtists();

--- a/client/src/pages/MainMenuPage.tsx
+++ b/client/src/pages/MainMenuPage.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'wouter';
 import { UserButton, useUser } from '@clerk/clerk-react';
 import { HoloDisc } from '@/components/ui/holo-disc';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useArtists } from '@/hooks/useArtists';
 import { useGameContext } from '@/contexts/GameContext';
 import { LabelCreationModal } from '@/components/LabelCreationModal';
@@ -116,7 +117,8 @@ export default function MainMenuPage() {
   const [, setLocation] = useLocation();
   const { user } = useUser();
   const { gameId, setGameId } = useGameContext();
-  const { gameState, createNewGame } = useGameStore();
+  const gameState = useGameState();
+  const { createNewGame } = useGameStore();
   // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
   const { data: artists = [] } = useArtists();
   const { isAdmin } = useIsAdmin();

--- a/client/src/pages/PlanReleasePage.tsx
+++ b/client/src/pages/PlanReleasePage.tsx
@@ -10,6 +10,7 @@ import {
   ExternalLink, Sparkles
 } from 'lucide-react';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useLocation } from 'wouter';
 import { apiRequest } from '@/lib/queryClient';
 import GameLayout from '@/layouts/GameLayout';
@@ -121,7 +122,8 @@ const CHIP_BASE = 'inline-flex items-center rounded-pill font-mono text-[11px] p
 
 export default function PlanReleasePage() {
   const [, setLocation] = useLocation();
-  const { gameState, loadGame, planRelease } = useGameStore();
+  const gameState = useGameState();
+  const { loadGame, planRelease } = useGameStore();
   const { toast } = useToast();
 
   // Dynamic data state (loaded from balance config)

--- a/client/src/pages/RecordingSessionPage.tsx
+++ b/client/src/pages/RecordingSessionPage.tsx
@@ -9,6 +9,7 @@ import { Music, Disc3, Star, Clock, Zap, Award, Loader2, AlertCircle, SlidersHor
 import type { GameState } from '@shared/schema';
 import { apiRequest } from '@/lib/queryClient';
 import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { useArtists } from '@/hooks/useArtists';
 import GameLayout from '@/layouts/GameLayout';
 
@@ -137,7 +138,8 @@ interface ProjectTypeAPI {
 
 export default function RecordingSessionPage() {
   const [, setLocation] = useLocation();
-  const { gameState, createProject } = useGameStore();
+  const gameState = useGameState();
+  const { createProject } = useGameStore();
   // Phase 3 PR-9: artists roster read from the TanStack Query cache, not Zustand.
   const { data: artists = [] } = useArtists();
   const [isCreating, setIsCreating] = useState(false);

--- a/client/src/pages/StreamingDecayTester.tsx
+++ b/client/src/pages/StreamingDecayTester.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, BarChart3, TrendingUp, Loader2, Settings, Code } from 'lucide-react';
 import { useLocation } from 'wouter';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { apiRequest } from '@/lib/queryClient';
 import GameLayout from '@/layouts/GameLayout';
 
@@ -65,7 +65,7 @@ interface AwarenessConfig {
 
 export default function StreamingDecayTester() {
   const [, setLocation] = useLocation();
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
 
   // Test Parameters
   const [songQuality, setSongQuality] = useState(75);

--- a/client/src/pages/Top100ChartPage.tsx
+++ b/client/src/pages/Top100ChartPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Top100ChartDisplay } from '../components/Top100ChartDisplay';
 import GameLayout from '@/layouts/GameLayout';
-import { useGameStore } from '@/store/gameStore';
+import { useGameState } from '@/hooks/useGameState';
 import { Badge } from '@/components/ui/badge';
 
 export function Top100ChartPage() {
-  const { gameState } = useGameStore();
+  const gameState = useGameState();
 
   return (
     <GameLayout>


### PR DESCRIPTION
## Summary

Phase 3.5 **PR-3b** (per `docs/01-planning/implementation-specs/[READY] phase-3.5-gamestate-tanstack-plan.md` sec3 PR-3) -- second half of the reader-migration PR, following PR-3a (#103, hooks + components).

Migrates the remaining 11 spine-reader **pages** from direct `useGameStore` gameState reads to the `useGameState()` facade added in PR-3a, plus 2 leftover **components** found by the post-migration sweep. Zero behavior change -- same Zustand subscription under the hood, same re-render granularity.

## Migrated (13 files)

**Pages (11, plan sec0.1-A)**, all under `client/src/pages/`:
`AROffice.tsx`, `ArtistPage.tsx`, `ArtistsLandingPage.tsx`, `ExecutiveSuitePage.tsx`, `GamePage.tsx`, `LivePerformancePage.tsx`, `MainMenuPage.tsx`, `PlanReleasePage.tsx`, `RecordingSessionPage.tsx`, `StreamingDecayTester.tsx`, `Top100ChartPage.tsx`

All 11 genuinely read the spine -- none needed to be skipped as "prop-only" the way `ar-office/AROffice.tsx` (component) was in PR-3a.

**Leftover components (2)**, found by the sweep and folded in (second commit):
- `client/src/components/ArtistRoster.tsx` -- subscribed `gameState` destructure split onto `useGameState()`; `signArtist`/`loadGame` stay on `useGameStore`.
- `client/src/components/SaveGameModal.tsx` -- the line-53 **subscribed** `gameState` destructure only; the imperative `useGameStore.getState()` sites are untouched (PR-6 scope).

Mixed files keep the non-spine destructure (actions, session/UI state) on `useGameStore()` and split only the `gameState` read onto `useGameState()`:
- `AROffice.tsx` (`signArtist`), `ArtistsLandingPage.tsx` (`signArtist`/`loadGame`), `ExecutiveSuitePage.tsx` (`selectedActions`/`removeAction`/`reorderActions`/`selectAction`/`getAROfficeStatus`/`advanceWeek`/`isAdvancingWeek`), `GamePage.tsx` (`campaignResults`/`createNewGame`/`isAdvancingWeek`/`loadGame`), `LivePerformancePage.tsx` / `RecordingSessionPage.tsx` (`createProject`), `MainMenuPage.tsx` (`createNewGame`), `PlanReleasePage.tsx` (`loadGame`/`planRelease`).
- `ArtistPage.tsx`, `Top100ChartPage.tsx`, `StreamingDecayTester.tsx` were pure `gameState`-only reads -- straight swap.

## Leftover direct-read report

After this PR, grepping `client/src` for direct `useGameStore` gameState-spine **subscribed reads** outside `gameStore.ts`, the facade, and tests finds **none**. Remaining `useGameStore` usage is:
- writers/actions and session-state reads (`selectedActions`, `isAdvancingWeek`, `weeklyOutcome`, `campaignResults`, etc.) -- expected, PR-4/PR-6 scope;
- `SaveGameModal.tsx`'s two imperative `useGameStore.getState()` sites -- PR-6 scope per PR-3a;
- prop-drilled components (`ar-office/AROffice.tsx`, `AccessTierBadges.tsx`, `ArtistDiscoveryModal.tsx`) -- receive `gameState` via props, not store reads.

## Verification

- `npm run check` -- clean (re-run after the leftover commit).
- `npx vitest run tests/client` -- 12 files, **110 tests passed** (re-run after the leftover commit).
- Full suite intentionally not run locally (shared Docker test DB on 5433 may be contended); CI is the merge gate.

Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)