### PR TITLE
feat(client): gameState query key + dual-write commit funnel (Phase 3.5 PR-4)

### DIFF
--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -23,6 +23,26 @@
 import { useGameStore } from '@/store/gameStore';
 import type { GameState } from '@shared/types/gameTypes';
 
+/**
+ * Query-key scope for the gameState spine record (Phase 3.5 PR-4).
+ *
+ * The spine (week, money, reputation, creativeCapital, focusSlots, access
+ * tiers, flags, A&R fields, embedded `musicLabel`) is a CLIENT-COMMITTED RECORD
+ * in the TanStack Query cache — the store's `commitGameState` funnel is the ONLY
+ * writer (fan-out seed, advance-week commit, slot math, `adoptServerBalances`).
+ * PR-4 makes the store dual-write Zustand + this cache key; `useGameState()`
+ * still reads Zustand until PR-5 flips it. Client-committed-record semantics
+ * (staleTime/gcTime Infinity, no focus/reconnect refetch) belong to the hook
+ * that reads this key in PR-5 — a background refetch here would race the
+ * synchronous slot math (see plan §0.6).
+ */
+export const GAME_STATE_SCOPE = 'gameState:record' as const;
+
+/** The gameState-record cache key for a game: `['gameState:record', gameId]`. */
+export function gameStateQueryKey(gameId: string): readonly [string, string] {
+  return [GAME_STATE_SCOPE, gameId];
+}
+
 export function useGameState(): GameState | null;
 export function useGameState<T>(selector: (gameState: GameState | null) => T): T;
 export function useGameState<T>(

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -19,6 +19,7 @@ import {
   discoveredArtistsQueryKey,
   fetchDiscoveredArtists,
 } from '@/hooks/useDiscoveredArtists';
+import { gameStateQueryKey } from '@/hooks/useGameState';
 
 // Internal helper: the shared 6-endpoint + email-snapshot parallel reload used
 // identically by loadGame / loadGameFromSave / advanceWeek. Fans out the same
@@ -173,6 +174,52 @@ async function refetchDiscoveredArtistsCache(gameState: GameState | null) {
   }
 }
 
+// Phase 3.5 PR-4: THE dual-write commit funnel for the gameState spine.
+//
+// Every gameState write in the store flows through here. It (a) writes Zustand
+// exactly as before — `set({ gameState: next })`, same shallow-merge semantics,
+// byte-for-byte identical resulting store state — and (b) synchronously mirrors
+// the same object into the TanStack Query cache at `gameStateQueryKey(next.id)`.
+// The cache is a CLIENT-COMMITTED RECORD: this funnel is its only writer, so the
+// two sources can never diverge. `useGameState()` still READS Zustand until PR-5
+// flips it; the cache write here is a no-op for readers this PR but lets PR-5 be
+// a one-file change.
+//
+// `previousGameId` handles the game-SWITCH writers (loadGame / loadGameFromSave /
+// createNewGame): when the committed game's id differs from the game we were on,
+// the stale prior key is removed so a switched-away game never lingers in cache.
+// The new key is always seeded BEFORE any gameId flip is observable (the write
+// is synchronous and precedes the return), satisfying the PR-4 ordering pin.
+//
+// The `set` parameter is the Zustand setter (the store closure's `set`, or a
+// `set`-compatible shim over `useGameStore.setState` for helpers outside the
+// closure like `adoptServerBalances`).
+type ZustandSet = (partial: Partial<GameStore>) => void;
+
+function commitGameState(
+  set: ZustandSet,
+  next: GameState,
+  previousGameId?: string | null,
+) {
+  // (a) Zustand write — unchanged semantics.
+  set({ gameState: next });
+  // (b) Cache mirror. Drop the stale key first on a game switch so a
+  // switched-away game never lingers in the cache. `removeQueries` is guarded
+  // for the mocked queryClient in the characterization harness (which stubs only
+  // invalidate/set/getQueryData) — its absence must not break the Zustand write.
+  if (
+    previousGameId &&
+    next.id &&
+    previousGameId !== next.id &&
+    typeof queryClient.removeQueries === 'function'
+  ) {
+    queryClient.removeQueries({ queryKey: gameStateQueryKey(previousGameId) });
+  }
+  if (next.id) {
+    queryClient.setQueryData(gameStateQueryKey(next.id), next);
+  }
+}
+
 // Phase 3 PR-10: adopt the SERVER-CANONICAL money + creativeCapital after a
 // mutation instead of doing optimistic client-side arithmetic on gameState.
 // signArtist / createProject / planRelease all recompute cost server-side (Phase
