### PR TITLE
feat(client): Phase 4 PR-4 - week-advance anticipation beat

### DIFF
--- a/client/src/components/GameHeader.tsx
+++ b/client/src/components/GameHeader.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useGameStore } from '@/store/gameStore';
 import { useGameState } from '@/hooks/useGameState';
 import { useGameContext } from '@/contexts/GameContext';
@@ -12,6 +12,8 @@ import { toast } from '@/hooks/use-toast';
 import logger from '@/lib/logger';
 import { getWeekDateRange } from '@shared/utils/seasonalCalculations';
 import { Coins, ChevronsRight, Zap } from 'lucide-react';
+import { useReducedMotion } from 'motion/react';
+import { WeekTransition } from '@/components/WeekTransition';
 
 /**
  * GameHeader — slim right-aligned v2 page header (Design System v2 §7).
@@ -27,6 +29,7 @@ export function GameHeader() {
     useGameStore();
   const { gameId } = useGameContext();
   const [isAutoSelecting, setIsAutoSelecting] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
 
   if (!gameState) {
     return null;
@@ -122,7 +125,12 @@ export function GameHeader() {
     }
   };
 
+  // Charging treatment while the advance is in flight (Phase 4 PR-4).
+  // Reduced motion keeps the plain "Processing…" text with no shimmer/pulse.
+  const isCharging = isAdvancingWeek && !prefersReducedMotion;
+
   return (
+    <>
     <header
       aria-label="Label vitals"
       className="flex flex-wrap items-center justify-end gap-4"
@@ -157,12 +165,33 @@ export function GameHeader() {
           type="button"
           onClick={handleAdvanceWeek}
           disabled={selectedActions.length === 0 || isAdvancingWeek}
-          className="relative flex w-full items-center justify-center gap-2 overflow-hidden rounded-button bg-gradient-to-br from-action-pink to-action-purple px-4 py-1.5 text-[13px] font-semibold text-white shadow-action transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          className={`relative flex w-full items-center justify-center gap-2 overflow-hidden rounded-button bg-gradient-to-br from-action-pink to-action-purple px-4 py-1.5 text-[13px] font-semibold text-white shadow-action transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50${
+            isCharging ? ' animate-pulse [animation-duration:1.6s]' : ''
+          }`}
+          // Charging: lift the disabled dim + add a soft glow so the pulse reads
+          // as energy, not a dead button. Inline style so it deterministically
+          // wins over the disabled:opacity-50 utility.
+          style={
+            isCharging
+              ? {
+                  opacity: 0.95,
+                  boxShadow: '0 0 18px rgba(255, 77, 141, 0.45)',
+                }
+              : undefined
+          }
         >
           <span
             aria-hidden="true"
             className="pointer-events-none absolute left-3.5 right-3.5 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"
           />
+          {/* charging shimmer sweep while the week advance is in flight */}
+          {isCharging && (
+            <span
+              aria-hidden="true"
+              data-testid="advance-week-charging"
+              className="animate-ds-shimmer pointer-events-none absolute inset-0 bg-gradient-to-r from-transparent via-white/25 to-transparent bg-[length:200%_100%] [animation-duration:1.2s]"
+            />
+          )}
           {isAdvancingWeek ? 'Processing…' : 'Advance Week'}
           <ChevronsRight className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
@@ -192,5 +221,9 @@ export function GameHeader() {
         </div>
       </div>
     </header>
+
+    {/* Week-transition interstitial — purely visual, never gates data flow */}
+    <WeekTransition isAdvancing={isAdvancingWeek} />
+    </>
   );
 }

