### PR TITLE
refactor(server): merge week advance into one transaction + FOR UPDATE guard (D6 PR-3)

### DIFF
--- a/server/services/advanceWeekService.ts
+++ b/server/services/advanceWeekService.ts
@@ -9,16 +9,26 @@
  *
  * Behavior is intentionally byte-equivalent to the pre-extraction handler,
  * including every console.log, the GameEngine construction, the action
- * formatting, the campaign-completed early return, and — critically — the
- * TWO SEPARATE transactions (D6: transactionality is out of scope; the split at
- * the boundary between engine execution and persistence moves verbatim, same tx
- * boundaries, same operations in each, same order).
+ * formatting, and the campaign-completed early return.
  *
- * TX 1: loads gameState + artists, checks campaign completion (early return),
- *       initializes serverGameData, loads released projects, builds the engine,
- *       formats actions, and runs engine.advanceWeek(actions, tx).
- * TX 2: persists the updated gameState, saves weekly actions, reads back
+ * D6 PR-3: the ENTIRE week advance is now ONE PostgreSQL transaction. The former
+ * TX 2 (gameStates UPDATE + weekly_actions INSERT + debug read-backs) was merged
+ * into TX 1, immediately after engine.advanceWeek(actions, tx) returns, in the
+ * SAME statement order. A crash anywhere mid-advance now rolls back the entire
+ * week — all-or-nothing (see tests/features/advance-week-atomicity.test.ts).
+ *
+ * The initial gameStates select takes a `SELECT ... FOR UPDATE` row lock so two
+ * concurrent advances for the same game serialize (the second blocks on the
+ * first's committed week N+1 state, then advances once more) instead of both
+ * reading week N and double-applying. (Reject-on-stale-week is a follow-up.)
+ *
+ * SINGLE TX: locks + loads gameState + artists, checks campaign completion
+ *       (early return — read-only), initializes serverGameData, loads released
+ *       projects, builds the engine, runs engine.advanceWeek(actions, tx),
+ *       persists the updated gameState, saves weekly actions, reads back
  *       projects/songs for the debug envelope, and assembles the response.
+ *       Response assembly/return happen from the resolved tx value; res.json is
+ *       after commit in the route.
  *
  * Errors: the service throws plain Errors (mirroring the handler's inline
  * `throw new Error(...)` sites). The route maps ZodError -> 400 VALIDATION_ERROR
@@ -47,12 +57,17 @@ export class AdvanceWeekService {
    */
   async advanceWeek(gameId: string, selectedActions: any[]) {
     // Wrap everything in a database transaction
-    const result = await this.db.transaction(async (tx) => {
-      // Get current game state
+    const finalResult = await this.db.transaction(async (tx) => {
+      // Get current game state. FOR UPDATE (D6 PR-3): lock this game's row for the
+      // whole transaction so two concurrent advance-week requests for the SAME game
+      // serialize — the second blocks here until the first commits week N+1, then
+      // reads that committed state and advances once more, instead of both reading
+      // week N and double-applying the week's effects.
       const [gameState] = await tx
         .select()
         .from(gameStates)
-        .where(eq(gameStates.id, gameId));
+        .where(eq(gameStates.id, gameId))
+        .for('update');
 
       if (!gameState) {
         throw new Error('Game not found');
@@ -140,7 +155,13 @@ export class AdvanceWeekService {
           hasSummary: !!weekResult.summary,
           hasCampaignResults: !!weekResult.campaignResults
         });
-        return { gameStateForEngine, weekResult };
+        // D6 PR-3: the campaign-completed path performs NO engine writes, but to
+        // stay byte-equivalent with the pre-merge two-tx handler (which always ran
+        // tx2 — persisting the unchanged gameState, no actions here, and assembling
+        // the debug envelope), we fall through to the SHARED persistence block
+        // below rather than returning early. currentWeek is unchanged (week 52),
+        // so the gameStates UPDATE is a no-op write of the same values.
+        return await this.persistAndAssemble(tx, gameId, weekResult, selectedActions);
       }
 
       // Initialize game data to load balance configuration
@@ -250,22 +271,38 @@ export class AdvanceWeekService {
         throw new Error(`Week advancement failed: ${engineError instanceof Error ? engineError.message : 'Unknown error'}`);
       }
 
-      return { gameStateForEngine, weekResult };
-    }); // End the first transaction here
+      // Ensure weekResult is defined (it should always be due to the throw in catch block)
+      if (!weekResult) {
+        throw new Error('Week advancement failed: No result returned from GameEngine');
+      }
 
-    console.log('[DEBUG] Project advancement transaction committed');
+      // D6 PR-3: persist + assemble the response INSIDE this same transaction
+      // (formerly the separate tx2). A crash anywhere above rolls the whole week
+      // back — all-or-nothing.
+      return await this.persistAndAssemble(tx, gameId, weekResult, selectedActions);
+    }); // End the single week-advance transaction here
 
-    // Destructure the result from the first transaction
-    const { gameStateForEngine, weekResult } = result;
+    console.log('[DEBUG] Week advancement transaction committed');
 
-    // Ensure weekResult is defined (it should always be due to the throw in catch block)
-    if (!weekResult) {
-      throw new Error('Week advancement failed: No result returned from GameEngine');
-    }
+    // Post-commit: return the envelope assembled from in-tx values. The route's
+    // res.json runs after this resolves (§4 post-commit ordering).
+    return finalResult;
+  }
 
-    // Now continue with the rest of the transaction for final updates
-    const finalResult = await this.db.transaction(async (tx) => {
-
+  /**
+   * Persists the advanced gameState + weekly actions and assembles the response
+   * envelope, running the debug read-backs. D6 PR-3: this is the former tx2 body,
+   * verbatim (same statements, same order), now invoked INSIDE the single
+   * week-advance transaction via the passed `tx`. Callers (both the normal and the
+   * campaign-completed early-return paths) share it so the envelope shape is
+   * identical in both branches.
+   */
+  private async persistAndAssemble(
+    tx: any,
+    gameId: string,
+    weekResult: any,
+    selectedActions: any[],
+  ) {
         // Update game state in database
         const [updatedGameState] = await tx
         .update(gameStates)
@@ -342,7 +379,7 @@ export class AdvanceWeekService {
             postEngineProjectCount: finalProjects?.length || 0
           },
           projectStates: {
-            final: finalProjects?.map(p => ({
+            final: finalProjects?.map((p: any) => ({
               id: p.id,
               title: p.title,
               stage: p.stage,
@@ -351,9 +388,9 @@ export class AdvanceWeekService {
           },
           songStates: {
             total: finalSongs?.length || 0,
-            released: finalSongs?.filter(s => s.isReleased).length || 0,
-            ready: finalSongs?.filter(s => s.isRecorded && !s.isReleased).length || 0,
-            songDetails: finalSongs?.map(s => ({
+            released: finalSongs?.filter((s: any) => s.isReleased).length || 0,
+            ready: finalSongs?.filter((s: any) => s.isRecorded && !s.isReleased).length || 0,
+            songDetails: finalSongs?.map((s: any) => ({
               id: s.id,
               title: s.title,
               isRecorded: s.isRecorded,
@@ -375,9 +412,6 @@ export class AdvanceWeekService {
           campaignResults: weekResult.campaignResults,
           debug: debugInfo
         };
-      });
-
-    return finalResult;
   }
 }
 

--- a/server/services/advanceWeekService.ts
+++ b/server/services/advanceWeekService.ts
@@ -22,8 +22,12 @@
  * first's committed week N+1 state, then advances once more) instead of both
  * reading week N and double-applying. (Reject-on-stale-week is a follow-up.)
  *
+ * Balance-config loads (getStartingValues + serverGameData.initialize — fs reads
+ * + Zod, no DB) run BEFORE the transaction so the row lock is never held across
+ * disk I/O.
+ *
  * SINGLE TX: locks + loads gameState + artists, checks campaign completion
- *       (early return — read-only), initializes serverGameData, loads released
+ *       (early return — read-only), loads released
  *       projects, builds the engine, runs engine.advanceWeek(actions, tx),
  *       persists the updated gameState, saves weekly actions, reads back
  *       projects/songs for the debug envelope, and assembles the response.
@@ -56,6 +60,17 @@ export class AdvanceWeekService {
    * original handler returned ({ gameState, summary, campaignResults, debug }).
    */
   async advanceWeek(gameId: string, selectedActions: any[]) {
+    // D6 PR-3 review fix: load balance config BEFORE the transaction so the
+    // FOR UPDATE row lock is never held across disk I/O. Neither call touches
+    // the DB or depends on tx: getStartingValues() reads balance JSON, and
+    // initialize() clears + reloads the JSON data files (fs.readFile + Zod).
+    // Get starting values from balance configuration
+    const startingValues = await this.serverGameData.getStartingValues();
+    // Initialize game data to load balance configuration
+    console.log('[DEBUG] Initializing serverGameData...');
+    await this.serverGameData.initialize();
+    console.log('[DEBUG] ServerGameData initialized successfully');
+
     // Wrap everything in a database transaction
     const finalResult = await this.db.transaction(async (tx) => {
       // Get current game state. FOR UPDATE (D6 PR-3): lock this game's row for the
@@ -78,9 +93,6 @@ export class AdvanceWeekService {
         .select()
         .from(artists)
         .where(eq(artists.gameId, gameId));
-
-      // Get starting values from balance configuration
-      const startingValues = await this.serverGameData.getStartingValues();
 
       // Convert database gameState to proper GameState type
       const gameStateForEngine = {
@@ -164,10 +176,7 @@ export class AdvanceWeekService {
         return await this.persistAndAssemble(tx, gameId, weekResult, selectedActions);
       }
 
-      // Initialize game data to load balance configuration
-      console.log('[DEBUG] Initializing serverGameData...');
-      await this.serverGameData.initialize();
-      console.log('[DEBUG] ServerGameData initialized successfully');
+      // (serverGameData.initialize() hoisted above the transaction — see top of method)
 
       // Query released projects for ongoing revenue calculation
       const releasedProjects = await tx

--- a/shared/engine/processors/ReleaseProcessor.ts
+++ b/shared/engine/processors/ReleaseProcessor.ts
@@ -1253,7 +1253,7 @@ export class ReleaseProcessor {
     if (ctx.gameData.updateSong) {
       try {
         console.log(`[SONG RELEASE] 🔄 Calling updateSong for song ID: ${song.id}`);
-        const updateResult = await ctx.gameData.updateSong(song.id, songUpdates);
+        const updateResult = await ctx.gameData.updateSong(song.id, songUpdates, ctx.dbTransaction);
         console.log(`[SONG RELEASE] ✅ Successfully updated song "${song.title}" in database`);
         console.log(`[SONG RELEASE] Update result:`, updateResult);
       } catch (error) {

--- a/tests/features/advance-week-atomicity.test.ts
+++ b/tests/features/advance-week-atomicity.test.ts
@@ -1,38 +1,33 @@
 // @vitest-environment node
 /**
- * D6 PR-1 — Failure-injection characterization net for POST /api/advance-week.
+ * D6 — Whole-week transaction atomicity net for POST /api/advance-week.
  *
- * These tests PIN THE CURRENT (BROKEN) transaction behavior of
- * `AdvanceWeekService.advanceWeek` so the D6 atomicity work (PR-2 / PR-3) can be
- * proven to change it. Today the week advance is NOT atomic:
+ * As of D6 PR-3 the ENTIRE week advance runs in ONE PostgreSQL transaction
+ * (`AdvanceWeekService.advanceWeek`). The former split — TX 1 (engine run) and
+ * TX 2 (gameStates UPDATE + weekly_actions INSERT + debug read-backs) — was
+ * merged into a single `db.transaction`, so a crash ANYWHERE mid-advance rolls
+ * the whole week back: all-or-nothing.
  *
- *   TX 1 (advanceWeekService.ts:50-254): loads state, runs the whole GameEngine
- *         (song creation, emails, charts, project stage advance) — committed as a
- *         unit... EXCEPT for a set of "escaping" writes that go through storage
- *         methods with no tx param (e.g. `updateArtist`, storage.ts:348) and thus
- *         run on the GLOBAL pool connection, autocommitting independently of tx1.
- *   TX 2 (advanceWeekService.ts:267-378): persists the advanced gameState
- *         (currentWeek/money/...) and inserts weekly_actions.
+ *   SINGLE TX (advanceWeekService.ts): SELECT ... FOR UPDATE on the game row,
+ *         loads state, runs the whole GameEngine (song creation, emails, charts,
+ *         project stage advance, tour city writes, planned-release marketing
+ *         idempotency flags), THEN persists the advanced gameState
+ *         (currentWeek/money/...) + inserts weekly_actions + reads back the debug
+ *         envelope. All bound to the same `tx`.
  *
- * Because tx1 and tx2 are SEPARATE transactions, a crash between them leaves a
- * half-applied week: the engine's rows are committed but the week/money never
- * advance (Test A — still pinned; flips in PR-3).
- *
- * Test B was updated by D6 PR-2: the artist mood/energy/popularity writes that
- * previously escaped tx1 (via storage.updateArtist, which had no tx param) now
- * honor the threaded dbTransaction and roll back WITH tx1. Its assertion is
- * inverted accordingly.
- *
- * Each assertion tagged `// PINS CURRENT BROKEN BEHAVIOR (D6):` deliberately pins
- * today's broken behavior:
- *   - Test A stays pinned; it flips in PR-3 (single transaction): a crash leaves
- *     the game exactly at week N — the engine rows must ALSO roll back.
- *   - Test B was FLIPPED in PR-2 (tx threaded through the escaping writes): the
- *     artist mood write now rolls back with tx1 (assertion inverted below).
+ * History of these tests:
+ *   - Test A previously PINNED the broken two-tx behavior (a crash between tx1
+ *     and tx2 left a half-applied week: engine rows committed, week/money not
+ *     advanced). D6 PR-3 FLIPPED it: a crash at the persistence step now rolls
+ *     back the engine writes too — no orphaned songs/tour writes/planned-release
+ *     flags, week unchanged, weekly_actions empty. All-or-nothing.
+ *   - Test B was FLIPPED in D6 PR-2: the artist mood/energy writes that once
+ *     escaped tx1 (via storage.updateArtist, which had no tx param) now honor the
+ *     threaded dbTransaction and roll back WITH the transaction.
  *
  * Harness: constructs `AdvanceWeekService` with INJECTED deps (test-DB-backed
- * `DatabaseStorage`, a `db` proxy that can inject a tx failure, and a gameData
- * bridge reusing the golden-master fixture). NEVER imports `server/db`.
+ * `DatabaseStorage`, a `db` proxy that can inject a mid-transaction failure, and
+ * a gameData bridge reusing the golden-master fixture). NEVER imports `server/db`.
  */
 
 import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
@@ -67,8 +62,9 @@ import { createGameData, type TestDb } from '../engine/golden-master-fixtures';
 
 // Fixed, human-readable-ish UUIDs per scenario for stability.
 const IDS = {
-  crashBetween: '00000000-0000-4000-8000-0000000000d1',
+  crashPersist: '00000000-0000-4000-8000-0000000000d1',
   escapeInTx1: '00000000-0000-4000-8000-0000000000d2',
+  concurrentA: '00000000-0000-4000-8000-0000000000d3',
 };
 
 let db: TestDb;
@@ -82,7 +78,7 @@ let db: TestDb;
  * server/db for its engine-bridge methods, so we inject a test-DB-backed
  * equivalent: reuse the golden-master `createGameData` (real balance JSON + row
  * reads/writes delegated to the test-DB storage) and add the two service-only
- * methods.
+ * methods plus the tx-honoring createSong/updateSong bridges.
  */
 function makeServiceGameData(storage: DatabaseStorage) {
   const gameData = createGameData(storage);
@@ -93,7 +89,7 @@ function makeServiceGameData(storage: DatabaseStorage) {
     // Mirror production ServerGameData.createSong (server/data/gameData.ts:827):
     // honor the passed transaction so song creation is tx-BOUND (as it is in
     // production). The golden-master bridge deliberately drops the tx (it never
-    // exercises rollback), which would make Test B's "songs roll back" assertion
+    // exercises rollback), which would make the "songs roll back" assertions
     // false-green; here we must match production so the pin is faithful.
     createSong: async (song: any, tx?: any) => {
       if (tx) {
@@ -102,6 +98,10 @@ function makeServiceGameData(storage: DatabaseStorage) {
       }
       return storage.createSong(song);
     },
+    // Mirror production ServerGameData.updateSong (server/data/gameData.ts:1080):
+    // honor the passed transaction (ReleaseProcessor.processSongRelease threads
+    // ctx.dbTransaction as of D6 PR-3) so song-release writes are tx-BOUND.
+    updateSong: async (songId: string, updates: any, tx?: any) => storage.updateSong(songId, updates, tx),
   };
 }
 
@@ -156,7 +156,79 @@ async function seedRecordingProject(gameId: string, artistId: string, startWeek:
   });
 }
 
-describe('D6 PR-1 — advance-week failure-injection characterization (pins broken behavior)', () => {
+/**
+ * Seeds an active Mini-Tour in production stage. With game at week 3 and
+ * startWeek 2, the week advances to 4 -> weeksElapsed=2 -> weeksInProduction=1 ->
+ * TourProcessor processes city 1 and writes `metadata.tourStats` via
+ * storage.updateProject(..., dbTransaction) (D6 PR-2 threaded the tx through it).
+ * Fixture mirrors golden-master-advance-week.test.ts's tour-week scenario.
+ */
+async function seedTourProject(gameId: string, artistId: string) {
+  const id = crypto.randomUUID();
+  await db.insert(schema.projects).values({
+    id,
+    gameId,
+    artistId,
+    title: 'D6 World Tour',
+    type: 'Mini-Tour',
+    stage: 'production',
+    startWeek: 2,
+    totalCost: 30000,
+    quality: 50,
+    metadata: {
+      cities: 3,
+      venueAccess: 'clubs',
+      venueCapacity: 500,
+    },
+  });
+  return id;
+}
+
+/**
+ * Seeds a planned release scheduled for the current week with a recorded (not yet
+ * released) song and a marketing budget. When the engine's processPlannedReleases
+ * runs, FinancialSystem.allocateMarketingInvestment flips the release's
+ * `metadata.baseMarketingAllocated` idempotency flag via
+ * storage.updateRelease(..., dbTransaction) (D6 PR-2 threaded the tx through it).
+ * On rollback, that flag must NOT be set.
+ */
+async function seedPlannedRelease(gameId: string, artistId: string, week: number) {
+  const releaseId = crypto.randomUUID();
+  const songId = crypto.randomUUID();
+  await db.insert(schema.songs).values({
+    id: songId,
+    title: 'D6 Planned Track',
+    artistId,
+    gameId,
+    quality: 60,
+    isRecorded: true,
+    isReleased: false,
+    productionBudget: 5000,
+  });
+  await db.insert(schema.releases).values({
+    id: releaseId,
+    title: 'D6 Planned Single',
+    type: 'single',
+    artistId,
+    gameId,
+    releaseWeek: week,
+    status: 'planned',
+    marketingBudget: 10000,
+    metadata: {
+      totalInvestment: 10000,
+      marketingBudget: { radio: 10000 },
+    },
+  });
+  await db.insert(schema.releaseSongs).values({
+    releaseId,
+    songId,
+    trackNumber: 1,
+    isSingle: false,
+  });
+  return { releaseId, songId };
+}
+
+describe('D6 — advance-week whole-week transaction atomicity', () => {
   beforeAll(async () => {
     await setupDatabase();
   });
@@ -166,35 +238,57 @@ describe('D6 PR-1 — advance-week failure-injection characterization (pins brok
     await clearDatabase(db);
   });
 
-  it('Test A — a crash BETWEEN tx1 and tx2 leaves a HALF-APPLIED week', async () => {
-    const gameId = IDS.crashBetween;
-    await seedGame(gameId, 2);
-    const artistId = await seedArtist(gameId, { name: 'Recorder' });
-    // A production Single with no songs yet generates songs this week (tx1-bound).
-    await seedRecordingProject(gameId, artistId, 2);
+  it('Test A — a crash at the persistence step rolls back the ENTIRE week (all-or-nothing)', async () => {
+    const gameId = IDS.crashPersist;
+    // Week 3 so the tour (startWeek 2) processes city 1 this advance.
+    await seedGame(gameId, 3);
+    // Mood 70 (>55) => -3 natural drift applied via storage.updateArtist (tx-bound
+    // as of D6 PR-2). Must NOT persist after rollback.
+    const artistId = await seedArtist(gameId, { name: 'Recorder', mood: 70 });
+    // (1) A production Single with no songs yet generates songs this week (tx-bound).
+    await seedRecordingProject(gameId, artistId, 3);
+    // (2) An active Mini-Tour writes project.metadata.tourStats this week (tx-bound
+    //     via ProjectStageProcessor/TourProcessor).
+    const tourId = await seedTourProject(gameId, artistId);
+    // (3) A planned release scheduled for this week flips its
+    //     metadata.baseMarketingAllocated idempotency flag (tx-bound via
+    //     FinancialSystem InvestmentTracker -> storage.updateRelease).
+    const { releaseId } = await seedPlannedRelease(gameId, artistId, 3);
 
     const storage = new DatabaseStorage(db);
     const gameData = makeServiceGameData(storage);
 
-    // db proxy: pass through the FIRST transaction (tx1 — the engine run), then
-    // simulate a crash BEFORE the SECOND transaction (tx2 — gameState/actions
-    // persistence) by throwing before its callback runs.
-    let txCall = 0;
+    // db proxy: run the REAL single transaction, but wrap the `tx` passed to the
+    // callback so the FIRST `update(gameStates)` call — the very first statement of
+    // the merged persistence block (the former tx1/tx2 boundary, now inside one
+    // tx) — throws. This models "the process crashes at the final persistence step"
+    // AFTER the engine fully ran and staged all its writes. Because it is one
+    // transaction, that crash must roll back everything the engine wrote.
     const dbProxy: any = {
-      transaction: (cb: any, ...rest: any[]) => {
-        txCall += 1;
-        if (txCall === 1) {
-          return (db as any).transaction(cb, ...rest);
-        }
-        // txCall === 2: crash between the two transactions.
-        throw new Error('[D6 TEST] injected crash between tx1 and tx2');
+      transaction: async (cb: any) => {
+        return (db as any).transaction(async (tx: any) => {
+          const wrapped = new Proxy(tx, {
+            get(target, prop, receiver) {
+              if (prop === 'update') {
+                return (table: any) => {
+                  if (table === schema.gameStates) {
+                    throw new Error('[D6 TEST] injected crash at persistence step');
+                  }
+                  return (target as any).update(table);
+                };
+              }
+              return Reflect.get(target, prop, receiver);
+            },
+          });
+          return cb(wrapped);
+        });
       },
     };
 
     const service = new AdvanceWeekService(storage as any, dbProxy, gameData as any);
 
     await expect(service.advanceWeek(gameId, [])).rejects.toThrow(
-      /injected crash between tx1 and tx2/,
+      /injected crash at persistence step/,
     );
 
     const [gsAfter] = await db
@@ -209,49 +303,76 @@ describe('D6 PR-1 — advance-week failure-injection characterization (pins brok
       .select()
       .from(schema.weeklyActions)
       .where(eq(schema.weeklyActions.gameId, gameId));
+    const emailsAfter = await db
+      .select()
+      .from(schema.emails)
+      .where(eq(schema.emails.gameId, gameId));
+    const [artistAfter] = await db
+      .select()
+      .from(schema.artists)
+      .where(eq(schema.artists.id, artistId));
+    const [tourAfter] = await db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, tourId));
+    const [releaseAfter] = await db
+      .select()
+      .from(schema.releases)
+      .where(eq(schema.releases.id, releaseId));
 
-    // PINS CURRENT BROKEN BEHAVIOR (D6): tx1's engine writes are already COMMITTED
-    // even though the week never finished advancing — the song-generation rows
-    // survive the crash. PR-3 (single tx) flips this: these rows must roll back.
-    expect(songsAfter.length).toBeGreaterThan(0);
+    // D6 PR-3 GUARANTEE (flipped from the pinned broken two-tx behavior): the whole
+    // week advance is ONE transaction, so a crash at the persistence step rolls back
+    // EVERYTHING the engine wrote. There must be NO committed engine rows and NO
+    // week/money change — the game is left exactly at week N.
 
-    // PINS CURRENT BROKEN BEHAVIOR (D6): tx2 never ran, so the week/money were NOT
-    // advanced despite tx1's writes being committed — the classic half-applied
-    // week. Replaying the week would DOUBLE-apply the committed engine effects.
-    // PR-3 flips this into an all-or-nothing outcome (week stays exactly at N with
-    // no orphaned engine rows).
-    expect(gsAfter.currentWeek).toBe(2); // NOT advanced to 3
-    expect(gsAfter.money).toBe(500000); // NOT burned down by tx2's UPDATE
+    // Only the planned-release's pre-seeded song remains; no engine-created
+    // recording songs survived the rollback.
+    expect(songsAfter.length).toBe(1);
+    // No engine-generated emails survived.
+    expect(emailsAfter.length).toBe(0);
 
-    // PINS CURRENT BROKEN BEHAVIOR (D6): weekly_actions is written in tx2, which
-    // never ran — so it is empty here. (No actions were passed, but the row-count
-    // assertion still documents that tx2's INSERT did not run.)
+    // Week/money NOT advanced — exactly at week N.
+    expect(gsAfter.currentWeek).toBe(3);
+    expect(gsAfter.money).toBe(500000);
+
+    // weekly_actions never written (persistence rolled back).
     expect(actionsAfter.length).toBe(0);
+
+    // Escaping-writes-now-tx-bound (PR-2) roll back with the tx: mood stays seeded 70.
+    expect(artistAfter.mood).toBe(70);
+
+    // Tour project write rolled back: metadata.tourStats was never committed.
+    expect((tourAfter.metadata as any)?.tourStats).toBeUndefined();
+
+    // Planned-release marketing idempotency flag rolled back: NOT set.
+    expect((releaseAfter.metadata as any)?.baseMarketingAllocated).toBeUndefined();
+    // Release still 'planned' (updateReleaseStatus rolled back too).
+    expect(releaseAfter.status).toBe('planned');
   });
 
-  it('Test B — an error DURING tx1 rolls back tx-bound writes but LEAKS escaping artist writes', async () => {
+  it('Test B — an error DURING the engine run rolls back tx-bound AND formerly-escaping writes', async () => {
     const gameId = IDS.escapeInTx1;
     await seedGame(gameId, 2);
     // Mood 70 (>55) => natural drift of -3 in processWeeklyMoodChanges, applied via
-    // storage.updateArtist(...) which has NO tx param => it commits on the GLOBAL
-    // pool connection, escaping tx1.
+    // storage.updateArtist(...). As of D6 PR-2 that write honors the threaded
+    // dbTransaction, so it rolls back WITH the transaction (it no longer escapes on
+    // the global connection).
     const artistId = await seedArtist(gameId, { name: 'Escaper', mood: 70 });
-    // Recording project so tx1 ALSO produces tx-bound song writes we can assert
-    // roll back.
+    // Recording project so the engine ALSO produces tx-bound song writes we can
+    // assert roll back.
     await seedRecordingProject(gameId, artistId, 2);
 
     const storage = new DatabaseStorage(db);
     const gameData = makeServiceGameData(storage);
 
-    // db proxy: run the REAL tx1 callback (so all engine writes execute — the
-    // escaping artist mood write autocommits on the global connection, and the
-    // tx-bound writes stage inside tx1), then throw BEFORE tx1 commits so drizzle
-    // rolls tx1 back. This faithfully models "an error occurred during tx1".
+    // db proxy: run the REAL callback (so all engine writes execute and stage inside
+    // the tx), then throw BEFORE the tx commits so drizzle rolls it back. This
+    // faithfully models "an error occurred during the engine run".
     const dbProxy: any = {
       transaction: async (cb: any) => {
         return (db as any).transaction(async (tx: any) => {
           await cb(tx);
-          throw new Error('[D6 TEST] injected error during tx1 (post-engine, pre-commit)');
+          throw new Error('[D6 TEST] injected error during engine run (pre-commit)');
         });
       },
     };
@@ -259,7 +380,7 @@ describe('D6 PR-1 — advance-week failure-injection characterization (pins brok
     const service = new AdvanceWeekService(storage as any, dbProxy, gameData as any);
 
     await expect(service.advanceWeek(gameId, [])).rejects.toThrow(
-      /injected error during tx1/,
+      /injected error during engine run/,
     );
 
     const [artistAfter] = await db
@@ -279,16 +400,49 @@ describe('D6 PR-1 — advance-week failure-injection characterization (pins brok
       .from(schema.chartEntries)
       .where(eq(schema.chartEntries.gameId, gameId));
 
-    // tx-bound writes correctly rolled back with tx1.
+    // tx-bound writes correctly rolled back.
     expect(songsAfter.length).toBe(0);
     expect(emailsAfter.length).toBe(0);
     expect(chartsAfter.length).toBe(0);
 
-    // D6 PR-2 GUARANTEE (flipped from the pinned broken behavior): the artist mood
-    // write is now tx-BOUND. storage.updateArtist honors the dbTransaction threaded
-    // through ArtistStateProcessor, so when tx1 rolls back the mood write rolls back
-    // WITH it — no longer escaping on the global connection. mood stays at its
-    // seeded 70 instead of drifting to 67.
+    // D6 PR-2 GUARANTEE: the artist mood write is tx-BOUND. storage.updateArtist
+    // honors the dbTransaction threaded through ArtistStateProcessor, so when the
+    // tx rolls back the mood write rolls back WITH it — no longer escaping on the
+    // global connection. mood stays at its seeded 70 instead of drifting to 67.
     expect(artistAfter.mood).toBe(70);
+  });
+
+  it('Concurrency smoke — two concurrent advances for the same game serialize (FOR UPDATE), advancing exactly once each', async () => {
+    const gameId = IDS.concurrentA;
+    await seedGame(gameId, 5);
+    await seedArtist(gameId, { name: 'Concurrent' });
+
+    // Two services sharing the SAME underlying test DB (separate DatabaseStorage
+    // instances, real db.transaction — no failure injection). The initial
+    // SELECT ... FOR UPDATE serializes them: the second blocks until the first
+    // commits week 6, then advances 6 -> 7. Final week must be start+2 with no
+    // deadlock and no double-apply of a single week.
+    const storageA = new DatabaseStorage(db);
+    const storageB = new DatabaseStorage(db);
+    const serviceA = new AdvanceWeekService(storageA as any, db as any, makeServiceGameData(storageA) as any);
+    const serviceB = new AdvanceWeekService(storageB as any, db as any, makeServiceGameData(storageB) as any);
+
+    const [resA, resB] = await Promise.all([
+      serviceA.advanceWeek(gameId, []),
+      serviceB.advanceWeek(gameId, []),
+    ]);
+
+    // Each call advanced the week by exactly one; the two results are weeks 6 and 7
+    // in some order (whichever acquired the row lock first).
+    const weeks = [resA.gameState.currentWeek, resB.gameState.currentWeek].sort();
+    expect(weeks).toEqual([6, 7]);
+
+    // Final persisted week is start+2 — each request applied exactly one week, no
+    // double-apply of a single week, no deadlock.
+    const [gsAfter] = await db
+      .select()
+      .from(schema.gameStates)
+      .where(eq(schema.gameStates.id, gameId));
+    expect(gsAfter.currentWeek).toBe(7);
   });
 });


### PR DESCRIPTION
## D6 PR-3 — Whole-week transaction atomicity (final D6 PR)

Merges the week advance into a single PostgreSQL transaction and adds a
`SELECT ... FOR UPDATE` concurrency guard. Completes D6 (PR-1 characterization,
PR-2 tx threading, PR-3 single-tx + lock).

### Before / after transaction shape

**Before (two transactions):**
```
tx1 { SELECT gameState; SELECT artists; [early return?]; SELECT released projects;
      gameEngine.advanceWeek(actions, tx1) }   <-- COMMIT
   ...crash here = half-applied week...
tx2 { UPDATE gameStates (week/money/...); INSERT weekly_actions;
      SELECT projects/songs (debug); assemble envelope }   <-- COMMIT
```

**After (one transaction):**
```
tx { SELECT gameState FOR UPDATE; SELECT artists; [early return -> persist];
     SELECT released projects; gameEngine.advanceWeek(actions, tx);
     UPDATE gameStates; INSERT weekly_actions; SELECT projects/songs (debug);
     assemble envelope }   <-- single COMMIT
```
The former tx2 body moved verbatim (same statements, same order) into a shared
`persistAndAssemble(tx, ...)` helper, invoked by both the normal and the
campaign-completed early-return paths so the envelope shape is identical in both.

### FOR UPDATE rationale
There was no locking or idempotency anywhere in the advance path. Two concurrent
`POST /api/advance-week` for the same game both read week N and both commit N+1
with doubled effects. The initial `gameStates` select now takes `.for('update')`,
so the second request blocks until the first commits week N+1, then reads that
committed state and advances once more (N+1 -> N+2). Reject-on-stale-week
(client-supplied expected week) is a logged follow-up, not this PR.

### Test A flip
Previously pinned the broken two-tx behavior (engine rows committed, week not
advanced). Now injects a crash at the persistence step (first `update(gameStates)`
throws, via a `tx` Proxy — the exact former tx1/tx2 boundary, now inside one tx)
and asserts TOTAL rollback: no engine songs, no emails, week unchanged (3),
money unchanged, `weekly_actions` empty, artist mood unchanged. All-or-nothing.

### Fixture extension (from PR-2 adversarial review)
Test A's fixture now also seeds:
- a **tour project** (active Mini-Tour, `ProjectStageProcessor`/`TourProcessor`
  path) — asserts `project.metadata.tourStats` never commits on rollback;
- a **planned release** (`FinancialSystem` InvestmentTracker idempotency path) —
  asserts `release.metadata.baseMarketingAllocated` never sets and the release
  stays `planned` on rollback.

Also threads `ctx.dbTransaction` into `ReleaseProcessor.processSongRelease`'s
`updateSong` call (ReleaseProcessor.ts:1256) — a latent tx escape (contrast the
tx-honoring `getArtist` at :1217).

### Concurrency smoke test
Fires two concurrent `advanceWeek` calls for the same game against the test DB;
asserts the two results are weeks 6 and 7 (in lock-acquisition order) and the
final persisted week is start+2 — each request applied exactly one week, no
double-apply, no deadlock.

### Golden-master result
Byte-identical. `golden-master-advance-week.test.ts` 10/10 pass with **no
snapshot writes**. This PR only moves the tx boundary in the service (which the
golden master doesn't drive) and threads a tx into one already-dead-but-latent
ReleaseProcessor path — no statement added/removed inside the engine, so no
read-your-writes visibility change reaches the pinned scenarios. No per-field
drift to document.

### Post-commit ordering
Everything atomic is a DB row -> inside the tx. After commit: the service returns
the envelope (assembled from in-tx values), then the route's `res.json`. The
debug read-backs stay INSIDE the tx so the envelope reflects exactly what
committed. The Phase-4 importance-classification loop lives in
`game-engine.ts` at WeekSummary assembly and is untouched/unmoved by this PR
(service-layer only), so it still runs after all changes are finalized.

### Validation
- `npm run check` clean.
- Full suite isolated (`--no-file-parallelism`, test DB on 5433): **852 passed / 72 files**.
- `advance-week.characterization.test.ts` HTTP envelope unchanged (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
