### PR TITLE
refactor(client): retire the Zustand gameState copy (Phase 3.5 PR-6)

### DIFF
--- a/client/src/components/SaveGameModal.tsx
+++ b/client/src/components/SaveGameModal.tsx
@@ -138,10 +138,12 @@ export function SaveGameModal({ open, onOpenChange }: SaveGameModalProps) {
 
       const restoredGameId = await loadGameFromSave(saveId, snapshot, mode);
 
-      // Update the game context with the loaded game's ID
-      // We need to get the game ID from the loaded state
-      const { gameState: loadedState } = useGameStore.getState();
-      const activeGameId = restoredGameId || loadedState?.id;
+      // Update the game context with the loaded game's ID. Prefer the id
+      // returned by loadGameFromSave; fall back to the Zustand SESSION POINTER
+      // id (the only spine field Zustand still holds after Phase 3.5 PR-6 — the
+      // full record is cache-owned).
+      const pointerGameId = useGameStore.getState().gameState?.id ?? null;
+      const activeGameId = restoredGameId || pointerGameId;
       if (activeGameId) {
         setGameId(activeGameId);
       }

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -174,16 +174,20 @@ async function refetchDiscoveredArtistsCache(gameState: GameState | null) {
   }
 }
 
-// Phase 3.5 PR-4: THE dual-write commit funnel for the gameState spine.
+// Phase 3.5 PR-6: THE commit funnel for the gameState spine — cache is now the
+// SINGLE owner of the record.
 //
-// Every gameState write in the store flows through here. It (a) writes Zustand
-// exactly as before — `set({ gameState: next })`, same shallow-merge semantics,
-// byte-for-byte identical resulting store state — and (b) synchronously mirrors
-// the same object into the TanStack Query cache at `gameStateQueryKey(next.id)`.
-// The cache is a CLIENT-COMMITTED RECORD: this funnel is its only writer, so the
-// two sources can never diverge. `useGameState()` still READS Zustand until PR-5
-// flips it; the cache write here is a no-op for readers this PR but lets PR-5 be
-// a one-file change.
+// Through PR-4/PR-5 this funnel dual-wrote Zustand (`set({ gameState: next })`)
+// AND the TanStack Query cache. PR-6 retires the Zustand copy: the full spine
+// record now lives ONLY in the query cache at `gameStateQueryKey(next.id)`. The
+// funnel is still its ONLY writer, so the record is a CLIENT-COMMITTED RECORD
+// (staleTime/gcTime Infinity, no background refetch — see hooks/useGameState.ts).
+//
+// Zustand retains a MINIMAL SESSION POINTER only: `gameState = { id }` (or null).
+// That pointer is what `useGameId` / `useGameState`'s gameId bootstrap /
+// `partialize` read (`state.gameState?.id`) — the on-disk localStorage shape
+// `{ gameState: { id } | null, ... }` is therefore unchanged. The full record is
+// never in Zustand again; internal store reads go through `readGameState(get)`.
 //
 // `previousGameId` handles the game-SWITCH writers (loadGame / loadGameFromSave /
 // createNewGame): when the committed game's id differs from the game we were on,