--- a/client/src/components/WeekTransition.tsx
+++ b/client/src/components/WeekTransition.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useReducedMotion } from 'motion/react';
+import { HoloDisc } from '@/components/ui/holo-disc';
+import { useGameState } from '@/hooks/useGameState';
+
+/** Minimum time the interstitial stays on screen so fast advances don't flash. */
+export const WEEK_TRANSITION_MIN_MS = 700;
+/** Safety net: force-dismiss if we are somehow still visible this long after the advance ended. */
+export const WEEK_TRANSITION_SAFETY_MS = 10_000;
+
+export interface WeekTransitionProps {
+  /** Whether the week advance is currently in flight (store's `isAdvancingWeek`). */
+  isAdvancing: boolean;
+}
+
+/**
+ * WeekTransition — full-screen anticipation interstitial for the week advance
+ * (Phase 4 PR-4, game-feel plan §3 row 4).
+ *
+ * Purely visual: it never gates, delays, or wraps any data flow. It appears
+ * when `isAdvancing` flips true, holds for a minimum of
+ * `WEEK_TRANSITION_MIN_MS` so fast server responses don't flash, and dismisses
+ * as soon as BOTH the advance has completed AND the minimum has elapsed — it
+ * never outlasts the advance by more than the minimum. The WeekSummary modal
+ * may open beneath it; the overlay simply sits on top until its timer ends.
+ *
+ * `pointer-events: none` throughout — it can never trap focus or block the
+ * app — plus a 10s auto-dismiss safety net in case a timer ever fails.
+ *
+ * Reduced motion: renders nothing at all.
+ */
+export function WeekTransition({ isAdvancing }: WeekTransitionProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const currentWeek = useGameState((gs) => gs?.currentWeek ?? 1);
+
+  const [visible, setVisible] = useState(false);
+  const [minElapsed, setMinElapsed] = useState(false);
+  // Latch the incoming week number when the transition starts so a mid-display
+  // gameState commit doesn't flip the label.
+  const targetWeekRef = useRef(currentWeek + 1);
+  // The minimum-display timer must SURVIVE `isAdvancing` flipping back to
+  // false (a fast server response), so it lives in a ref and is only cleared
+  // on unmount / restart — not by this effect's re-run cleanup.
+  const minTimerRef = useRef<number | null>(null);
+
+  // Show + start the minimum-display clock when an advance begins.
+  useEffect(() => {
+    if (prefersReducedMotion || !isAdvancing) return;
+    targetWeekRef.current = currentWeek + 1;
+    setVisible(true);
+    setMinElapsed(false);
+    if (minTimerRef.current !== null) {
+      window.clearTimeout(minTimerRef.current);
+    }
+    minTimerRef.current = window.setTimeout(
+      () => setMinElapsed(true),
+      WEEK_TRANSITION_MIN_MS,
+    );
+    // currentWeek intentionally read-latched, not a re-trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdvancing, prefersReducedMotion]);
+
+  // Clear the minimum-display timer on unmount only.
+  useEffect(() => {
+    return () => {
+      if (minTimerRef.current !== null) {
+        window.clearTimeout(minTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Dismiss as soon as the advance is done AND the minimum has elapsed.
+  useEffect(() => {
+    if (visible && !isAdvancing && minElapsed) {
+      setVisible(false);
+    }
+  }, [visible, isAdvancing, minElapsed]);
+
+  // Safety net: never linger more than 10s past the end of the advance.
+  useEffect(() => {
+    if (!visible || isAdvancing) return;
+    const timer = window.setTimeout(
+      () => setVisible(false),
+      WEEK_TRANSITION_SAFETY_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [visible, isAdvancing]);
+
+  if (prefersReducedMotion || !visible) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      aria-hidden="true"
+      data-testid="week-transition"
+      className="pointer-events-none fixed inset-0 z-[120] flex flex-col items-center justify-center gap-6 bg-black/70 backdrop-blur-sm"
+    >
+      {/* holo-disc spinning up (fast spin = charging feel) */}
+      <HoloDisc size={104} spinSeconds={1.6} grooves />
+
+      <div className="text-center">
+        <div className="font-mono text-[11px] uppercase tracking-[0.3em] text-text-label">
+          Advancing to
+        </div>
+        <div className="text-aberration mt-1 font-mono text-3xl font-semibold uppercase tracking-[0.2em] text-white">
+          Week {targetWeekRef.current}
+        </div>
+      </div>
+
+      {/* shimmer sweep — scoped fast variant of the v2 .shimmer-bar */}
+      <div
+        className="shimmer-bar w-56"
+        style={{ animationDuration: '1.4s' }}
+      />
+    </div>,
+    document.body,
+  );
+}
+
+export default WeekTransition;

--- a/tests/client/game-header-anticipation.test.tsx
+++ b/tests/client/game-header-anticipation.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * GameHeader advance-week anticipation test (Phase 4 PR-4).
+ *
+ * Pins the charging treatment: while `isAdvancingWeek` the button shows the
+ * shimmer/pulse charged state (plain "Processing…" text under reduced
+ * motion), and the pre-existing disabled logic
+ * (`selectedActions.length === 0 || isAdvancingWeek`) is unchanged.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const mockUseReducedMotion = vi.fn(() => false);
+vi.mock('motion/react', async () => {
+  const actual =
+    await vi.importActual<typeof import('motion/react')>('motion/react');
+  return {
+    ...actual,
+    useReducedMotion: () => mockUseReducedMotion(),
+  };
+});
+
+const fakeGameState = {
+  id: 'game-1',
+  currentWeek: 5,
+  money: 250_000,
+  focusSlots: 3,
+  usedFocusSlots: 3, // no free slots -> AUTO button not rendered
+};
+vi.mock('@/hooks/useGameState', () => ({
+  useGameState: vi.fn((selector?: (gs: any) => any) =>
+    selector ? selector(fakeGameState) : fakeGameState,
+  ),
+}));
+
+const fakeStore = {
+  selectedActions: [] as string[],
+  isAdvancingWeek: false,
+  advanceWeek: vi.fn(),
+  selectAction: vi.fn(),
+};
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: vi.fn((selector?: (s: any) => any) =>
+    selector ? selector(fakeStore) : fakeStore,
+  ),
+}));
+
+vi.mock('@/contexts/GameContext', () => ({
+  useGameContext: () => ({ gameId: 'game-1' }),
+}));
+
+vi.mock('@/services/executiveService', () => ({
+  fetchExecutives: vi.fn(),
+  fetchRoleMeetings: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+import { GameHeader } from '@/components/GameHeader';
+
+const advanceButton = () =>
+  screen.getByRole('button', { name: /advance week|processing/i });
+
+describe('GameHeader advance-week anticipation', () => {
+  beforeEach(() => {
+    mockUseReducedMotion.mockReturnValue(false);
+    fakeStore.selectedActions = ['action-1'];
+    fakeStore.isAdvancingWeek = false;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the normal state when not advancing: label text, enabled, no charging layer', () => {
+    render(<GameHeader />);
+    const button = advanceButton();
+    expect(button).toHaveTextContent('Advance Week');
+    expect(button).not.toBeDisabled();
+    expect(
+      screen.queryByTestId('advance-week-charging'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+  });
+
+  it('is disabled when no actions are selected', () => {
+    fakeStore.selectedActions = [];
+    render(<GameHeader />);
+    expect(advanceButton()).toBeDisabled();
+  });
+
+  it('renders the charging state while advancing: Processing text, shimmer layer, still disabled', () => {
+    fakeStore.isAdvancingWeek = true;
+    render(<GameHeader />);
+    const button = advanceButton();
+    expect(button).toHaveTextContent('Processing…');
+    expect(button).toBeDisabled();
+    expect(screen.getByTestId('advance-week-charging')).toBeInTheDocument();
+    expect(button.className).toContain('animate-pulse');
+    // gradient + layout classes untouched (no layout shift)
+    expect(button.className).toContain('from-action-pink');
+    expect(button.className).toContain('to-action-purple');
+  });
+
+  it('mounts the WeekTransition interstitial while advancing', () => {
+    fakeStore.isAdvancingWeek = true;
+    render(<GameHeader />);
+    expect(screen.getByTestId('week-transition')).toBeInTheDocument();
+  });
+
+  it('reduced motion: plain Processing text, no shimmer, no interstitial', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    fakeStore.isAdvancingWeek = true;
+    render(<GameHeader />);
+    const button = advanceButton();
+    expect(button).toHaveTextContent('Processing…');
+    expect(button).toBeDisabled();
+    expect(
+      screen.queryByTestId('advance-week-charging'),
+    ).not.toBeInTheDocument();
+    expect(button.className).not.toContain('animate-pulse');
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+  });
+
+  it('disabled logic is unchanged: advancing wins even with actions selected', () => {
+    fakeStore.selectedActions = ['a', 'b'];
+    fakeStore.isAdvancingWeek = true;
+    render(<GameHeader />);
+    expect(advanceButton()).toBeDisabled();
+  });
+});

--- a/tests/client/week-transition.test.tsx
+++ b/tests/client/week-transition.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * WeekTransition interstitial test (Phase 4 PR-4).
+ *
+ * The overlay is purely visual: it appears when the week advance starts,
+ * holds for a minimum display window so fast responses don't flash, and
+ * dismisses as soon as BOTH the advance has completed AND the minimum has
+ * elapsed. Under reduced motion it never renders at all. Fake timers drive
+ * the minimum-display clock.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+const mockUseReducedMotion = vi.fn(() => false);
+vi.mock('motion/react', async () => {
+  const actual =
+    await vi.importActual<typeof import('motion/react')>('motion/react');
+  return {
+    ...actual,
+    useReducedMotion: () => mockUseReducedMotion(),
+  };
+});
+
+const fakeGameState = { currentWeek: 5 };
+vi.mock('@/hooks/useGameState', () => ({
+  useGameState: vi.fn((selector?: (gs: any) => any) =>
+    selector ? selector(fakeGameState) : fakeGameState,
+  ),
+}));
+
+import {
+  WeekTransition,
+  WEEK_TRANSITION_MIN_MS,
+} from '@/components/WeekTransition';
+
+describe('WeekTransition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('does not render when no advance is in flight', () => {
+    render(<WeekTransition isAdvancing={false} />);
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+  });
+
+  it('appears when the advance starts and shows the incoming week number', () => {
+    render(<WeekTransition isAdvancing={true} />);
+    expect(screen.getByTestId('week-transition')).toBeInTheDocument();
+    // currentWeek 5 -> transitioning INTO week 6
+    expect(screen.getByText(/week 6/i)).toBeInTheDocument();
+  });
+
+  it('stays up through the minimum display window when the advance finishes early', () => {
+    const { rerender } = render(<WeekTransition isAdvancing={true} />);
+    expect(screen.getByTestId('week-transition')).toBeInTheDocument();
+
+    // Server answers fast: advance completes at ~100ms.
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    rerender(<WeekTransition isAdvancing={false} />);
+
+    // Still visible: the minimum has not elapsed yet.
+    expect(screen.getByTestId('week-transition')).toBeInTheDocument();
+
+    // Just before the minimum: still visible.
+    act(() => {
+      vi.advanceTimersByTime(WEEK_TRANSITION_MIN_MS - 101);
+    });
+    expect(screen.getByTestId('week-transition')).toBeInTheDocument();
+
+    // Minimum reached: dismisses.
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+  });
+
+  it('dismisses immediately once the advance completes after the minimum elapsed (no artificial delay)', () => {
+    const { rerender } = render(<WeekTransition isAdvancing={true} />);
+
+    // Slow advance: minimum elapses while still in flight.
+    act(() => {
+      vi.advanceTimersByTime(WEEK_TRANSITION_MIN_MS + 500);
+    });
+    expect(screen.getByTestId('week-transition')).toBeInTheDocument();
+
+    // Advance completes -> dismisses on the very next render, no extra timer.
+    rerender(<WeekTransition isAdvancing={false} />);
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+  });
+
+  it('re-appears for a subsequent advance', () => {
+    const { rerender } = render(<WeekTransition isAdvancing={true} />);
+    act(() => {
+      vi.advanceTimersByTime(WEEK_TRANSITION_MIN_MS);
+    });
+    rerender(<WeekTransition isAdvancing={false} />);
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+
+    rerender(<WeekTransition isAdvancing={true} />);
+    expect(screen.getByTestId('week-transition')).toBeInTheDocument();
+  });
+
+  it('never renders under reduced motion, even while advancing', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    const { rerender } = render(<WeekTransition isAdvancing={true} />);
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(WEEK_TRANSITION_MIN_MS * 2);
+    });
+    rerender(<WeekTransition isAdvancing={false} />);
+    expect(screen.queryByTestId('week-transition')).not.toBeInTheDocument();
+  });
+
+  it('is pointer-transparent (cannot block the app)', () => {
+    render(<WeekTransition isAdvancing={true} />);
+    expect(screen.getByTestId('week-transition')).toHaveClass(
+      'pointer-events-none',
+    );
+  });
+});


### PR DESCRIPTION
Phase 4 PR-4 (game-feel plan section 3, row 4): the click-to-results gap becomes a moment.

## What changed

**Charged Advance Week button** (`GameHeader.tsx`)
While `isAdvancingWeek`, the button keeps its gradient + Processing… text but gains an animated shimmer sweep across its face (`ds-shimmer` keyframes at a fast 1.2s scoped duration) plus a soft 1.6s pulse and a pink glow (inline style lifts the disabled dim to 0.95 so the pulse reads as energy, not a dead button). The disabled expression `selectedActions.length === 0 || isAdvancingWeek` is byte-for-byte unchanged; no layout shift.

**Week-transition interstitial** (new `client/src/components/WeekTransition.tsx`)
A full-screen portal overlay in the v2 HUD language: dark scrim + backdrop blur, a 104px HoloDisc spinning up fast (1.6s/rev, grooves on), ADVANCING TO / WEEK N in mono type with the `text-aberration` treatment, and a fast shimmer-bar sweep. Rendered as a fragment sibling from GameHeader only.

## Min-display / no-data-gating design

- Appears when `isAdvancingWeek` flips true; the incoming week number is latched at that moment (facade read via `useGameState(selector)`), so a mid-display gameState commit cannot flip the label.
- Holds a **700ms minimum** so fast server responses do not flash, then dismisses as soon as BOTH the advance completed AND the minimum elapsed — it never outlasts the advance by more than the minimum (no artificial delay).
- **Purely visual**: zero coupling to store logic, data flow, or the WeekSummary modal (which may open beneath it). `pointer-events: none` throughout, plus a 10s auto-dismiss safety net after the advance ends in case a timer ever fails.
- The minimum-display timer lives in a ref cleared only on unmount, so the advance completing early cannot cancel it (a bug the tests caught).

## Reduced motion

`useReducedMotion` (motion/react): no interstitial at all, and the button shows a plain Processing… text state with no shimmer, pulse, or glow.

## Tests

13 new jsdom component tests, all passing:
- `tests/client/game-header-anticipation.test.tsx` (6): normal vs charging state, disabled logic pinned (empty actions / advancing wins), interstitial mounts while advancing, reduced-motion plain state.
- `tests/client/week-transition.test.tsx` (7, fake timers): hidden when idle, appears with correct incoming week, survives an early advance finish through the 700ms minimum, dismisses immediately once the advance completes past the minimum, re-arms for the next advance, never renders under reduced motion, pointer-transparent.

Validation: `npx vitest run tests/client client/src` — 28 files / 251 tests passed (includes the gameState-ownership grep gate); `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
