### PR TITLE
feat(client): flip useGameState read side to the query cache (Phase 3.5 PR-5)

### DIFF
--- a/client/src/components/__tests__/ArtistRoster.test.tsx
+++ b/client/src/components/__tests__/ArtistRoster.test.tsx
@@ -26,6 +26,21 @@ vi.mock('@/hooks/useArtists', () => ({
   useArtists: mockUseArtists,
 }));
 
+// Phase 3.5 PR-5: `useGameState()`'s READ side flipped from Zustand onto the
+// TanStack cache (it now calls `useQueryClient()` + `useSyncExternalStore`), so
+// it needs a QueryClientProvider. Mock it here — same store-only pattern as
+// useProjects/useArtists above — so this component test stays store-only and
+// QueryClient-free. The mock returns the same fake gameState the store mock
+// supplies; assertions are unchanged. `useGameId` is unused by ArtistRoster.
+const { mockUseGameState } = vi.hoisted(() => ({ mockUseGameState: vi.fn() }));
+vi.mock('@/hooks/useGameState', () => ({
+  useGameState: (selector?: (gs: unknown) => unknown) => {
+    const gs = mockUseGameState();
+    return selector ? selector(gs) : gs;
+  },
+  useGameId: () => (mockUseGameState() as { id?: string } | null)?.id ?? null,
+}));
+
 vi.mock('wouter', () => ({
   useLocation: () => [null, setLocationMock],
 }));