@@ -199,12 +246,13 @@ async function adoptServerBalances(get: () => GameStore, gameId: string) {
     if (!serverGameState) return;
     const current = get().gameState;
     if (!current) return;
-    useGameStore.setState({
-      gameState: {
-        ...current,
-        money: serverGameState.money,
-        creativeCapital: serverGameState.creativeCapital,
-      },
+    // Phase 3.5 PR-4: route the two-field merge through the dual-write funnel so
+    // the cache mirror stays in lock-step. Same-game write (id unchanged), so no
+    // previous-key removal. `useGameStore.setState` is the setter here.
+    commitGameState((partial) => useGameStore.setState(partial), {
+      ...current,
+      money: serverGameState.money,
+      creativeCapital: serverGameState.creativeCapital,
     });
   } catch (error) {
     console.error('[PR-10] Failed to adopt server balances:', error);
@@ -309,6 +357,7 @@ export const useGameStore = create<GameStore>()(
 
       // Load existing game
       loadGame: async (gameId: string) => {
+        const previousGameId = get().gameState?.id ?? null;
         try {
           const {
             gameData: data,
@@ -348,8 +397,11 @@ export const useGameStore = create<GameStore>()(
           // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /
           // artists are seeded into the TanStack Query cache by fetchGameBundle —
           // no longer written here.
+          // Phase 3.5 PR-4: gameState flows through the dual-write funnel (Zustand
+          // + cache); the remaining store fields keep their plain `set`. Game
+          // switch → the funnel removes the previous game's stale record key.
+          commitGameState(set, gameStateWithLabel, previousGameId);
           set({
-            gameState: gameStateWithLabel,
             roles: data.roles,
             weeklyActions: data.weeklyActions,
             emails: emailList,
@@ -372,6 +424,7 @@ export const useGameStore = create<GameStore>()(
 
       // Load game from save
       loadGameFromSave: async (saveId: string, snapshot: GameSaveSnapshot, mode: 'overwrite' | 'fork' = 'overwrite') => {
+        const previousGameId = get().gameState?.id ?? null;
         try {
           if (!snapshot?.gameState?.id) {
             throw new Error('Invalid save data format');
@@ -421,8 +474,12 @@ export const useGameStore = create<GameStore>()(
           // with the server's authoritative copy.
           seedArtistsCache(baseGameState.id, snapshot.artists || []);
 
+          // Phase 3.5 PR-4: commit the interim gameState through the funnel
+          // (Zustand + cache). Game switch from `previousGameId` → its stale
+          // record key is removed; the new interim key is seeded here BEFORE any
+          // downstream gameId flip is observable.
+          commitGameState(set, interimGameState, previousGameId);
           set({
-            gameState: interimGameState,
             roles: (snapshot.roles || []) as unknown as Role[],
             emails: snapshot.emails || [],
             executives: snapshot.executives || [],
@@ -460,8 +517,11 @@ export const useGameStore = create<GameStore>()(
           // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /
           // artists seeded into the query cache by fetchGameBundle above — no
           // longer written into the store.
+          // Phase 3.5 PR-4: commit the post-restore gameState through the funnel.
+          // On a FORK the restored id differs from the interim id — pass the
+          // interim id as `previousGameId` so the interim key is cleared.
+          commitGameState(set, syncedGameState, interimGameState.id);
           set({
-            gameState: syncedGameState,
             roles: gameData.roles || [],
             weeklyActions: gameData.weeklyActions || [],
             emails: emailList || [],
@@ -505,6 +565,7 @@ export const useGameStore = create<GameStore>()(
           // ============================================================================
 
           const currentGame = get().gameState;
+          const previousGameId = currentGame?.id ?? null;
           if (currentGame?.id) {
             console.log(`[ORPHANED GAME CLEANUP] Checking if current game ${currentGame.id} (Week ${currentGame.currentWeek}) has saves...`);
 
@@ -614,9 +675,12 @@ export const useGameStore = create<GameStore>()(
           seedArtistsCache(gameState.id, []);
           queryClient.setQueryData(discoveredArtistsQueryKey(gameState.id), []);
 
-          // Clear campaign results and set new state
+          // Clear campaign results and set new state.
+          // Phase 3.5 PR-4: commit the new game's gameState through the funnel.
+          // The new id differs from `previousGameId` (or there was none) → the
+          // funnel removes the old game's stale record key and seeds the new one.
+          commitGameState(set, syncedGameState, previousGameId);
           set({
-            gameState: syncedGameState,
             roles: [],
             weeklyActions: [],
             emails: [],
@@ -655,11 +719,10 @@ export const useGameStore = create<GameStore>()(
           const arUsed = gameState.arOfficeSlotUsed ? 1 : 0;
           const newUsedSlots = newSelectedActions.length + arUsed;
           
-          // Update local state
-          set({
-            selectedActions: newSelectedActions,
-            gameState: { ...gameState, usedFocusSlots: newUsedSlots }
-          });
+          // Update local state. Phase 3.5 PR-4: gameState → dual-write funnel
+          // (same game, no key removal); selectedActions keeps its plain `set`.
+          set({ selectedActions: newSelectedActions });
+          commitGameState(set, { ...gameState, usedFocusSlots: newUsedSlots });
 
           await syncSlotsPatch(gameState.id, {
             usedFocusSlots: newUsedSlots,
@@ -676,11 +739,10 @@ export const useGameStore = create<GameStore>()(
           const arUsed = gameState.arOfficeSlotUsed ? 1 : 0;
           const newUsedSlots = newSelectedActions.length + arUsed;
           
-          // Update local state
-          set({
-            selectedActions: newSelectedActions,
-            gameState: { ...gameState, usedFocusSlots: newUsedSlots }
-          });
+          // Update local state. Phase 3.5 PR-4: gameState → dual-write funnel
+          // (same game, no key removal); selectedActions keeps its plain `set`.
+          set({ selectedActions: newSelectedActions });
+          commitGameState(set, { ...gameState, usedFocusSlots: newUsedSlots });
 
           // Sync focus slots and A&R status to server to prevent desync issues
           await syncSlotsPatch(gameState.id, {
@@ -702,10 +764,13 @@ export const useGameStore = create<GameStore>()(
       clearActions: () => {
         const { gameState } = get();
         const arUsed = gameState?.arOfficeSlotUsed ? 1 : 0;
-        set({ 
-          selectedActions: [],
-          gameState: gameState ? { ...gameState, usedFocusSlots: arUsed } : gameState
-        });
+        // Phase 3.5 PR-4: selectedActions keeps its plain `set`; gameState (when
+        // present) flows through the dual-write funnel. When gameState is null it
+        // stays null (no funnel write) — same as the prior conditional.
+        set({ selectedActions: [] });
+        if (gameState) {
+          commitGameState(set, { ...gameState, usedFocusSlots: arUsed });
+        }
       },
 
       // Advance week
@@ -817,8 +882,10 @@ export const useGameStore = create<GameStore>()(
           // artists seeded into the query cache by fetchGameBundle — no longer
           // written into the store. The artists seed reflects post-week mood
           // changes (formerly `artists: gameData.artists`).
+          // Phase 3.5 PR-4: gameState → dual-write funnel (same game, no key
+          // removal); the session/UI fields keep their plain `set`.
+          commitGameState(set, syncedGameState);
           set({
-            gameState: syncedGameState,
             emails: emailList || [],
             executives: Array.isArray(executivesData) ? executivesData : [],
             moodEvents: Array.isArray(moodEventsData) ? moodEventsData : [],
@@ -1089,7 +1156,8 @@ export const useGameStore = create<GameStore>()(
             ...gameState,
             money: result.newBalance
           };
-          set({ gameState: updatedGameState });
+          // Phase 3.5 PR-4: dual-write funnel (same game).
+          commitGameState(set, updatedGameState);
 
           // Phase 3 PR-7: projects are cache-owned now. Invalidate the projects
           // key so useProjects drops the cancelled project instead of filtering
@@ -1152,7 +1220,8 @@ export const useGameStore = create<GameStore>()(
           usedFocusSlots: selectedActions.length + 1,
         } as GameState;
 
-        set({ gameState: updated });
+        // Phase 3.5 PR-4: dual-write funnel (same game).
+        commitGameState(set, updated);
 
         await syncSlotsPatch(gameState.id, {
           usedFocusSlots: updated.usedFocusSlots,
@@ -1172,7 +1241,8 @@ export const useGameStore = create<GameStore>()(
           usedFocusSlots: selectedActions.length,
         } as GameState;
 
-        set({ gameState: updated });
+        // Phase 3.5 PR-4: dual-write funnel (same game).
+        commitGameState(set, updated);
 
         await syncSlotsPatch(gameState.id, {
           usedFocusSlots: updated.usedFocusSlots,

--- a/tests/client/gameStore-dual-write.characterization.test.ts
+++ b/tests/client/gameStore-dual-write.characterization.test.ts
@@ -1,0 +1,273 @@
+/**
+ * gameStore dual-write funnel characterization tests (Phase 3.5 PR-4).
+ *
+ * PR-4 routes every gameState write in the store through a single
+ * `commitGameState()` funnel that dual-writes: the Zustand `set({ gameState })`
+ * (unchanged) PLUS `queryClient.setQueryData(gameStateQueryKey(id), next)`. This
+ * suite asserts the INVARIANT that makes PR-5's reader flip safe: after every
+ * store action, the cache record at `gameStateQueryKey(id)` deep-equals the
+ * Zustand `gameState`. The Zustand side itself is pinned unchanged by
+ * gameStore-spine.characterization.test.ts (the PR-1 net) — this file adds the
+ * cache-equivalence half.
+ *
+ * The mocked queryClient here exposes `removeQueries` in addition to
+ * set/get/invalidate because the game-SWITCH writers (loadGame /
+ * loadGameFromSave / createNewGame) drop the previous game's stale record key.
+ *
+ * Mirrors the mock/harness setup of the other gameStore characterization tests.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const queryCache = new Map<string, unknown>();
+vi.mock('@/lib/queryClient', () => ({
+  apiRequest: vi.fn(),
+  queryClient: {
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    setQueryData: vi.fn((key: unknown, value: unknown) => {
+      queryCache.set(JSON.stringify(key), value);
+      return value;
+    }),
+    getQueryData: vi.fn((key: unknown) => queryCache.get(JSON.stringify(key))),
+    removeQueries: vi.fn(({ queryKey }: { queryKey: unknown }) => {
+      queryCache.delete(JSON.stringify(queryKey));
+    }),
+  },
+}));
+vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import { apiRequest, queryClient } from '@/lib/queryClient';
+import { gameStateQueryKey } from '@/hooks/useGameState';
+import { useGameStore } from '@/store/gameStore';
+import {
+  routeApiRequest as routeApiRequestImpl,
+  jsonResponse,
+  resetGameStore as resetGameStoreImpl,
+  baseGameState,
+} from './gameStore-harness';
+
+const mockedApiRequest = apiRequest as unknown as ReturnType<typeof vi.fn>;
+const routeApiRequest = (routes: Array<{ match: (url: string) => boolean; body: unknown }>) =>
+  routeApiRequestImpl(mockedApiRequest, routes);
+const resetGameStore = () => resetGameStoreImpl(useGameStore);
+
+/** The single invariant this whole suite exists to prove. */
+function cacheEqualsStore(gameId: string) {
+  const store = useGameStore.getState().gameState;
+  const cached = queryClient.getQueryData(gameStateQueryKey(gameId));
+  expect(cached).toEqual(store);
+}
+
+beforeEach(() => {
+  mockedApiRequest.mockReset();
+  queryCache.clear();
+  resetGameStore();
+  mockedApiRequest.mockResolvedValue(jsonResponse({}));
+});
+
+describe('dual-write funnel: same-game slot writers', () => {
+  it('selectAction mirrors the new gameState into the cache', () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }),
+      selectedActions: [],
+    });
+
+    void useGameStore.getState().selectAction('action-A');
+
+    expect(useGameStore.getState().gameState!.usedFocusSlots).toBe(1);
+    cacheEqualsStore('game-1');
+    expect(
+      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots,
+    ).toBe(1);
+  });
+
+  it('removeAction mirrors the decremented gameState into the cache', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', usedFocusSlots: 2, arOfficeSlotUsed: false }),
+      selectedActions: ['action-A', 'action-B'],
+    });
+
+    await useGameStore.getState().removeAction('action-A');
+
+    cacheEqualsStore('game-1');
+    expect(
+      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots,
+    ).toBe(1);
+  });
+
+  it('clearActions mirrors the reset gameState into the cache', () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', usedFocusSlots: 2, arOfficeSlotUsed: false }),
+      selectedActions: ['action-A', 'action-B'],
+    });
+
+    useGameStore.getState().clearActions();
+
+    cacheEqualsStore('game-1');
+    expect(
+      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots,
+    ).toBe(0);
+  });
+
+  it('consumeAROfficeSlot mirrors the A&R gameState into the cache', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 1, arOfficeSlotUsed: false }),
+      selectedActions: ['action-A'],
+    });
+
+    await useGameStore.getState().consumeAROfficeSlot('active');
+
+    cacheEqualsStore('game-1');
+    expect(
+      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).arOfficeSlotUsed,
+    ).toBe(true);
+  });
+
+  it('releaseAROfficeSlot mirrors the cleared A&R gameState into the cache', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 2, arOfficeSlotUsed: true, arOfficeSourcingType: 'active' }),
+      selectedActions: ['action-A'],
+    });
+
+    await useGameStore.getState().releaseAROfficeSlot();
+
+    cacheEqualsStore('game-1');
+    expect(
+      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).arOfficeSlotUsed,
+    ).toBe(false);
+  });
+});
+
+describe('dual-write funnel: balance-adopting writers', () => {
+  it('cancelProject mirrors result.newBalance into the cache', async () => {
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 20000 }) });
+    routeApiRequest([
+      { match: (u) => u.includes('/cancel'), body: { newBalance: 27500, refundAmount: 7500 } },
+    ]);
+
+    await useGameStore.getState().cancelProject('proj-1', { refundAmount: 7500 });
+
+    cacheEqualsStore('game-1');
+    expect((queryClient.getQueryData(gameStateQueryKey('game-1')) as any).money).toBe(27500);
+  });
+
+  it('adoptServerBalances (via planRelease) mirrors the two-field merge into the cache', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4, musicLabel: { name: 'Keep' } }),
+    });
+    routeApiRequest([
+      { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 55000, creativeCapital: 1 } } },
+      { match: (u) => u.includes('/releases/plan'), body: { ok: true } },
+    ]);
+
+    await useGameStore.getState().planRelease({ metadata: { totalInvestment: 1000 } });
+
+    cacheEqualsStore('game-1');
+    const cached = queryClient.getQueryData(gameStateQueryKey('game-1')) as any;
+    expect(cached.money).toBe(55000);
+    expect(cached.creativeCapital).toBe(1);
+    expect(cached.musicLabel).toEqual({ name: 'Keep' }); // preserved, not clobbered
+  });
+});
+
+describe('dual-write funnel: game-switch writers seed the new key + drop the old', () => {
+  function routeLoad(gameId: string, musicLabel: any) {
+    mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
+      if (url.endsWith('/songs')) return jsonResponse([]);
+      if (url.endsWith('/releases')) return jsonResponse([]);
+      if (url.endsWith('/release-songs')) return jsonResponse([]);
+      if (url.endsWith('/executives')) return jsonResponse([]);
+      if (url.endsWith('/mood-events')) return jsonResponse([]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [], total: 0, unreadCount: 0 });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      return jsonResponse({
+        gameState: { id: gameId, currentWeek: 3, money: 5000, arOfficeSlotUsed: false, arOfficeSourcingType: null },
+        musicLabel,
+        artists: [],
+        projects: [],
+        roles: [],
+        weeklyActions: [],
+      });
+    });
+  }
+
+  it('loadGame seeds the loaded game key equal to the store gameState', async () => {
+    routeLoad('game-1', { name: 'Loaded Label' });
+
+    await useGameStore.getState().loadGame('game-1');
+
+    cacheEqualsStore('game-1');
+    expect((queryClient.getQueryData(gameStateQueryKey('game-1')) as any).musicLabel).toEqual({
+      name: 'Loaded Label',
+    });
+  });
+
+  it('switching games via loadGame drops the previous game key and seeds the new one', async () => {
+    // Start on game-A with a seeded record.
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-A' }) });
+    queryClient.setQueryData(gameStateQueryKey('game-A'), baseGameState({ id: 'game-A' }));
+
+    routeLoad('game-B', { name: 'B Label' });
+    await useGameStore.getState().loadGame('game-B');
+
+    // Old key removed, new key seeded and equal to the store.
+    expect(queryClient.getQueryData(gameStateQueryKey('game-A'))).toBeUndefined();
+    cacheEqualsStore('game-B');
+    expect(queryClient.removeQueries).toHaveBeenCalledWith({
+      queryKey: gameStateQueryKey('game-A'),
+    });
+  });
+
+  it('createNewGame drops the previous (orphaned) game key and seeds the new game', async () => {
+    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    queryClient.setQueryData(gameStateQueryKey('game-1'), baseGameState({ id: 'game-1' }));
+
+    mockedApiRequest.mockImplementation(async (method: string, url: string) => {
+      if (method === 'GET' && url.endsWith('/api/saves')) return jsonResponse([]); // orphaned
+      if (method === 'DELETE' && /\/api\/game\/[^/]+$/.test(url)) return jsonResponse({ ok: true });
+      if (method === 'POST' && url.endsWith('/api/game')) return jsonResponse({ id: 'game-2', currentWeek: 1 });
+      if (method === 'GET' && /\/api\/game\/[^/]+$/.test(url)) {
+        return jsonResponse({ gameState: { id: 'game-2', currentWeek: 1 }, musicLabel: null });
+      }
+      return jsonResponse({});
+    });
+
+    await useGameStore.getState().createNewGame('Balanced');
+
+    expect(queryClient.getQueryData(gameStateQueryKey('game-1'))).toBeUndefined();
+    cacheEqualsStore('game-2');
+    expect((queryClient.getQueryData(gameStateQueryKey('game-2')) as any).id).toBe('game-2');
+  });
+});
+
+describe('dual-write funnel: advanceWeek commits the merged gameState to the cache', () => {
+  it('mirrors the post-advance gameState (refetch-wins merge) into the cache', async () => {
+    useGameStore.setState({
+      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }),
+      selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
+    });
+
+    mockedApiRequest.mockImplementation(async (_m: string, url: string) => {
+      if (url.includes('/advance-week')) {
+        return jsonResponse({ gameState: { id: 'game-1', currentWeek: 6, money: 9000 }, summary: { week: 6 }, campaignResults: null });
+      }
+      if (url.endsWith('/songs')) return jsonResponse([]);
+      if (url.endsWith('/releases')) return jsonResponse([]);
+      if (url.endsWith('/release-songs')) return jsonResponse([]);
+      if (url.endsWith('/executives')) return jsonResponse([]);
+      if (url.endsWith('/mood-events')) return jsonResponse([]);
+      if (url.includes('/emails?') || url.endsWith('/emails')) return jsonResponse({ emails: [], total: 0, unreadCount: 0 });
+      if (url.includes('/saves')) return jsonResponse({ ok: true });
+      if (url.includes('/ar-office/artists')) return jsonResponse({ artists: [] });
+      // GET /api/game/:id reload — money 12345 wins over advance-week's 9000.
+      return jsonResponse({ gameState: { id: 'game-1', currentWeek: 6, money: 12345 }, musicLabel: { name: 'L' }, artists: [], projects: [] });
+    });
+
+    await useGameStore.getState().advanceWeek();
+
+    cacheEqualsStore('game-1');
+    const cached = queryClient.getQueryData(gameStateQueryKey('game-1')) as any;
+    expect(cached.currentWeek).toBe(6);
+    expect(cached.money).toBe(12345); // refetch-wins, mirrored to cache
+    expect(cached.usedFocusSlots).toBe(0);
+  });
+});