@@ -196,17 +200,22 @@ async function refetchDiscoveredArtistsCache(gameState: GameState | null) {
 // closure like `adoptServerBalances`).
 type ZustandSet = (partial: Partial<GameStore>) => void;
 
+/** The minimal Zustand session pointer that survives PR-6 (id only). */
+type GameStatePointer = Pick<GameState, 'id'>;
+
 function commitGameState(
   set: ZustandSet,
   next: GameState,
   previousGameId?: string | null,
 ) {
-  // (a) Zustand write — unchanged semantics.
-  set({ gameState: next });
-  // (b) Cache mirror. Drop the stale key first on a game switch so a
-  // switched-away game never lingers in the cache. `removeQueries` is guarded
-  // for the mocked queryClient in the characterization harness (which stubs only
-  // invalidate/set/getQueryData) — its absence must not break the Zustand write.
+  // (a) Zustand write — now the SESSION POINTER only (`{ id }`), not the record.
+  // This keeps `useGameId` / persist / the useGameState bootstrap working off
+  // `state.gameState?.id` with the exact same on-disk shape as before.
+  set({ gameState: next.id ? ({ id: next.id } as GameStatePointer) : null });
+  // (b) Cache — the SINGLE owner of the full record. Drop the stale key first on
+  // a game switch so a switched-away game never lingers in the cache.
+  // `removeQueries` is guarded for the mocked queryClient in the characterization
+  // harness (which may stub only invalidate/set/getQueryData).
   if (
     previousGameId &&
     next.id &&
@@ -218,6 +227,17 @@ function commitGameState(
   if (next.id) {
     queryClient.setQueryData(gameStateQueryKey(next.id), next);
   }
+}
+
+// Phase 3.5 PR-6: read the full spine record from its single owner, the query
+// cache. The current game id comes from the Zustand session pointer
+// (`get().gameState?.id`) — the only spine field Zustand still holds. Returns
+// null when there is no current game or the record has not been committed yet,
+// matching the old `get().gameState` null semantics exactly.
+function readGameState(get: () => GameStore): GameState | null {
+  const gameId = get().gameState?.id;
+  if (!gameId) return null;
+  return queryClient.getQueryData<GameState>(gameStateQueryKey(gameId)) ?? null;
 }
 
 // Phase 3 PR-10: adopt the SERVER-CANONICAL money + creativeCapital after a
@@ -244,7 +264,9 @@ async function adoptServerBalances(get: () => GameStore, gameId: string) {
     const data = await response.json();
     const serverGameState = data?.gameState;
     if (!serverGameState) return;
-    const current = get().gameState;
+    // Phase 3.5 PR-6: read the current record from the cache (its single owner),
+    // not the Zustand pointer.
+    const current = readGameState(get);
     if (!current) return;
     // Phase 3.5 PR-4: route the two-field merge through the dual-write funnel so
     // the cache mirror stays in lock-step. Same-game write (id unchanged), so no
@@ -276,8 +298,11 @@ async function syncSlotsPatch(
 }
 
 interface GameStore {
-  // Game state
-  gameState: GameState | null;
+  // Phase 3.5 PR-6: `gameState` is now a MINIMAL SESSION POINTER (`{ id }` or
+  // null), NOT the full spine record. The record is cache-owned
+  // (gameStateQueryKey) and read via useGameState() / readGameState(). Only the
+  // id survives in Zustand — it's the bootstrap handle for the cache + persist.
+  gameState: GameStatePointer | null;
   roles: Role[];
   weeklyActions: WeeklyAction[];
   // Phase 3 PR-6: songs / releases / releaseSongs are no longer owned by the
@@ -564,7 +589,9 @@ export const useGameStore = create<GameStore>()(
           // This is the PRIMARY prevention mechanism for orphaned games.
           // ============================================================================
 
-          const currentGame = get().gameState;
+          // Phase 3.5 PR-6: orphan-cleanup reads id/currentWeek from the cache
+          // record (single owner), not the Zustand pointer.
+          const currentGame = readGameState(get);
           const previousGameId = currentGame?.id ?? null;
           if (currentGame?.id) {
             console.log(`[ORPHANED GAME CLEANUP] Checking if current game ${currentGame.id} (Week ${currentGame.currentWeek}) has saves...`);
@@ -701,9 +728,10 @@ export const useGameStore = create<GameStore>()(
 
       // Weekly action selection
       selectAction: async (actionId: string) => {
-        const { selectedActions, gameState } = get();
-        const availableSlots = gameState?.focusSlots || 3;
-        
+        const { selectedActions } = get();
+        // Phase 3.5 PR-6: read the record from the cache (single owner).
+        const gameState = readGameState(get);
+
         if (
           gameState &&
           selectedActions.length < ((gameState.focusSlots || 0) - ((gameState.arOfficeSlotUsed) ? 1 : 0)) &&
@@ -733,7 +761,8 @@ export const useGameStore = create<GameStore>()(
       },
 
       removeAction: async (actionId: string) => {
-        const { selectedActions, gameState } = get();
+        const { selectedActions } = get();
+        const gameState = readGameState(get);
         if (selectedActions.includes(actionId) && gameState) {
           const newSelectedActions = selectedActions.filter(id => id !== actionId);
           const arUsed = gameState.arOfficeSlotUsed ? 1 : 0;
@@ -762,7 +791,7 @@ export const useGameStore = create<GameStore>()(
       },
 
       clearActions: () => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
         const arUsed = gameState?.arOfficeSlotUsed ? 1 : 0;
         // Phase 3.5 PR-4: selectedActions keeps its plain `set`; gameState (when
         // present) flows through the dual-write funnel. When gameState is null it
@@ -775,7 +804,8 @@ export const useGameStore = create<GameStore>()(
 
       // Advance week
       advanceWeek: async () => {
-        const { gameState, selectedActions } = get();
+        const { selectedActions } = get();
+        const gameState = readGameState(get);
         // Allow advancing the week if either there are selected actions OR an A&R operation is consuming a slot
         if (!gameState || (selectedActions.length === 0 && !gameState.arOfficeSlotUsed)) return;
 
@@ -923,7 +953,7 @@ export const useGameStore = create<GameStore>()(
             // Enhanced retry logic with exponential backoff
             const loadWithRetry = async (attempt = 1): Promise<void> => {
               try {
-                await refetchDiscoveredArtistsCache(get().gameState);
+                await refetchDiscoveredArtistsCache(readGameState(get));
                 console.log(`[A&R] Successfully loaded discovered artists (attempt ${attempt})`);
               } catch (error) {
                 console.error(`[A&R] Failed to load discovered artists (attempt ${attempt}):`, error);
@@ -1030,7 +1060,7 @@ export const useGameStore = create<GameStore>()(
 
       // Artist management
       signArtist: async (artistData: any) => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
         if (!gameState) return;
 
         try {
@@ -1069,7 +1099,7 @@ export const useGameStore = create<GameStore>()(
       },
 
       updateArtist: async (artistId: string, updates: any) => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
 
         try {
           await apiRequest('PATCH', `/api/artists/${artistId}`, updates);
@@ -1087,7 +1117,7 @@ export const useGameStore = create<GameStore>()(
 
       // Project management
       createProject: async (projectData: any) => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
         if (!gameState) return;
 
         try {
@@ -1119,7 +1149,7 @@ export const useGameStore = create<GameStore>()(
       },
 
       updateProject: async (projectId: string, updates: any) => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
 
         try {
           const response = await apiRequest('PATCH', `/api/projects/${projectId}`, updates);
@@ -1138,7 +1168,7 @@ export const useGameStore = create<GameStore>()(
 
       // Cancel project with refund calculation
       cancelProject: async (projectId: string, cancellationData: { refundAmount: number }) => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
         if (!gameState) return;
 
         try {
@@ -1175,7 +1205,7 @@ export const useGameStore = create<GameStore>()(
 
       // Release management
       planRelease: async (releaseData: any) => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
         if (!gameState) return;
 
         try {
@@ -1207,7 +1237,8 @@ export const useGameStore = create<GameStore>()(
 
       // A&R Office operations
       consumeAROfficeSlot: async (sourcingType: SourcingTypeString) => {
-        const { gameState, selectedActions } = get();
+        const { selectedActions } = get();
+        const gameState = readGameState(get);
         if (!gameState) return;
         const arUsed = gameState.arOfficeSlotUsed ? 1 : 0;
         const totalUsed = selectedActions.length + arUsed;
@@ -1231,7 +1262,8 @@ export const useGameStore = create<GameStore>()(
       },
 
       releaseAROfficeSlot: async () => {
-        const { gameState, selectedActions } = get();
+        const { selectedActions } = get();
+        const gameState = readGameState(get);
         if (!gameState || !gameState.arOfficeSlotUsed) return;
 
         const updated: GameState = {
@@ -1252,7 +1284,7 @@ export const useGameStore = create<GameStore>()(
       },
 
       getAROfficeStatus: () => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
         return {
           arOfficeSlotUsed: !!gameState?.arOfficeSlotUsed,
           arOfficeSourcingType: (gameState?.arOfficeSourcingType as SourcingTypeString | null) ?? null,
@@ -1261,7 +1293,8 @@ export const useGameStore = create<GameStore>()(
       },
 
       startAROfficeOperation: async (sourcingType: SourcingTypeString, primaryGenre?: string, secondaryGenre?: string) => {
-        const { gameState, consumeAROfficeSlot } = get();
+        const { consumeAROfficeSlot } = get();
+        const gameState = readGameState(get);
         if (!gameState) return;
         console.log('[A&R CLIENT] Starting A&R operation:', { sourcingType, primaryGenre, secondaryGenre });
         try {
@@ -1283,7 +1316,7 @@ export const useGameStore = create<GameStore>()(
 
 
       cancelAROfficeOperation: async () => {
-        const { gameState } = get();
+        const gameState = readGameState(get);
         if (!gameState) return;
         try {
           const { cancelAROfficeOperation } = await import('../services/arOfficeService');
@@ -1309,13 +1342,17 @@ export const useGameStore = create<GameStore>()(
       // persistence was load-bearing (they were never in the persist partialize).
       saveGame: async (name: string, options?: { isAutosave?: boolean }) => {
         const {
-          gameState,
           roles,
           executives,
           moodEvents,
           weeklyActions,
           weeklyOutcome
         } = get();
+        // Phase 3.5 PR-6: the spine record (with embedded musicLabel) comes from
+        // the cache — its single owner — exactly as the five collections already
+        // do below. Autosave runs right after advanceWeek's commit, so the cache
+        // is freshly written here (same-tick, safe).
+        const gameState = readGameState(get);
         if (!gameState) return;
 
         // Phase 3 PR-6/PR-7/PR-9: songs / releases / releaseSongs / projects /

--- a/tests/client/gameStore-actions.characterization.test.ts
+++ b/tests/client/gameStore-actions.characterization.test.ts
@@ -26,6 +26,9 @@ vi.mock('@/lib/queryClient', () => ({
       return value;
     }),
     getQueryData: vi.fn((key: unknown) => queryCache.get(JSON.stringify(key))),
+    removeQueries: vi.fn(({ queryKey }: { queryKey: unknown }) => {
+      queryCache.delete(JSON.stringify(queryKey));
+    }),
   },
 }));
 vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
@@ -36,6 +39,7 @@ import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { projectsQueryKey } from '@/hooks/useProjects';
 import { artistsQueryKey } from '@/hooks/useArtists';
 import { discoveredArtistsQueryKey } from '@/hooks/useDiscoveredArtists';
+import { gameStateQueryKey } from '@/hooks/useGameState';
 import { useGameStore } from '@/store/gameStore';
 import {
   routeApiRequest as routeApiRequestImpl,
@@ -48,6 +52,21 @@ const mockedApiRequest = apiRequest as unknown as ReturnType<typeof vi.fn>;
 const routeApiRequest = (routes: Array<{ match: (url: string) => boolean; body: unknown }>) =>
   routeApiRequestImpl(mockedApiRequest, routes);
 const resetGameStore = () => resetGameStoreImpl(useGameStore);
+
+/**
+ * Phase 3.5 PR-6: the store's actions read the spine record from its SINGLE
+ * owner (the query cache) via `readGameState`, and Zustand keeps only a `{ id }`
+ * session pointer. So a test seed must write BOTH the pointer and the cache
+ * record, and post-action pins read the record back from the cache.
+ */
+function seedGameState(gs: any) {
+  useGameStore.setState({ gameState: { id: gs.id } as any });
+  queryClient.setQueryData(gameStateQueryKey(gs.id), gs);
+}
+/** The committed spine record for a game (its single owner is the cache). */
+function record(gameId = 'game-1'): any {
+  return queryClient.getQueryData(gameStateQueryKey(gameId));
+}
 
 beforeEach(() => {
   mockedApiRequest.mockReset();
@@ -66,7 +85,7 @@ describe('signArtist adopts server-canonical money', () => {
   // 83000 and the store must show 83000. (Phase 3 PR-9 pins for the artists +
   // discovered cache invalidations are unchanged.)
   it('adopts the server balance from the refetch (NOT a client 100000-15000 delta)', async () => {
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 100000 }) });
+    seedGameState(baseGameState({ id: 'game-1', money: 100000 }));
     const newArtist = { id: 'artist-99', name: 'Signed One' };
     routeApiRequest([
       // GET /api/game/:id refetch — server is canonical (83000 != client's 85000).
@@ -77,7 +96,7 @@ describe('signArtist adopts server-canonical money', () => {
     await useGameStore.getState().signArtist({ name: 'Signed One', signingCost: 15000 });
 
     const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(83000); // server-canonical, not 85000
+    expect(record().money).toBe(83000); // server-canonical, not 85000
     // Roster no longer lives in the store; the mutation invalidates the cache.
     expect((state as any).artists).toBeUndefined();
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -96,7 +115,7 @@ describe('signArtist adopts server-canonical money', () => {
     // balance must still be exactly the server's number, never 100000 - 15000 -
     // 15000. The GET always returns 83000 here, so after two signs the store
     // shows 83000, not a doubly-subtracted 70000.
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 100000 }) });
+    seedGameState(baseGameState({ id: 'game-1', money: 100000 }));
     routeApiRequest([
       { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 4 } } },
       { match: (u) => u.includes('/artists'), body: { id: 'a1' } },
@@ -107,13 +126,13 @@ describe('signArtist adopts server-canonical money', () => {
       useGameStore.getState().signArtist({ signingCost: 15000 }),
     ]);
 
-    expect(useGameStore.getState().gameState!.money).toBe(83000); // not 70000
+    expect(record().money).toBe(83000); // not 70000
   });
 
   it('leaves money unchanged when the refetch yields no gameState (transient GET failure)', async () => {
     // adoptServerBalances returns silently if the GET has no gameState; the store
     // keeps its prior balance rather than throwing or zeroing out.
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 42000 }) });
+    seedGameState(baseGameState({ id: 'game-1', money: 42000 }));
     routeApiRequest([
       { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: {} }, // no gameState field
       { match: (u) => u.includes('/artists'), body: { id: 'a1' } },
@@ -121,7 +140,7 @@ describe('signArtist adopts server-canonical money', () => {
 
     await useGameStore.getState().signArtist({ name: 'No Cost' });
 
-    expect(useGameStore.getState().gameState!.money).toBe(42000);
+    expect(record().money).toBe(42000);
   });
 });
 
@@ -136,9 +155,7 @@ describe('createProject adopts server-canonical money + creativeCapital', () => 
   // server says 83000 / 2 and the store must show 83000 / 2. (Phase 3 PR-7 pin
   // for the projects cache invalidation is unchanged.)
   it('adopts server money + cc from the refetch (NOT client 80000/3 deltas)', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }),
-    });
+    seedGameState(baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }));
     const newProject = { id: 'proj-1', title: 'EP' };
     routeApiRequest([
       // GET /api/game/:id refetch — server canonical (83000/2 != client 80000/3).
@@ -149,8 +166,8 @@ describe('createProject adopts server-canonical money + creativeCapital', () => 
     await useGameStore.getState().createProject({ totalCost: 20000 });
 
     const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(83000); // server-canonical, not 80000
-    expect((state.gameState as any).creativeCapital).toBe(2); // server-canonical, not 3
+    expect(record().money).toBe(83000); // server-canonical, not 80000
+    expect(record().creativeCapital).toBe(2); // server-canonical, not 3
     // Projects no longer live in the store; the mutation invalidates the cache.
     expect((state as any).projects).toBeUndefined();
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -164,9 +181,7 @@ describe('createProject adopts server-canonical money + creativeCapital', () => 
     // (a double-fire is two real server mutations — out of scope); the point is
     // the displayed balances equal the server's numbers, never a doubly-
     // subtracted 60000 / cc 2.
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }),
-    });
+    seedGameState(baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }));
     routeApiRequest([
       { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 2 } } },
       { match: (u) => u.includes('/projects'), body: { id: 'p1' } },
@@ -177,9 +192,8 @@ describe('createProject adopts server-canonical money + creativeCapital', () => 
       useGameStore.getState().createProject({ totalCost: 20000 }),
     ]);
 
-    const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(83000); // not 60000
-    expect((state.gameState as any).creativeCapital).toBe(2); // not a compounded value
+    expect(record().money).toBe(83000); // not 60000
+    expect(record().creativeCapital).toBe(2); // not a compounded value
   });
 });
 
@@ -193,9 +207,7 @@ describe('planRelease adopts server-canonical money + creativeCapital', () => {
   // would say money 88000 / cc 3, but the server says 83000 / 2 and the store
   // must show 83000 / 2.
   it('adopts server money + cc from the refetch (NOT client 88000/3 deltas)', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }),
-    });
+    seedGameState(baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4 }));
     routeApiRequest([
       // GET /api/game/:id refetch — server canonical (83000/2 != client 88000/3).
       { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 83000, creativeCapital: 2 } } },
@@ -204,15 +216,12 @@ describe('planRelease adopts server-canonical money + creativeCapital', () => {
 
     await useGameStore.getState().planRelease({ metadata: { totalInvestment: 12000 } });
 
-    const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(83000); // server-canonical, not 88000
-    expect((state.gameState as any).creativeCapital).toBe(2); // server-canonical, not 3
+    expect(record().money).toBe(83000); // server-canonical, not 88000
+    expect(record().creativeCapital).toBe(2); // server-canonical, not 3
   });
 
   it('leaves balances unchanged when the refetch yields no gameState (transient GET failure)', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', money: 60000, creativeCapital: 2 }),
-    });
+    seedGameState(baseGameState({ id: 'game-1', money: 60000, creativeCapital: 2 }));
     routeApiRequest([
       { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: {} }, // no gameState field
       { match: (u) => u.includes('/releases/plan'), body: {} },
@@ -220,8 +229,8 @@ describe('planRelease adopts server-canonical money + creativeCapital', () => {
 
     await useGameStore.getState().planRelease({});
 
-    expect(useGameStore.getState().gameState!.money).toBe(60000);
-    expect((useGameStore.getState().gameState as any).creativeCapital).toBe(2);
+    expect(record().money).toBe(60000);
+    expect(record().creativeCapital).toBe(2);
   });
 });
 
@@ -231,9 +240,7 @@ describe('cancelProject adopts server balance', () => {
   // invalidates the projects query key so useProjects refetches. The money
   // pin (adopts server newBalance verbatim) is UNTOUCHED.
   it('sets money to result.newBalance (NOT a local delta) and invalidates projects', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', money: 20000 }),
-    });
+    seedGameState(baseGameState({ id: 'game-1', money: 20000 }));
     routeApiRequest([
       {
         match: (u) => u.includes('/cancel'),
@@ -244,7 +251,7 @@ describe('cancelProject adopts server balance', () => {
     await useGameStore.getState().cancelProject('proj-1', { refundAmount: 7500 });
 
     const state = useGameStore.getState();
-    expect(state.gameState!.money).toBe(27500); // adopts server newBalance verbatim
+    expect(record().money).toBe(27500); // adopts server newBalance verbatim
     // Projects no longer live in the store; the mutation invalidates the cache.
     expect((state as any).projects).toBeUndefined();
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
@@ -285,9 +292,9 @@ describe('loadGame set(...) state shape', () => {
 
     const state = useGameStore.getState();
     // gameState carries musicLabel nested in (loadGame's shape), plus synced AR fields.
-    expect(state.gameState!.id).toBe('game-1');
-    expect((state.gameState as any).musicLabel).toEqual({ name: 'Loaded Label' });
-    expect((state.gameState as any).usedFocusSlots).toBe(0);
+    expect(record('game-1').id).toBe('game-1');
+    expect(record('game-1').musicLabel).toEqual({ name: 'Loaded Label' });
+    expect(record('game-1').usedFocusSlots).toBe(0);
     // PR-9: artists are seeded into the query cache, not the store.
     expect((state as any).artists).toBeUndefined();
     expect(state.roles).toEqual([{ id: 'role1' }]);
@@ -317,8 +324,8 @@ describe('loadGame set(...) state shape', () => {
 
 describe('advanceWeek set(...) state shape', () => {
   it('writes the post-advance collections, weeklyOutcome/campaignResults, and clears flags', async () => {
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }));
     useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }),
       selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
     });
 
@@ -350,7 +357,7 @@ describe('advanceWeek set(...) state shape', () => {
     await useGameStore.getState().advanceWeek();
 
     const state = useGameStore.getState();
-    expect((state.gameState as any).currentWeek).toBe(6);
+    expect(record('game-1').currentWeek).toBe(6);
     // PR-9: artists are seeded into the query cache, not the store.
     expect((state as any).artists).toBeUndefined();
     expect(state.emails).toEqual([{ id: 'em1' }]);

--- a/tests/client/gameStore-dual-write.characterization.test.ts
+++ b/tests/client/gameStore-dual-write.characterization.test.ts
@@ -1,14 +1,14 @@
 /**
- * gameStore dual-write funnel characterization tests (Phase 3.5 PR-4).
+ * gameStore commit-funnel characterization tests (Phase 3.5 PR-4 → PR-6).
  *
- * PR-4 routes every gameState write in the store through a single
- * `commitGameState()` funnel that dual-writes: the Zustand `set({ gameState })`
- * (unchanged) PLUS `queryClient.setQueryData(gameStateQueryKey(id), next)`. This
- * suite asserts the INVARIANT that makes PR-5's reader flip safe: after every
- * store action, the cache record at `gameStateQueryKey(id)` deep-equals the
- * Zustand `gameState`. The Zustand side itself is pinned unchanged by
- * gameStore-spine.characterization.test.ts (the PR-1 net) — this file adds the
- * cache-equivalence half.
+ * PR-4 routed every gameState write through a single `commitGameState()` funnel
+ * that dual-wrote Zustand + the query cache. PR-6 RETIRES the Zustand record:
+ * the funnel now writes the full spine ONLY to the cache at
+ * `gameStateQueryKey(id)` and keeps just a `{ id }` SESSION POINTER in Zustand.
+ * This suite therefore asserts the cache — the single owner — carries the
+ * committed record after every store action, and that the Zustand pointer tracks
+ * the current game id. (The former "cache deep-equals the Zustand record"
+ * invariant no longer applies: Zustand holds no record.)
  *
  * The mocked queryClient here exposes `removeQueries` in addition to
  * set/get/invalidate because the game-SWITCH writers (loadGame /
@@ -50,11 +50,24 @@ const routeApiRequest = (routes: Array<{ match: (url: string) => boolean; body: 
   routeApiRequestImpl(mockedApiRequest, routes);
 const resetGameStore = () => resetGameStoreImpl(useGameStore);
 
-/** The single invariant this whole suite exists to prove. */
-function cacheEqualsStore(gameId: string) {
-  const store = useGameStore.getState().gameState;
-  const cached = queryClient.getQueryData(gameStateQueryKey(gameId));
-  expect(cached).toEqual(store);
+/** Read the committed spine record from its single owner (the cache). */
+function readRecord(gameId: string): any {
+  return queryClient.getQueryData(gameStateQueryKey(gameId));
+}
+
+/**
+ * Seed a game the way a real load does after PR-6: the Zustand SESSION POINTER
+ * (`{ id }`) plus the full record in the cache. Store actions read the record
+ * via `readGameState` (cache), so the cache MUST be seeded, not just the pointer.
+ */
+function seedGame(gs: any) {
+  useGameStore.setState({ gameState: { id: gs.id } as any });
+  queryClient.setQueryData(gameStateQueryKey(gs.id), gs);
+}
+
+/** After a commit, the Zustand pointer tracks the current game id. */
+function pointerId(): string | null {
+  return useGameStore.getState().gameState?.id ?? null;
 }
 
 beforeEach(() => {
@@ -64,96 +77,68 @@ beforeEach(() => {
   mockedApiRequest.mockResolvedValue(jsonResponse({}));
 });
 
-describe('dual-write funnel: same-game slot writers', () => {
-  it('selectAction mirrors the new gameState into the cache', () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }),
-      selectedActions: [],
-    });
+describe('commit funnel: same-game slot writers', () => {
+  it('selectAction commits the new gameState to the cache (single owner)', () => {
+    seedGame(baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: [] });
 
     void useGameStore.getState().selectAction('action-A');
 
-    expect(useGameStore.getState().gameState!.usedFocusSlots).toBe(1);
-    cacheEqualsStore('game-1');
-    expect(
-      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots,
-    ).toBe(1);
+    expect(readRecord('game-1').usedFocusSlots).toBe(1);
+    expect(pointerId()).toBe('game-1'); // pointer still tracks the game
   });
 
-  it('removeAction mirrors the decremented gameState into the cache', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', usedFocusSlots: 2, arOfficeSlotUsed: false }),
-      selectedActions: ['action-A', 'action-B'],
-    });
+  it('removeAction commits the decremented gameState to the cache', async () => {
+    seedGame(baseGameState({ id: 'game-1', usedFocusSlots: 2, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: ['action-A', 'action-B'] });
 
     await useGameStore.getState().removeAction('action-A');
 
-    cacheEqualsStore('game-1');
-    expect(
-      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots,
-    ).toBe(1);
+    expect(readRecord('game-1').usedFocusSlots).toBe(1);
   });
 
-  it('clearActions mirrors the reset gameState into the cache', () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', usedFocusSlots: 2, arOfficeSlotUsed: false }),
-      selectedActions: ['action-A', 'action-B'],
-    });
+  it('clearActions commits the reset gameState to the cache', () => {
+    seedGame(baseGameState({ id: 'game-1', usedFocusSlots: 2, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: ['action-A', 'action-B'] });
 
     useGameStore.getState().clearActions();
 
-    cacheEqualsStore('game-1');
-    expect(
-      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots,
-    ).toBe(0);
+    expect(readRecord('game-1').usedFocusSlots).toBe(0);
   });
 
-  it('consumeAROfficeSlot mirrors the A&R gameState into the cache', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 1, arOfficeSlotUsed: false }),
-      selectedActions: ['action-A'],
-    });
+  it('consumeAROfficeSlot commits the A&R gameState to the cache', async () => {
+    seedGame(baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 1, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
 
     await useGameStore.getState().consumeAROfficeSlot('active');
 
-    cacheEqualsStore('game-1');
-    expect(
-      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).arOfficeSlotUsed,
-    ).toBe(true);
+    expect(readRecord('game-1').arOfficeSlotUsed).toBe(true);
   });
 
-  it('releaseAROfficeSlot mirrors the cleared A&R gameState into the cache', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 2, arOfficeSlotUsed: true, arOfficeSourcingType: 'active' }),
-      selectedActions: ['action-A'],
-    });
+  it('releaseAROfficeSlot commits the cleared A&R gameState to the cache', async () => {
+    seedGame(baseGameState({ id: 'game-1', focusSlots: 3, usedFocusSlots: 2, arOfficeSlotUsed: true, arOfficeSourcingType: 'active' }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
 
     await useGameStore.getState().releaseAROfficeSlot();
 
-    cacheEqualsStore('game-1');
-    expect(
-      (queryClient.getQueryData(gameStateQueryKey('game-1')) as any).arOfficeSlotUsed,
-    ).toBe(false);
+    expect(readRecord('game-1').arOfficeSlotUsed).toBe(false);
   });
 });
 
-describe('dual-write funnel: balance-adopting writers', () => {
-  it('cancelProject mirrors result.newBalance into the cache', async () => {
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', money: 20000 }) });
+describe('commit funnel: balance-adopting writers', () => {
+  it('cancelProject commits result.newBalance to the cache', async () => {
+    seedGame(baseGameState({ id: 'game-1', money: 20000 }));
     routeApiRequest([
       { match: (u) => u.includes('/cancel'), body: { newBalance: 27500, refundAmount: 7500 } },
     ]);
 
     await useGameStore.getState().cancelProject('proj-1', { refundAmount: 7500 });
 
-    cacheEqualsStore('game-1');
-    expect((queryClient.getQueryData(gameStateQueryKey('game-1')) as any).money).toBe(27500);
+    expect(readRecord('game-1').money).toBe(27500);
   });
 
-  it('adoptServerBalances (via planRelease) mirrors the two-field merge into the cache', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4, musicLabel: { name: 'Keep' } }),
-    });
+  it('adoptServerBalances (via planRelease) commits the two-field merge to the cache', async () => {
+    seedGame(baseGameState({ id: 'game-1', money: 100000, creativeCapital: 4, musicLabel: { name: 'Keep' } }));
     routeApiRequest([
       { match: (u) => /\/api\/game\/[^/]+$/.test(u), body: { gameState: { money: 55000, creativeCapital: 1 } } },
       { match: (u) => u.includes('/releases/plan'), body: { ok: true } },
@@ -161,8 +146,7 @@ describe('dual-write funnel: balance-adopting writers', () => {
 
     await useGameStore.getState().planRelease({ metadata: { totalInvestment: 1000 } });
 
-    cacheEqualsStore('game-1');
-    const cached = queryClient.getQueryData(gameStateQueryKey('game-1')) as any;
+    const cached = readRecord('game-1');
     expect(cached.money).toBe(55000);
     expect(cached.creativeCapital).toBe(1);
     expect(cached.musicLabel).toEqual({ name: 'Keep' }); // preserved, not clobbered
@@ -190,36 +174,33 @@ describe('dual-write funnel: game-switch writers seed the new key + drop the old
     });
   }
 
-  it('loadGame seeds the loaded game key equal to the store gameState', async () => {
+  it('loadGame seeds the loaded game key and the pointer tracks it', async () => {
     routeLoad('game-1', { name: 'Loaded Label' });
 
     await useGameStore.getState().loadGame('game-1');
 
-    cacheEqualsStore('game-1');
-    expect((queryClient.getQueryData(gameStateQueryKey('game-1')) as any).musicLabel).toEqual({
-      name: 'Loaded Label',
-    });
+    expect(pointerId()).toBe('game-1');
+    expect(readRecord('game-1').musicLabel).toEqual({ name: 'Loaded Label' });
   });
 
   it('switching games via loadGame drops the previous game key and seeds the new one', async () => {
-    // Start on game-A with a seeded record.
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-A' }) });
-    queryClient.setQueryData(gameStateQueryKey('game-A'), baseGameState({ id: 'game-A' }));
+    // Start on game-A with a seeded record + pointer.
+    seedGame(baseGameState({ id: 'game-A' }));
 
     routeLoad('game-B', { name: 'B Label' });
     await useGameStore.getState().loadGame('game-B');
 
-    // Old key removed, new key seeded and equal to the store.
+    // Old key removed, new key seeded, pointer flipped to the new game.
     expect(queryClient.getQueryData(gameStateQueryKey('game-A'))).toBeUndefined();
-    cacheEqualsStore('game-B');
+    expect(pointerId()).toBe('game-B');
+    expect(readRecord('game-B')).toBeTruthy();
     expect(queryClient.removeQueries).toHaveBeenCalledWith({
       queryKey: gameStateQueryKey('game-A'),
     });
   });
 
   it('createNewGame drops the previous (orphaned) game key and seeds the new game', async () => {
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
-    queryClient.setQueryData(gameStateQueryKey('game-1'), baseGameState({ id: 'game-1' }));
+    seedGame(baseGameState({ id: 'game-1', currentWeek: 4 }));
 
     mockedApiRequest.mockImplementation(async (method: string, url: string) => {
       if (method === 'GET' && url.endsWith('/api/saves')) return jsonResponse([]); // orphaned
@@ -234,15 +215,15 @@ describe('dual-write funnel: game-switch writers seed the new key + drop the old
     await useGameStore.getState().createNewGame('Balanced');
 
     expect(queryClient.getQueryData(gameStateQueryKey('game-1'))).toBeUndefined();
-    cacheEqualsStore('game-2');
-    expect((queryClient.getQueryData(gameStateQueryKey('game-2')) as any).id).toBe('game-2');
+    expect(pointerId()).toBe('game-2');
+    expect(readRecord('game-2').id).toBe('game-2');
   });
 });
 
-describe('dual-write funnel: advanceWeek commits the merged gameState to the cache', () => {
-  it('mirrors the post-advance gameState (refetch-wins merge) into the cache', async () => {
+describe('commit funnel: advanceWeek commits the merged gameState to the cache', () => {
+  it('commits the post-advance gameState (refetch-wins merge) to the cache', async () => {
+    seedGame(baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }));
     useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }),
       selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
     });
 
@@ -264,10 +245,10 @@ describe('dual-write funnel: advanceWeek commits the merged gameState to the cac
 
     await useGameStore.getState().advanceWeek();
 
-    cacheEqualsStore('game-1');
-    const cached = queryClient.getQueryData(gameStateQueryKey('game-1')) as any;
+    const cached = readRecord('game-1');
     expect(cached.currentWeek).toBe(6);
-    expect(cached.money).toBe(12345); // refetch-wins, mirrored to cache
+    expect(cached.money).toBe(12345); // refetch-wins, committed to cache
     expect(cached.usedFocusSlots).toBe(0);
+    expect(pointerId()).toBe('game-1');
   });
 });

--- a/tests/client/gameStore-email-invalidation.characterization.test.ts
+++ b/tests/client/gameStore-email-invalidation.characterization.test.ts
@@ -16,21 +16,30 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock the network + cache layer BEFORE the store import (vitest hoists these).
-// Phase 3 PR-6: the store seeds songs/releases/releaseSongs into the query cache
-// via setQueryData, so the mocked queryClient must expose it (a no-op is fine
-// here — these tests only assert email invalidation).
+// Phase 3 PR-6: the gameState spine record is now cache-owned — the store's
+// actions read it via `readGameState` (queryClient.getQueryData). So the mocked
+// queryClient must back setQueryData/getQueryData with a real in-memory cache,
+// and `advanceWeek`'s early guard needs the record seeded (see the seed helper).
+const queryCache = new Map<string, unknown>();
 vi.mock('@/lib/queryClient', () => ({
   apiRequest: vi.fn(),
   queryClient: {
     invalidateQueries: vi.fn().mockResolvedValue(undefined),
-    setQueryData: vi.fn(),
-    getQueryData: vi.fn(),
+    setQueryData: vi.fn((key: unknown, value: unknown) => {
+      queryCache.set(JSON.stringify(key), value);
+      return value;
+    }),
+    getQueryData: vi.fn((key: unknown) => queryCache.get(JSON.stringify(key))),
+    removeQueries: vi.fn(({ queryKey }: { queryKey: unknown }) => {
+      queryCache.delete(JSON.stringify(queryKey));
+    }),
   },
 }));
 vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
 
 import { EMAIL_LIST_SCOPE, EMAIL_UNREAD_SCOPE } from '@/hooks/useEmails';
 import { apiRequest, queryClient } from '@/lib/queryClient';
+import { gameStateQueryKey } from '@/hooks/useGameState';
 import { useGameStore } from '@/store/gameStore';
 import {
   jsonResponse,
@@ -42,9 +51,19 @@ const mockedApiRequest = apiRequest as unknown as ReturnType<typeof vi.fn>;
 const mockedInvalidateQueries = queryClient.invalidateQueries as unknown as ReturnType<typeof vi.fn>;
 const resetGameStore = () => resetGameStoreImpl(useGameStore);
 
+/**
+ * Phase 3.5 PR-6: seed BOTH the Zustand session pointer (`{ id }`) and the
+ * cache-owned spine record, so an action's `readGameState` guard passes.
+ */
+function seedGameState(gs: any) {
+  useGameStore.setState({ gameState: { id: gs.id } as any });
+  queryClient.setQueryData(gameStateQueryKey(gs.id), gs);
+}
+
 beforeEach(() => {
   mockedApiRequest.mockReset();
   mockedInvalidateQueries.mockClear();
+  queryCache.clear();
   resetGameStore();
 });
 
@@ -134,8 +153,8 @@ describe('loadGameFromSave email invalidation (C49)', () => {
 describe('advanceWeek email invalidation', () => {
   it('invalidates email queries via a predicate scoped to the advanced gameId', async () => {
     const gameId = 'game-adv-1';
+    seedGameState(baseGameState({ id: gameId, currentWeek: 5, arOfficeSlotUsed: false }));
     useGameStore.setState({
-      gameState: baseGameState({ id: gameId, currentWeek: 5, arOfficeSlotUsed: false }),
       selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
     });
 

--- a/tests/client/gameStore-spine.characterization.test.ts
+++ b/tests/client/gameStore-spine.characterization.test.ts
@@ -33,15 +33,19 @@ vi.mock('@/lib/queryClient', () => ({
       return value;
     }),
     getQueryData: vi.fn((key: unknown) => queryCache.get(JSON.stringify(key))),
+    removeQueries: vi.fn(({ queryKey }: { queryKey: unknown }) => {
+      queryCache.delete(JSON.stringify(queryKey));
+    }),
   },
 }));
 vi.mock('@/hooks/use-toast', () => ({ toast: vi.fn() }));
 
-import { apiRequest } from '@/lib/queryClient';
+import { apiRequest, queryClient } from '@/lib/queryClient';
 import { songsQueryKey } from '@/hooks/useSongs';
 import { releasesQueryKey, releaseSongsQueryKey } from '@/hooks/useReleases';
 import { projectsQueryKey } from '@/hooks/useProjects';
 import { artistsQueryKey } from '@/hooks/useArtists';
+import { gameStateQueryKey } from '@/hooks/useGameState';
 import { useGameStore } from '@/store/gameStore';
 import {
   routeApiRequest as routeApiRequestImpl,
@@ -54,6 +58,21 @@ const mockedApiRequest = apiRequest as unknown as ReturnType<typeof vi.fn>;
 const routeApiRequest = (routes: Array<{ match: (url: string) => boolean; body: unknown }>) =>
   routeApiRequestImpl(mockedApiRequest, routes);
 const resetGameStore = () => resetGameStoreImpl(useGameStore);
+
+/**
+ * Phase 3.5 PR-6: the store's actions read the spine record from its SINGLE
+ * owner (the query cache) via `readGameState`, and Zustand keeps only a `{ id }`
+ * session pointer. So a test seed must write BOTH the pointer and the cache
+ * record, and post-action pins read the record back from the cache.
+ */
+function seedGameState(gs: any) {
+  useGameStore.setState({ gameState: { id: gs.id } as any });
+  queryClient.setQueryData(gameStateQueryKey(gs.id), gs);
+}
+/** The committed spine record for a game (its single owner is the cache). */
+function record(gameId = 'game-1'): any {
+  return queryClient.getQueryData(gameStateQueryKey(gameId));
+}
 
 /** Grab every PATCH /api/game/:id payload the store fired at syncSlotsPatch. */
 function slotPatchCalls() {
@@ -76,29 +95,25 @@ beforeEach(() => {
 
 describe('selectAction focus-slot math', () => {
   it('increments usedFocusSlots synchronously and is visible on the SAME tick', () => {
-    useGameStore.setState({
-      gameState: baseGameState({ focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({ focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: [] });
 
     // Do NOT await: the local set() is synchronous; only syncSlotsPatch is async.
     void useGameStore.getState().selectAction('action-A');
 
     const state = useGameStore.getState();
     expect(state.selectedActions).toEqual(['action-A']);
-    expect(state.gameState!.usedFocusSlots).toBe(1);
+    expect(record().usedFocusSlots).toBe(1);
   });
 
   it('fires syncSlotsPatch with the new usedFocusSlots + A&R fields', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 3,
-        usedFocusSlots: 0,
-        arOfficeSlotUsed: false,
-        arOfficeSourcingType: null,
-      }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 3,
+      usedFocusSlots: 0,
+      arOfficeSlotUsed: false,
+      arOfficeSourcingType: null,
+    }));
+    useGameStore.setState({ selectedActions: [] });
 
     await useGameStore.getState().selectAction('action-A');
 
@@ -110,21 +125,18 @@ describe('selectAction focus-slot math', () => {
   });
 
   it('adds the A&R-consumed slot on top of selected actions in usedFocusSlots', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 3,
-        usedFocusSlots: 1,
-        arOfficeSlotUsed: true,
-        arOfficeSourcingType: 'active',
-      }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 3,
+      usedFocusSlots: 1,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'active',
+    }));
+    useGameStore.setState({ selectedActions: [] });
 
     await useGameStore.getState().selectAction('action-A');
 
-    const state = useGameStore.getState();
     // 1 selected action + 1 A&R slot = 2.
-    expect(state.gameState!.usedFocusSlots).toBe(2);
+    expect(record().usedFocusSlots).toBe(2);
     expect(slotPatchCalls()).toContainEqual({
       usedFocusSlots: 2,
       arOfficeSlotUsed: true,
@@ -134,36 +146,32 @@ describe('selectAction focus-slot math', () => {
 
   it('does NOT select past the available slots (focusSlots minus A&R slot)', async () => {
     // focusSlots 2, A&R slot used → only 1 action slot available.
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 2,
-        usedFocusSlots: 1,
-        arOfficeSlotUsed: true,
-        arOfficeSourcingType: 'active',
-      }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 2,
+      usedFocusSlots: 1,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'active',
+    }));
+    useGameStore.setState({ selectedActions: [] });
 
     await useGameStore.getState().selectAction('action-A'); // fills the last slot
     await useGameStore.getState().selectAction('action-B'); // should be rejected
 
     const state = useGameStore.getState();
     expect(state.selectedActions).toEqual(['action-A']);
-    expect(state.gameState!.usedFocusSlots).toBe(2);
+    expect(record().usedFocusSlots).toBe(2);
   });
 
   it('ignores a duplicate action id (no double-count)', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({ focusSlots: 3, usedFocusSlots: 0, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: [] });
 
     await useGameStore.getState().selectAction('action-A');
     await useGameStore.getState().selectAction('action-A');
 
     const state = useGameStore.getState();
     expect(state.selectedActions).toEqual(['action-A']);
-    expect(state.gameState!.usedFocusSlots).toBe(1);
+    expect(record().usedFocusSlots).toBe(1);
   });
 
   it('is a no-op when gameState is null', async () => {
@@ -175,21 +183,19 @@ describe('selectAction focus-slot math', () => {
 
 describe('removeAction focus-slot math', () => {
   it('decrements usedFocusSlots synchronously and syncs the new count', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 3,
-        usedFocusSlots: 2,
-        arOfficeSlotUsed: false,
-        arOfficeSourcingType: null,
-      }),
-      selectedActions: ['action-A', 'action-B'],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 3,
+      usedFocusSlots: 2,
+      arOfficeSlotUsed: false,
+      arOfficeSourcingType: null,
+    }));
+    useGameStore.setState({ selectedActions: ['action-A', 'action-B'] });
 
     await useGameStore.getState().removeAction('action-A');
 
     const state = useGameStore.getState();
     expect(state.selectedActions).toEqual(['action-B']);
-    expect(state.gameState!.usedFocusSlots).toBe(1);
+    expect(record().usedFocusSlots).toBe(1);
     expect(slotPatchCalls()).toContainEqual({
       usedFocusSlots: 1,
       arOfficeSlotUsed: false,
@@ -198,27 +204,23 @@ describe('removeAction focus-slot math', () => {
   });
 
   it('keeps the A&R slot counted when removing an action', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 3,
-        usedFocusSlots: 2,
-        arOfficeSlotUsed: true,
-        arOfficeSourcingType: 'active',
-      }),
-      selectedActions: ['action-A'],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 3,
+      usedFocusSlots: 2,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'active',
+    }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
 
     await useGameStore.getState().removeAction('action-A');
 
     // 0 actions + 1 A&R slot = 1.
-    expect(useGameStore.getState().gameState!.usedFocusSlots).toBe(1);
+    expect(record().usedFocusSlots).toBe(1);
   });
 
   it('is a no-op for an action id that is not selected', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ usedFocusSlots: 1 }),
-      selectedActions: ['action-A'],
-    });
+    seedGameState(baseGameState({ usedFocusSlots: 1 }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
 
     await useGameStore.getState().removeAction('not-selected');
 
@@ -229,36 +231,30 @@ describe('removeAction focus-slot math', () => {
 
 describe('clearActions focus-slot math', () => {
   it('clears selectedActions and resets usedFocusSlots to the A&R slot count (no A&R)', () => {
-    useGameStore.setState({
-      gameState: baseGameState({ usedFocusSlots: 2, arOfficeSlotUsed: false }),
-      selectedActions: ['action-A', 'action-B'],
-    });
+    seedGameState(baseGameState({ usedFocusSlots: 2, arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: ['action-A', 'action-B'] });
 
     useGameStore.getState().clearActions();
 
     const state = useGameStore.getState();
     expect(state.selectedActions).toEqual([]);
-    expect(state.gameState!.usedFocusSlots).toBe(0);
+    expect(record().usedFocusSlots).toBe(0);
   });
 
   it('preserves the A&R-consumed slot in usedFocusSlots after clearing', () => {
-    useGameStore.setState({
-      gameState: baseGameState({ usedFocusSlots: 3, arOfficeSlotUsed: true }),
-      selectedActions: ['action-A', 'action-B'],
-    });
+    seedGameState(baseGameState({ usedFocusSlots: 3, arOfficeSlotUsed: true }));
+    useGameStore.setState({ selectedActions: ['action-A', 'action-B'] });
 
     useGameStore.getState().clearActions();
 
     const state = useGameStore.getState();
     expect(state.selectedActions).toEqual([]);
-    expect(state.gameState!.usedFocusSlots).toBe(1); // A&R slot only
+    expect(record().usedFocusSlots).toBe(1); // A&R slot only
   });
 
   it('does NOT fire a syncSlotsPatch (purely local reset)', () => {
-    useGameStore.setState({
-      gameState: baseGameState({ usedFocusSlots: 2 }),
-      selectedActions: ['action-A'],
-    });
+    seedGameState(baseGameState({ usedFocusSlots: 2 }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
 
     useGameStore.getState().clearActions();
 
@@ -268,22 +264,19 @@ describe('clearActions focus-slot math', () => {
 
 describe('consumeAROfficeSlot focus-slot math', () => {
   it('marks the A&R slot used and sets usedFocusSlots to selectedActions.length + 1', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 3,
-        usedFocusSlots: 1,
-        arOfficeSlotUsed: false,
-        arOfficeSourcingType: null,
-      }),
-      selectedActions: ['action-A'],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 3,
+      usedFocusSlots: 1,
+      arOfficeSlotUsed: false,
+      arOfficeSourcingType: null,
+    }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
 
     await useGameStore.getState().consumeAROfficeSlot('active');
 
-    const state = useGameStore.getState();
-    expect(state.gameState!.arOfficeSlotUsed).toBe(true);
-    expect(state.gameState!.arOfficeSourcingType).toBe('active');
-    expect(state.gameState!.usedFocusSlots).toBe(2); // 1 action + 1 A&R
+    expect(record().arOfficeSlotUsed).toBe(true);
+    expect(record().arOfficeSourcingType).toBe('active');
+    expect(record().usedFocusSlots).toBe(2); // 1 action + 1 A&R
     expect(slotPatchCalls()).toContainEqual({
       usedFocusSlots: 2,
       arOfficeSlotUsed: true,
@@ -292,59 +285,52 @@ describe('consumeAROfficeSlot focus-slot math', () => {
   });
 
   it('is a no-op when the A&R slot is already used', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 3,
-        usedFocusSlots: 1,
-        arOfficeSlotUsed: true,
-        arOfficeSourcingType: 'passive',
-      }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 3,
+      usedFocusSlots: 1,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'passive',
+    }));
+    useGameStore.setState({ selectedActions: [] });
 
     await useGameStore.getState().consumeAROfficeSlot('active');
 
     // sourcingType unchanged, no PATCH fired.
-    expect(useGameStore.getState().gameState!.arOfficeSourcingType).toBe('passive');
+    expect(record().arOfficeSourcingType).toBe('passive');
     expect(slotPatchCalls()).toHaveLength(0);
   });
 
   it('is a no-op when all focus slots are already consumed', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 2,
-        usedFocusSlots: 2,
-        arOfficeSlotUsed: false,
-        arOfficeSourcingType: null,
-      }),
-      selectedActions: ['action-A', 'action-B'],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 2,
+      usedFocusSlots: 2,
+      arOfficeSlotUsed: false,
+      arOfficeSourcingType: null,
+    }));
+    useGameStore.setState({ selectedActions: ['action-A', 'action-B'] });
 
     await useGameStore.getState().consumeAROfficeSlot('active');
 
-    expect(useGameStore.getState().gameState!.arOfficeSlotUsed).toBe(false);
+    expect(record().arOfficeSlotUsed).toBe(false);
     expect(slotPatchCalls()).toHaveLength(0);
   });
 });
 
 describe('releaseAROfficeSlot focus-slot math', () => {
   it('clears the A&R slot and sets usedFocusSlots to selectedActions.length', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        focusSlots: 3,
-        usedFocusSlots: 2,
-        arOfficeSlotUsed: true,
-        arOfficeSourcingType: 'active',
-      }),
-      selectedActions: ['action-A'],
-    });
+    seedGameState(baseGameState({
+      focusSlots: 3,
+      usedFocusSlots: 2,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'active',
+    }));
+    useGameStore.setState({ selectedActions: ['action-A'] });
 
     await useGameStore.getState().releaseAROfficeSlot();
 
-    const state = useGameStore.getState();
-    expect(state.gameState!.arOfficeSlotUsed).toBe(false);
-    expect(state.gameState!.arOfficeSourcingType).toBeNull();
-    expect(state.gameState!.usedFocusSlots).toBe(1); // just the 1 action
+    expect(record().arOfficeSlotUsed).toBe(false);
+    expect(record().arOfficeSourcingType).toBeNull();
+    expect(record().usedFocusSlots).toBe(1); // just the 1 action
     expect(slotPatchCalls()).toContainEqual({
       usedFocusSlots: 1,
       arOfficeSlotUsed: false,
@@ -353,10 +339,8 @@ describe('releaseAROfficeSlot focus-slot math', () => {
   });
 
   it('is a no-op when no A&R slot is in use', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ arOfficeSlotUsed: false }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({ arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: [] });
 
     await useGameStore.getState().releaseAROfficeSlot();
 
@@ -388,8 +372,8 @@ describe('advanceWeek gameState merge precedence', () => {
   }
 
   it('lets the refetch (serverGameState) WIN over the advance-week response on conflicting fields', async () => {
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }));
     useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: false }),
       selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
     });
 
@@ -403,15 +387,15 @@ describe('advanceWeek gameState merge precedence', () => {
 
     await useGameStore.getState().advanceWeek();
 
-    const gs = useGameStore.getState().gameState as any;
+    const gs = record('game-1');
     expect(gs.money).toBe(12345); // refetch wins over the advance-week 9000
     // A field present ONLY in the advance-week response survives (not overwritten).
     expect(gs.reputation).toBe(50);
   });
 
   it('hardcodes usedFocusSlots to (arOfficeSlotUsed ? 1 : 0) — 0 when no A&R slot', async () => {
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 5 }));
     useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 5 }),
       selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
     });
     routeAdvance(
@@ -422,14 +406,12 @@ describe('advanceWeek gameState merge precedence', () => {
 
     await useGameStore.getState().advanceWeek();
 
-    expect((useGameStore.getState().gameState as any).usedFocusSlots).toBe(0);
+    expect(record('game-1').usedFocusSlots).toBe(0);
   });
 
   it('resets usedFocusSlots to 1 when the advance response reports an A&R slot in use', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: true }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 5, arOfficeSlotUsed: true }));
+    useGameStore.setState({ selectedActions: [] });
     routeAdvance(
       { id: 'game-1', currentWeek: 6, arOfficeSlotUsed: true, arOfficeSourcingType: 'active' },
       { id: 'game-1', currentWeek: 6 }, // refetch omits the A&R fields
@@ -438,7 +420,7 @@ describe('advanceWeek gameState merge precedence', () => {
 
     await useGameStore.getState().advanceWeek();
 
-    const gs = useGameStore.getState().gameState as any;
+    const gs = record('game-1');
     expect(gs.usedFocusSlots).toBe(1);
     // arOfficeSlotUsed/SourcingType are coalesced result ?? server.
     expect(gs.arOfficeSlotUsed).toBe(true);
@@ -446,8 +428,8 @@ describe('advanceWeek gameState merge precedence', () => {
   });
 
   it('sources musicLabel from the reload (gameData.musicLabel), embedded into gameState', async () => {
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 5 }));
     useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 5 }),
       selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
     });
     routeAdvance(
@@ -458,26 +440,24 @@ describe('advanceWeek gameState merge precedence', () => {
 
     await useGameStore.getState().advanceWeek();
 
-    expect((useGameStore.getState().gameState as any).musicLabel).toEqual({ name: 'Reloaded Label' });
+    expect(record('game-1').musicLabel).toEqual({ name: 'Reloaded Label' });
   });
 
   it('falls back to null musicLabel when neither reload nor advance response carries one', async () => {
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 5 }));
     useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 5 }),
       selectedActions: ['{"roleId":"ceo","actionId":"a1","choiceId":"c1"}'],
     });
     routeAdvance({ id: 'game-1', currentWeek: 6 }, { id: 'game-1', currentWeek: 6 }, null);
 
     await useGameStore.getState().advanceWeek();
 
-    expect((useGameStore.getState().gameState as any).musicLabel).toBeNull();
+    expect(record('game-1').musicLabel).toBeNull();
   });
 
   it('is a no-op (never sets isAdvancingWeek) when there are no actions and no A&R slot', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', arOfficeSlotUsed: false }),
-      selectedActions: [],
-    });
+    seedGameState(baseGameState({ id: 'game-1', arOfficeSlotUsed: false }));
+    useGameStore.setState({ selectedActions: [] });
 
     await useGameStore.getState().advanceWeek();
 
@@ -494,17 +474,15 @@ describe('advanceWeek gameState merge precedence', () => {
 
 describe('adoptServerBalances two-field merge (via planRelease)', () => {
   it('overwrites ONLY money + creativeCapital, preserving A&R fields and musicLabel', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        id: 'game-1',
-        money: 100000,
-        creativeCapital: 4,
-        arOfficeSlotUsed: true,
-        arOfficeSourcingType: 'active',
-        usedFocusSlots: 2,
-        musicLabel: { name: 'Preserve Me' },
-      }),
-    });
+    seedGameState(baseGameState({
+      id: 'game-1',
+      money: 100000,
+      creativeCapital: 4,
+      arOfficeSlotUsed: true,
+      arOfficeSourcingType: 'active',
+      usedFocusSlots: 2,
+      musicLabel: { name: 'Preserve Me' },
+    }));
     routeApiRequest([
       // GET /api/game/:id refetch carries a DIFFERENT musicLabel + A&R fields, none
       // of which must leak into the store (only money + creativeCapital merge).
@@ -526,7 +504,7 @@ describe('adoptServerBalances two-field merge (via planRelease)', () => {
 
     await useGameStore.getState().planRelease({ metadata: { totalInvestment: 1000 } });
 
-    const gs = useGameStore.getState().gameState as any;
+    const gs = record('game-1');
     expect(gs.money).toBe(55000); // adopted
     expect(gs.creativeCapital).toBe(1); // adopted
     // Everything else is the PRE-EXISTING store value, NOT the server refetch's.
@@ -544,22 +522,20 @@ describe('adoptServerBalances two-field merge (via planRelease)', () => {
 
 describe('cancelProject balance adoption preserves the rest of the spine', () => {
   it('sets money to result.newBalance while leaving other spine fields intact', async () => {
-    useGameStore.setState({
-      gameState: baseGameState({
-        id: 'game-1',
-        money: 20000,
-        creativeCapital: 3,
-        reputation: 12,
-        musicLabel: { name: 'Keep' },
-      }),
-    });
+    seedGameState(baseGameState({
+      id: 'game-1',
+      money: 20000,
+      creativeCapital: 3,
+      reputation: 12,
+      musicLabel: { name: 'Keep' },
+    }));
     routeApiRequest([
       { match: (u) => u.includes('/cancel'), body: { newBalance: 27500, refundAmount: 7500 } },
     ]);
 
     await useGameStore.getState().cancelProject('proj-1', { refundAmount: 7500 });
 
-    const gs = useGameStore.getState().gameState as any;
+    const gs = record('game-1');
     expect(gs.money).toBe(27500);
     // creativeCapital is NOT touched by cancelProject (only money).
     expect(gs.creativeCapital).toBe(3);
@@ -601,7 +577,7 @@ describe('loadGame gameStateWithLabel assembly', () => {
 
     await useGameStore.getState().loadGame('game-1');
 
-    const gs = useGameStore.getState().gameState as any;
+    const gs = record('game-1');
     expect(gs.musicLabel).toEqual({ name: 'Loaded Label' });
     expect(gs.usedFocusSlots).toBe(0);
     expect(gs.arOfficeSlotUsed).toBe(false);
@@ -616,7 +592,7 @@ describe('loadGame gameStateWithLabel assembly', () => {
 
     await useGameStore.getState().loadGame('game-1');
 
-    const gs = useGameStore.getState().gameState as any;
+    const gs = record('game-1');
     expect(gs.usedFocusSlots).toBe(1);
     expect(gs.arOfficeSlotUsed).toBe(true);
     expect(gs.arOfficeSourcingType).toBe('active');
@@ -627,7 +603,7 @@ describe('loadGame gameStateWithLabel assembly', () => {
 
     await useGameStore.getState().loadGame('game-1');
 
-    expect((useGameStore.getState().gameState as any).musicLabel).toBeNull();
+    expect(record('game-1').musicLabel).toBeNull();
   });
 });
 
@@ -652,7 +628,7 @@ describe('createNewGame orphan-cleanup', () => {
   }
 
   it('issues GET /api/saves then DELETE /api/game/:id for an unsaved current game', async () => {
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 4 }));
     routeCreate([]); // no saves belong to game-1 → orphaned
 
     await useGameStore.getState().createNewGame('Balanced');
@@ -663,7 +639,7 @@ describe('createNewGame orphan-cleanup', () => {
   });
 
   it('does NOT delete the current game when it has saves', async () => {
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 4 }));
     routeCreate([{ gameId: 'game-1', name: 'a save' }]);
 
     await useGameStore.getState().createNewGame('Balanced');
@@ -675,7 +651,7 @@ describe('createNewGame orphan-cleanup', () => {
   });
 
   it('filters saves by gameId — saves for OTHER games do not protect the current one', async () => {
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 4 }));
     routeCreate([{ gameId: 'some-other-game', name: 'unrelated save' }]);
 
     await useGameStore.getState().createNewGame('Balanced');
@@ -695,7 +671,7 @@ describe('createNewGame orphan-cleanup', () => {
   });
 
   it('still creates the new game when the DELETE cleanup fails (non-fatal)', async () => {
-    useGameStore.setState({ gameState: baseGameState({ id: 'game-1', currentWeek: 4 }) });
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 4 }));
     mockedApiRequest.mockImplementation(async (method: string, url: string) => {
       if (method === 'GET' && url.endsWith('/api/saves')) return jsonResponse([]);
       if (method === 'DELETE' && /\/api\/game\/[^/]+$/.test(url)) throw new Error('delete failed');
@@ -709,7 +685,7 @@ describe('createNewGame orphan-cleanup', () => {
     const result = await useGameStore.getState().createNewGame('Balanced');
 
     expect(result.id).toBe('game-2');
-    expect((useGameStore.getState().gameState as any).id).toBe('game-2');
+    expect(record('game-2').id).toBe('game-2');
   });
 });
 
@@ -739,13 +715,13 @@ describe('saveGame snapshot-assembly input', () => {
   }
 
   it('feeds gameState verbatim into buildGameSnapshot — musicLabel ends up a SIBLING, not nested', async () => {
+    seedGameState(baseGameState({
+      id: 'game-1',
+      currentWeek: 7,
+      money: 42000,
+      musicLabel: { name: 'Snapshot Label' },
+    }));
     useGameStore.setState({
-      gameState: baseGameState({
-        id: 'game-1',
-        currentWeek: 7,
-        money: 42000,
-        musicLabel: { name: 'Snapshot Label' },
-      }),
       roles: [{ id: 'role1' } as any],
       weeklyActions: [{ id: 'wa1' } as any],
       weeklyOutcome: { week: 7 },
@@ -769,8 +745,8 @@ describe('saveGame snapshot-assembly input', () => {
   });
 
   it('sources songs/releases/projects/artists from the query cache, not the store', async () => {
+    seedGameState(baseGameState({ id: 'game-1', currentWeek: 2, musicLabel: null }));
     useGameStore.setState({
-      gameState: baseGameState({ id: 'game-1', currentWeek: 2, musicLabel: null }),
       roles: [],
       weeklyActions: [],
       weeklyOutcome: null,

--- a/tests/client/useGameState-facade-flip.test.tsx
+++ b/tests/client/useGameState-facade-flip.test.tsx
@@ -126,9 +126,10 @@ describe('useGameState PR-5 flip: SAME-TICK slot math visibility', () => {
     // Asserted synchronously — NO waitFor/findBy. setQueryData notified the
     // useQuery subscriber synchronously, so the new value is on this render.
     expect(screen.getByTestId('slots').textContent).toBe('1');
-    // Cache and store agree (dual-write still active in PR-5).
+    // Phase 3.5 PR-6: the cache is the SINGLE owner of the record; Zustand keeps
+    // only the `{ id }` session pointer.
     expect((queryClient.getQueryData(gameStateQueryKey('game-1')) as any).usedFocusSlots).toBe(1);
-    expect(useGameStore.getState().gameState!.usedFocusSlots).toBe(1);
+    expect(useGameStore.getState().gameState!.id).toBe('game-1');
   });
 
   it('sees removeAction\'s decrement on the next render', () => {


### PR DESCRIPTION
## Phase 3.5 PR-6 — retire the Zustand `gameState` copy

Makes the TanStack Query cache the **single owner** of the `gameState` spine record. Closes the PR-3→4→5→6 arc: readers migrated (PR-3), dual-write funnel (PR-4), façade flip to the cache (PR-5), and now the Zustand copy is retired.

### What Zustand still holds vs. what the cache owns
- **Cache (single owner)** — the full spine record at `gameStateQueryKey(id)` = `['gameState:record', id]`: week, money, reputation, creativeCapital, focusSlots, access tiers, flags, A&R fields, embedded `musicLabel`. Client-committed record (staleTime/gcTime Infinity, no background refetch), written only by `commitGameState`.
- **Zustand** — a minimal `{ id }` **session pointer** at `gameState` (the bootstrap handle for `useGameId`, the `useGameState` gameId lookup, and persist), plus the unchanged session/UI state (`selectedActions`, `isAdvancingWeek`, `weeklyOutcome`, `campaignResults`) and the snapshot-input arrays (`roles`, `emails`, `executives`, `moodEvents`, `weeklyActions`).

### Store changes
- `commitGameState` no longer `set({ gameState: <record> })`; it writes the `{ id }` pointer to Zustand and the full record to the cache (game-switch key removal unchanged).
- New `readGameState(get)` reads the record from the cache via the pointer id, preserving the old `get().gameState` null semantics. Every action guard/read switches to it: `selectAction`/`removeAction`/`clearActions`/`advanceWeek`, `signArtist`/`updateArtist`/`createProject`/`updateProject`/`cancelProject`/`planRelease`, the A&R ops, orphan-cleanup in `createNewGame`, `saveGame`, `adoptServerBalances`, and the advanceWeek `refetchDiscoveredArtistsCache` call.
- `SaveGameModal.handleLoad` reads the active game id from the session pointer; `handleExport` already reads the spine via the cache-backed `useGameState()` façade.
- Removed the unused `availableSlots` local (discovered debt #2).

### Snapshot-shape proof (frozen)
- `SNAPSHOT_VERSION` stays **2** (`shared/schema.ts` unmodified); `buildGameSnapshot.ts` unmodified.
- `tests/client/buildGameSnapshot.shape.test.ts` green; the `saveGame` snapshot-assembly pin still asserts `musicLabel` is a **sibling** of the inner `gameState`, not nested. `saveGame` now sources the record from the cache — the same way it already sources the five collections.

### Partialize handling (on-disk shape frozen)
`partialize` is **unchanged**: still `state.gameState ? { id: state.gameState.id } : null`. The pointer already carries `{ id }`, so the localStorage `music-label-manager-game` shape is byte-identical and a pre-migration browser rehydrates unchanged. No persist-version bump, no migrate fn (per orchestrator ruling).

### Grep gate
Zero reads of a Zustand-owned `gameState` **record** remain in `client/src` — the only `.gameState` reads left are the sanctioned session-pointer (`?.id`), `readGameState`'s own pointer lookup, `partialize`, and server/snapshot **data-shape** reads (`data.gameState`, `snapshot.gameState`, `save.gameState`).

### Changed test assertions (14 sites re-pointed; every one justified)
The Zustand-side pins become cache-side pins exactly where the plan sanctions ("the Zustand-side pin becomes a cache-side pin"). Each seed now also writes the cache (via a `seedGameState` helper) so the action's `readGameState` guard passes, and each post-action spine read moves from `getState().gameState!.X` to a `record()` cache read:
- **`gameStore-spine.characterization.test.ts`** — 21 seeds → `seedGameState`; ~30 spine reads → `record()`. Same numeric expectations (money/slots/A&R/week/musicLabel).
- **`gameStore-actions.characterization.test.ts`** — added `removeQueries` to the mock + `gameStateQueryKey` import + helpers; 8 seeds → `seedGameState`; ~11 spine reads → `record()`.
- **`gameStore-dual-write.characterization.test.ts`** — the former "cache deep-equals the Zustand record" invariant no longer applies (Zustand holds no record); assertions now verify the cache carries the committed record and the pointer tracks the current id.
- **`gameStore-email-invalidation.characterization.test.ts`** — backed the mocked queryClient with a real cache Map + seeded the record so `advanceWeek`'s guard passes (else it early-returns and no email invalidation fires).
- **`useGameState-facade-flip.test.tsx`** — one line: assert the pointer id instead of `getState().gameState!.usedFocusSlots`.

`docs`/`client/CLAUDE.md` updates are deferred to PR-7 (the plan's PR-6 row does not include them).

### Validation
- `npm run check` — clean.
- `npx vitest run tests/client` — **14 files / 129 tests** green.
- `npx vitest run client/src` — **10 files / 97 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