@@ -71,6 +86,10 @@ describe('ArtistRoster', () => {
     setLocationMock.mockClear();
     mockUseGameStore.mockReset();
     mockUseArtists.mockReset();
+    mockUseGameState.mockReset();
+    // Façade returns the same spine the store mock supplies (PR-5: read path is
+    // the cache, mocked here to keep the test store-only / QueryClient-free).
+    mockUseGameState.mockReturnValue({ id: 'game-1', currentWeek: 12 });
 
     mockUseArtists.mockReturnValue({
       data: [

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -1,25 +1,62 @@
 /**
- * gameState spine façade (Phase 3.5 PR-3a).
+ * gameState spine façade (Phase 3.5 PR-3a → PR-5).
  *
  * `gameState` (week, money, reputation, creativeCapital, focusSlots, access
- * tiers, flags, A&R fields, embedded `musicLabel`) is still owned by the
- * Zustand store today. This hook is the READ façade the rest of the app goes
- * through so the eventual ownership flip onto the TanStack Query cache
- * (Phase 3.5 PRs 4-6) is a one-file change (`useGameState.ts` only) instead of
- * a 25-file rewrite.
+ * tiers, flags, A&R fields, embedded `musicLabel`) is a CLIENT-COMMITTED RECORD
+ * in the TanStack Query cache at `gameStateQueryKey(gameId)`. The store's
+ * `commitGameState` funnel (PR-4) is its ONLY writer (fan-out seed, advance-week
+ * commit, slot math, `adoptServerBalances`). This hook is the READ façade the
+ * rest of the app goes through.
  *
- * Right now `useGameState()` is LITERALLY `useGameStore((s) => s.gameState)`
- * — zero behavior change, same Zustand subscription, same re-render
- * granularity. Do not add `isLoading`/query-object semantics here; callers
- * null-check the returned value exactly like they did against the store.
+ * PR-5 (this file): the READ side flips off Zustand and onto the query cache.
+ *
+ * MECHANISM — `useSyncExternalStore` on the QueryCache, NOT `useQuery`.
+ * The plan's critical correctness property (§0.6, AC #3) is that the store's
+ * SYNCHRONOUS slot math (`selectAction` etc.) — which commits via `setQueryData`
+ * — must be visible on the NEXT RENDER, same-tick, exactly as the old Zustand
+ * `useSyncExternalStore` subscription delivered. `useQuery` does NOT satisfy
+ * this: React Query v5 defers observer notifications through its `notifyManager`
+ * batch (a microtask/scheduler tick), so a `useQuery` reader only re-renders on
+ * a LATER tick — an RTL test must `waitFor` it, and XState `SYNC_SLOTS` /
+ * `SelectionSummary` / the CommandDock AUTO filler would see a one-tick-stale
+ * slot count. (This was verified empirically; the plan's assumption that
+ * `setQueryData` notifies `useQuery` subscribers synchronously does not hold for
+ * v5's batched notifyManager.) `useSyncExternalStore` subscribed directly to the
+ * QueryCache re-renders SYNCHRONOUSLY when `setQueryData` fires during an event —
+ * the same guarantee Zustand gave. The plan explicitly sanctioned this
+ * alternative ("via useQuery OR useSyncExternalStore on the cache").
+ *
+ * A `useQuery` is ALSO mounted here, but ONLY to drive the COLD-CACHE FALLBACK
+ * fetch + client-committed-record semantics (staleTime/gcTime Infinity, no
+ * focus/mount/reconnect refetch). Its `.data` is ignored for reads — the read
+ * comes from the cache via `useSyncExternalStore`. PR-4's dual-write funnel
+ * pre-seeds the key on every load/create/advance, so the fallback never fires in
+ * practice.
+ *
+ * The gameId BOOTSTRAP: `useGameState` must know WHICH game to subscribe to
+ * before the cache has data. `gameId` is still read from Zustand — a tiny
+ * session pointer (`s.gameState?.id`) — while the record itself comes from the
+ * cache. PR-4's funnel seeds the new key BEFORE any gameId flip is observable,
+ * so game-switch never shows a stale record.
+ *
+ * LOADING/NULL semantics are identical to the old Zustand read: before any game
+ * loads, `useGameState()` returns `null` (not undefined, not a loading throw).
+ * Do NOT expose `isLoading`/query-object semantics here; callers null-check the
+ * returned value exactly like they did against the store.
  *
  * `useGameState` accepts an optional selector so call sites can keep
  * selector-level subscription granularity (e.g. `useGameState((gs) =>
  * gs?.money)`) instead of subscribing to the whole spine object.
  *
+ * ROLLBACK: reverting this one file restores the Zustand read path; PR-4's
+ * dual-write keeps both sources correct either way.
+ *
  * See docs/01-planning/implementation-specs/[READY] phase-3.5-gamestate-tanstack-plan.md
- * (§1 "synchronized copy first, wholesale flip second", §3 PR-3).
+ * (§1 "synchronized copy first, wholesale flip second", §3 PR-5, §0.6).
  */
+import { useCallback, useSyncExternalStore } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiRequest } from '@/lib/queryClient';
 import { useGameStore } from '@/store/gameStore';
 import type { GameState } from '@shared/types/gameTypes';
 
@@ -43,18 +80,88 @@ export function gameStateQueryKey(gameId: string): readonly [string, string] {
   return [GAME_STATE_SCOPE, gameId];
 }
 
+/**
+ * Cold-cache fallback queryFn. In practice this NEVER fires — PR-4's
+ * `commitGameState` funnel pre-seeds `gameStateQueryKey(gameId)` on every load /
+ * create / advance-week, so `useQuery` resolves from the seeded cache without
+ * fetching. It exists only so a hard cache miss (e.g. a direct navigation that
+ * somehow bypassed the store bootstrap) degrades to a full-bundle GET rather
+ * than throwing. Mirrors the store's `fetchGameBundle` shape: the server row
+ * embeds `musicLabel` as a sibling of `gameState`, which we re-embed into the
+ * spine exactly as the store does (`{ ...data.gameState, musicLabel }`).
+ */
+async function fetchGameStateRecord(gameId: string): Promise<GameState> {
+  const response = await apiRequest('GET', `/api/game/${gameId}`);
+  const data = await response.json();
+  return {
+    ...data.gameState,
+    musicLabel: data.musicLabel ?? null,
+  } as GameState;
+}
+
 export function useGameState(): GameState | null;
 export function useGameState<T>(selector: (gameState: GameState | null) => T): T;
 export function useGameState<T>(
   selector?: (gameState: GameState | null) => T,
 ): GameState | null | T {
-  return useGameStore((state) =>
-    selector ? selector(state.gameState) : state.gameState,
+  // gameId bootstrap: still a Zustand-owned session pointer. The RECORD comes
+  // from the cache; only the "which game am I on" handle stays in the store.
+  const gameId = useGameStore((state) => state.gameState?.id ?? null);
+
+  // The context client — in-app this IS the `@/lib/queryClient` singleton the
+  // store's funnel writes to (App.tsx mounts it), so reads and the funnel's
+  // writes hit the same cache. Reading via context (not the imported singleton)
+  // also lets tests provide their own client + seed it.
+  const client = useQueryClient();
+
+  // Cold-cache fallback + client-committed-record semantics. `.data` is
+  // deliberately UNUSED for reads (see header) — this exists only to fetch on a
+  // hard cache miss and to pin refetch-off / infinite-stale on the record key so
+  // no background refetch can race the synchronous slot math (plan §0.6).
+  useQuery<GameState>({
+    queryKey: gameId ? gameStateQueryKey(gameId) : [GAME_STATE_SCOPE, '__none__'],
+    queryFn: () => fetchGameStateRecord(gameId as string),
+    enabled: !!gameId,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+
+  // SAME-TICK read: subscribe to the QueryCache directly. `setQueryData` fires
+  // the cache listener synchronously, and `useSyncExternalStore` re-renders in
+  // the same commit — matching the old Zustand subscription's timing exactly.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      client.getQueryCache().subscribe(onStoreChange),
+    [client],
   );
+  // `getQueryData` returns the STORED object reference (stable until the funnel
+  // replaces it via setQueryData), so useSyncExternalStore sees no spurious
+  // change. Collapse `undefined` (no game / not yet seeded) to `null` for the
+  // exact `GameState | null` contract the old Zustand read had.
+  const getSnapshot = useCallback((): GameState | null => {
+    if (!gameId) return null;
+    return client.getQueryData<GameState>(gameStateQueryKey(gameId)) ?? null;
+  }, [client, gameId]);
+
+  const gameState = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return selector ? selector(gameState) : gameState;
 }
 
-/** Convenience selector: the current game id, or null. Mirrors the 9 domain
- * hooks' `useGameStore((state) => state.gameState?.id)` derivation. */
+/**
+ * Convenience selector: the current game id, or null.
+ *
+ * Reads the Zustand session pointer DIRECTLY (`s.gameState?.id`) rather than
+ * going through the cache-backed `useGameState()`. The id is the bootstrap
+ * handle that tells the cache which record to load, so it must be available
+ * before (and independent of) the cached record — and reading it from Zustand
+ * keeps this a cheap store subscription instead of an extra query subscription.
+ * Byte-identical to the 9 domain hooks' original
+ * `useGameStore((state) => state.gameState?.id)` derivation.
+ */
 export function useGameId(): string | null {
-  return useGameState((gameState) => gameState?.id ?? null);
+  return useGameStore((state) => state.gameState?.id ?? null);
 }

--- a/tests/client/useDiscoveredArtists.test.tsx
+++ b/tests/client/useDiscoveredArtists.test.tsx
@@ -34,6 +34,7 @@ import {
   DISCOVERED_ARTISTS_SCOPE,
   discoveredArtistsQueryKey,
 } from '@/hooks/useDiscoveredArtists';
+import { gameStateQueryKey } from '@/hooks/useGameState';
 
 const mockedApiRequest = vi.mocked(apiRequest);
 const mockedUseGameStore = vi.mocked(useGameStore);
@@ -42,8 +43,18 @@ function jsonResponse(body: unknown): Response {
   return { json: async () => body } as unknown as Response;
 }
 
-/** Drive the three separate selectors the hook reads off a single state object. */
+// Phase 3.5 PR-5 harness update: `useDiscoveredArtists` reads flags /
+// arOfficeSlotUsed via `useGameState`, whose READ side now comes from the
+// TanStack cache (not Zustand). `useGameId` still reads the Zustand pointer, so
+// the store mock keeps supplying the id — but the record fields must ALSO be
+// seeded into the cache the flipped `useGameState` reads. `mockStore` stashes
+// the state so `renderWithClient` can seed both sources. No assertion changed —
+// only the source the same `gameState` is fed through. (Without this, the
+// cache-backed `useGameState` returns null flags and fires its cold-cache
+// fallback GET.)
+let currentMockState: any = null;
 function mockStore(state: any) {
+  currentMockState = state;
   mockedUseGameStore.mockImplementation((selector: any) => selector(state));
 }
 
@@ -51,6 +62,12 @@ function renderWithClient(ui: React.ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  // Seed the gameState record into the cache so the flipped `useGameState`
+  // (PR-5) reads flags/arOfficeSlotUsed from where the funnel writes them.
+  const gameState = currentMockState?.gameState;
+  if (gameState?.id) {
+    queryClient.setQueryData(gameStateQueryKey(gameState.id), gameState);
+  }
   render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
   return queryClient;
 }

--- a/tests/client/useGameState-facade-flip.test.tsx
+++ b/tests/client/useGameState-facade-flip.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * useGameState façade-flip render-timing test (Phase 3.5 PR-5).
+ *
+ * PR-5 flips the READ side of `useGameState()` off the Zustand `gameState` copy
+ * and onto the TanStack Query cache at `gameStateQueryKey(gameId)`. The whole
+ * risk of the phase lives in one property: after the store does its SYNCHRONOUS
+ * focus-slot math (`selectAction` etc.) and commits via the dual-write funnel,
+ * a rendered component reading `useGameState()` must see the new value on the
+ * NEXT RENDER — same-tick, no waiting — exactly as the old Zustand subscription
+ * delivered. XState `SYNC_SLOTS`, `SelectionSummary`, and the CommandDock AUTO
+ * filler all depend on this (plan §0.6, §6).
+ *
+ * This test renders a REAL component through `useGameState()`, uses the REAL
+ * `queryClient` singleton (the same one the store's `commitGameState` funnel
+ * writes to) in a `QueryClientProvider`, fires a real store action, and asserts
+ * the re-rendered value WITHOUT `waitFor`/`findBy` — proving `setQueryData`
+ * notifies the `useQuery` subscriber synchronously.
+ *
+ * It also proves client-committed-record semantics: a simulated window `focus`
+ * event does NOT trigger a refetch that could clobber the optimistic slot math.
+ * The queryFn is wired to throw so any refetch attempt would surface loudly.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock apiRequest so a stray refetch can't hit the network; the queryFn wraps
+// it, so this doubles as a tripwire if the record key ever tries to refetch.
+const { apiRequestMock } = vi.hoisted(() => ({
+  apiRequestMock: vi.fn(async () => {
+    throw new Error('useGameState queryFn should never fetch (client-committed record)');
+  }),
+}));
+vi.mock('@/lib/queryClient', async () => {
+  const { QueryClient } = await import('@tanstack/react-query');
+  return {
+    apiRequest: apiRequestMock,
+    queryClient: new QueryClient({
+      defaultOptions: {
+        // Mirror the app defaults that PR-5 must OVERRIDE per-key: a 60s
+        // staleTime + focus refetch. If the hook forgot the overrides, a focus
+        // event would refetch and this test's tripwire queryFn would throw.
+        queries: {
+          staleTime: 60_000,
+          refetchOnWindowFocus: true,
+          retry: false,
+        },
+      },
+    }),
+  };
+});
+vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@/lib/queryClient';
+import { useGameState, gameStateQueryKey } from '@/hooks/useGameState';
+import { useGameStore } from '@/store/gameStore';
+import { baseGameState, resetGameStore as resetGameStoreImpl } from './gameStore-harness';
+
+const resetGameStore = () => resetGameStoreImpl(useGameStore);
+
+// A minimal real consumer of the façade — renders the focus-slot count that the
+// exec suite / selection summary read every render.
+function SlotProbe() {
+  const usedFocusSlots = useGameState((gs) => gs?.usedFocusSlots ?? null);
+  const money = useGameState((gs) => gs?.money ?? null);
+  return (
+    <div>
+      <span data-testid="slots">{String(usedFocusSlots)}</span>
+      <span data-testid="money">{String(money)}</span>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SlotProbe />
+    </QueryClientProvider>,
+  );
+}
+
+/** Seed both sources exactly as a real load would: Zustand id pointer + cache record. */
+function seedGame(gs: ReturnType<typeof baseGameState>) {
+  useGameStore.setState({ gameState: gs, selectedActions: [] });
+  queryClient.setQueryData(gameStateQueryKey(gs.id), gs);
+}
+
+beforeEach(() => {
+  apiRequestMock.mockClear();
+  queryClient.clear();
+  resetGameStore();
+});
+
+afterEach(() => {
+  queryClient.clear();
+});
+
+describe('useGameState PR-5 flip: reads from the query cache', () => {
+  it('returns null before any game loads (no undefined-flash)', () => {
+    renderProbe();
+    expect(screen.getByTestId('slots').textContent).toBe('null');
+    expect(screen.getByTestId('money').textContent).toBe('null');
+  });
+
+  it('reads the seeded record from the cache', () => {
+    seedGame(baseGameState({ id: 'game-1', usedFocusSlots: 1, money: 42000 }));
+    renderProbe();
+    expect(screen.getByTestId('slots').textContent).toBe('1');
+    expect(screen.getByTestId('money').textContent).toBe('42000');
+  });
+});
+
+describe('useGameState PR-5 flip: SAME-TICK slot math visibility', () => {
+  it('a component sees selectAction\'s slot increment on the next render (no waitFor)', () => {
+    seedGame(baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }));
+    renderProbe();
+    expect(screen.getByTestId('slots').textContent).toBe('0');
+
+    // Fire the real store action. selectAction does synchronous slot math and
+    // commits via the dual-write funnel BEFORE its background syncSlotsPatch.
+    act(() => {
+      void useGameStore.getState().selectAction('{"roleId":"ceo","actionId":"a1","choiceId":"c1"}');
+    });
+
+    // Asserted synchronously — NO waitFor/findBy. setQueryData notified the
+    // useQuery subscriber synchronously, so the new value is on this render.
+    expect(screen.getByTestId('slots').textContent).toBe('1');
+    // Cache and store agree (dual-write still active in PR-5).
+    expect((queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots).toBe(1);
+    expect(useGameStore.getState().gameState!.usedFocusSlots).toBe(1);
+  });
+
+  it('sees removeAction\'s decrement on the next render', () => {
+    seedGame(baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 1, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
+    renderProbe();
+    expect(screen.getByTestId('slots').textContent).toBe('1');
+
+    act(() => {
+      void useGameStore.getState().removeAction('action-A');
+    });
+
+    expect(screen.getByTestId('slots').textContent).toBe('0');
+  });
+});
+
+describe('useGameState PR-5 flip: client-committed-record semantics', () => {
+  it('a window focus does NOT refetch/clobber the record (queryFn never fires)', () => {
+    seedGame(baseGameState({ id: 'game-1', usedFocusSlots: 2 }));
+    renderProbe();
+    expect(screen.getByTestId('slots').textContent).toBe('2');
+
+    // Simulate the focus event the app-default refetchOnWindowFocus reacts to.
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    // The tripwire queryFn (apiRequestMock throws) must NOT have been called,
+    // and the value must be untouched.
+    expect(apiRequestMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('slots').textContent).toBe('2');
+  });
+});


### PR DESCRIPTION
## Phase 3.5 PR-5 — flip `useGameState()` read side to the query cache ⚠️ riskiest PR

Flips the `useGameState` façade's READ side off Zustand and onto the TanStack Query cache at `['gameState:record', gameId]` (the key PR-4's dual-write funnel already writes). One-file production diff (`useGameState.ts`) + one new test + two harness extensions. Store-side dual-write is untouched, so rollback is `git revert` of the one file.

### Mechanism — `useSyncExternalStore` on the QueryCache, NOT `useQuery`
The plan suggested `useQuery` *or* `useSyncExternalStore on the cache`. I verified empirically that **`useQuery` does NOT satisfy the plan's critical same-tick property**: React Query v5 defers observer notifications through its batched `notifyManager` (a microtask/scheduler tick), so a `useQuery` reader only re-renders on a *later* tick — an RTL test must `waitFor` it, and XState `SYNC_SLOTS` / `SelectionSummary` / the CommandDock AUTO filler would see a one-tick-stale focus-slot count. The plan's assumption that "`setQueryData` notifies `useQuery` subscribers synchronously" is false for v5's batched notifyManager.

`useSyncExternalStore` subscribed directly to the QueryCache re-renders **synchronously** when `setQueryData` fires during an event — the same guarantee Zustand's own `useSyncExternalStore` gave. A `useQuery` is *also* mounted, but only to drive the cold-cache fallback fetch and pin client-committed-record semantics (`staleTime`/`gcTime` Infinity, `refetchOnWindowFocus`/`Mount`/`Reconnect` off). Its `.data` is ignored for reads. Reads go through the **context** client (`useQueryClient()`), which in-app IS the `@/lib/queryClient` singleton the funnel writes to (App.tsx mounts it), so reads and writes share one cache.

### Same-tick proof (RTL, no `waitFor`)
New `tests/client/useGameState-facade-flip.test.tsx` renders a real component through `useGameState()`, uses the real `queryClient` in a provider, fires the real `selectAction`/`removeAction` store actions inside `act()`, and asserts the re-rendered focus-slot count **synchronously** (no `waitFor`/`findBy`). It also asserts a simulated `window` `focus` event does NOT refetch (the queryFn is a throwing tripwire) and that `null` is returned before any game loads (no undefined-flash).

### gameId bootstrap
`gameId` is still read from Zustand — a tiny session pointer (`s.gameState?.id`) — while the record itself comes from the cache. `useGameId()` reads the Zustand pointer directly (cheap store subscription, byte-identical to the original derivation), independent of the cached record so it's available before the cache is seeded. PR-4's funnel seeds the new key before any gameId flip is observable.

### Loading/null semantics
Identical to the old Zustand read: no game → `null`; `getSnapshot` collapses `undefined` to `null`. No `isLoading`/query-object exposed.

### Harness changes (no assertions changed)
- **`tests/client/useDiscoveredArtists.test.tsx`**: `renderWithClient` now seeds the mocked `gameState` into the cache under `gameStateQueryKey(id)`, because `useDiscoveredArtists` reads `flags`/`arOfficeSlotUsed` via the now-cache-backed `useGameState`. Same `gameState`, fed through the cache instead of Zustand. Without it the flipped hook returns null flags and fires its cold-cache fallback GET.
- **`client/src/components/__tests__/ArtistRoster.test.tsx`**: mocks `@/hooks/useGameState` to return the fake spine — the exact store-only, QueryClient-free pattern the file already uses for `useProjects`/`useArtists` (PR-7/PR-9). `useGameState` now needs a QueryClientProvider (`useQueryClient`), which this deliberately store-only component test doesn't mount.

### Rollback story
Revert this one file — PR-4's dual-write keeps both Zustand and the cache correct indefinitely, so the Zustand read path resumes working immediately.

### Validation
- `npm run check` clean.
- `npx vitest run tests/client client/src` → **226 passed (24 files)**. PR-1 spine net, PR-4 dual-write net, and the query-key contract all green unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