--- a/tests/client/query-key-contract.test.ts
+++ b/tests/client/query-key-contract.test.ts
@@ -36,6 +36,7 @@ import {
   DISCOVERED_ARTISTS_SCOPE,
   discoveredArtistsQueryKey,
 } from '@/hooks/useDiscoveredArtists';
+import { GAME_STATE_SCOPE, gameStateQueryKey } from '@/hooks/useGameState';
 
 const GAME_ID = 'game-1';
 const ARTIST_ID = 'artist-1';
@@ -70,6 +71,8 @@ const REAL_QUERY_KEYS: readonly unknown[][] = [
   // [SCOPE, gameId]
   [...artistsQueryKey(GAME_ID)],
   [...discoveredArtistsQueryKey(GAME_ID)],
+  // gameState spine record (useGameState.ts, Phase 3.5 PR-4): [SCOPE, gameId]
+  [...gameStateQueryKey(GAME_ID)],
   ['api', 'saves'],
 ];
 
@@ -191,6 +194,31 @@ describe('query-key contract: artist mutation invalidations (PR-9)', () => {
   it('the artist scope constants and hook keys agree element-for-element', () => {
     expect(artistsQueryKey(GAME_ID)).toEqual([ARTISTS_SCOPE, GAME_ID]);
     expect(discoveredArtistsQueryKey(GAME_ID)).toEqual([DISCOVERED_ARTISTS_SCOPE, GAME_ID]);
+  });
+});
+
+describe('query-key contract: gameState record key (Phase 3.5 PR-4)', () => {
+  // The dual-write funnel (commitGameState) writes the spine to the query cache
+  // at gameStateQueryKey(gameId) == [GAME_STATE_SCOPE, gameId]. It's a
+  // client-committed record written via setQueryData (not invalidated), but the
+  // key must still be a real, uniquely-scoped shape that matches nothing else.
+  it('the gameState record key is [GAME_STATE_SCOPE, gameId]', () => {
+    expect(gameStateQueryKey(GAME_ID)).toEqual([GAME_STATE_SCOPE, GAME_ID]);
+    expect(GAME_STATE_SCOPE).toBe('gameState:record');
+  });
+
+  it('a gameState-key write targets exactly one game (no cross-game bleed)', () => {
+    expect(someRealKeyMatchesInvalidationKey(gameStateQueryKey(GAME_ID))).toBe(true);
+    expect(someRealKeyMatchesInvalidationKey(gameStateQueryKey('other'))).toBe(false);
+  });
+
+  it('the gameState scope does not collide with any other hook scope', () => {
+    // No OTHER real query key starts with GAME_STATE_SCOPE — the record key is
+    // its own namespace, so a spine commit can never clobber a collection cache.
+    const collisions = REAL_QUERY_KEYS.filter(
+      (real) => real[0] === GAME_STATE_SCOPE && real[1] !== GAME_ID,
+    );
+    expect(collisions).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Phase 3.5 PR-4 — gameState record key + dual-write funnel

Implements exactly PR-4 of the [gameState → TanStack plan](docs/01-planning/implementation-specs/): introduce the `['gameState:record', gameId]` query key and route all gameState writes through one dual-write funnel. **Readers are untouched** — `useGameState()` still reads Zustand; PR-5 flips it. This PR only makes the cache a synchronized mirror so the eventual flip is a one-file change.

### Funnel design
`commitGameState(set, next, previousGameId?)` in `gameStore.ts`:
1. **Zustand write, unchanged** — `set({ gameState: next })`, same shallow-merge semantics, byte-for-byte identical resulting store state.
2. **Cache mirror** — `queryClient.setQueryData(gameStateQueryKey(next.id), next)` synchronously.
3. **Game switch** — when `previousGameId !== next.id`, `removeQueries` drops the stale key first, then the new key is seeded (before any gameId flip is observable). The `removeQueries` call is guarded so the mock-free characterization harness (which stubs only set/get/invalidate) is unaffected.

`gameStateQueryKey` / `GAME_STATE_SCOPE = 'gameState:record'` live in `useGameState.ts`. Client-committed-record staleTime/refetch semantics are documented on the scope but belong to the PR-5 reader (a background refetch on this key would race the synchronous slot math — plan §0.6).

### The 12 funneled sites
`loadGame`, `loadGameFromSave` (interim + post-restore = 2), `createNewGame`, `selectAction`, `removeAction`, `clearActions`, `advanceWeek`, `cancelProject`, `consumeAROfficeSlot`, `releaseAROfficeSlot`, `adoptServerBalances`. Game-switch writers (loadGame / loadGameFromSave / createNewGame) pass `previousGameId`; same-game writers omit it. Partial-field writers still build `next` from `get().gameState` exactly as today; non-gameState fields keep their plain `set`.

### Tests
- `query-key-contract.test.ts` — extended: record key shape `[GAME_STATE_SCOPE, gameId]`, single-game targeting, and a non-collision assertion (the record scope namespaces nothing else).
- `gameStore-dual-write.characterization.test.ts` (new) — asserts the invariant `getQueryData(gameStateQueryKey(id)) deep-equals getState().gameState` after every store action, plus old-key removal / new-key seeding on game switch.
- **PR-1 spine net (`gameStore-spine.characterization.test.ts`) passes UNCHANGED** — the Zustand side is pinned.

### Verification
- `npm run check` — clean.
- `npx vitest run tests/client` — 13 files, **124 passed**.
- `npx vitest run client/src` — 10 files, **97 passed**.

No deviation from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
