### PR TITLE
feat(client): Phase 4 PR-5 - celebration tier (particles, campaign-end staging, notable chime)

### DIFF
--- a/client/src/components/CampaignResultsModal.tsx
+++ b/client/src/components/CampaignResultsModal.tsx
@@ -1,7 +1,12 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { motion, useReducedMotion } from 'motion/react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AnimatedNumber } from './motion-primitives/animated-number';
+import { ParticleBurst } from './motion-primitives/particle-burst';
+import { useStagedReveal } from '@/hooks/useStagedReveal';
 
 interface CampaignResults {
   campaignCompleted: boolean;
@@ -24,7 +29,43 @@ interface CampaignResultsModalProps {
   onNewGame: () => void;
 }
 
+// --- Staged reveal timeline (Phase 4 PR-5) ---------------------------------
+// The five score-breakdown cells stagger in one at a time after the header.
+// Stage 0 is the header/score beat; stages 1..5 reveal the breakdown cells in
+// order. Total mandatory sequence = sum of STAGE_DELAYS = 1050ms, well under
+// the ~3s budget. Reduced motion / a click jump straight to fully revealed.
+const BREAKDOWN_COUNT = 5;
+const STAGE_COUNT = BREAKDOWN_COUNT + 1; // header + 5 cells
+const STAGE_DELAYS = [0, 250, 200, 200, 200, 200];
+
+// A staged reveal cell: fades/slides in once `revealed` flips true. Under
+// reduced motion (`instant`) it renders as a plain div, visible immediately.
+const RevealCell: React.FC<{
+  revealed: boolean;
+  instant: boolean;
+  className?: string;
+  children: React.ReactNode;
+}> = ({ revealed, instant, className, children }) => {
+  if (instant) {
+    return <div className={className}>{children}</div>;
+  }
+  return (
+    <motion.div
+      className={className}
+      initial={false}
+      animate={{ opacity: revealed ? 1 : 0, y: revealed ? 0 : 10 }}
+      transition={{ duration: 0.3, ease: 'easeOut' }}
+      aria-hidden={revealed ? undefined : true}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
 export function CampaignResultsModal({ campaignResults, onClose, onNewGame }: CampaignResultsModalProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const instant = !!prefersReducedMotion;
+
   const getVictoryTypeColor = (victoryType: string) => {
     switch (victoryType) {
       case 'Commercial Success':
@@ -59,24 +100,82 @@ export function CampaignResultsModal({ campaignResults, onClose, onNewGame }: Ca
     }
   };
 
+  const finalScore = campaignResults.finalScore;
+
+  const { currentStage, isComplete, skip } = useStagedReveal({
+    stageCount: STAGE_COUNT,
+    stageDelays: STAGE_DELAYS,
+    instant,
+  });
+
+  // Final-score count-up. AnimatedNumber renders statically on FIRST mount, so
+  // we start at 0 (or finalScore under reduced motion, to avoid a 0 flash) and
+  // move to the real score right after mount to drive the spring. A click-skip
+  // flips `wasSkipped`, jumping AnimatedNumber to the final value.
+  const [scoreValue, setScoreValue] = useState(() => (instant ? finalScore : 0));
+  const [wasSkipped, setWasSkipped] = useState(false);
+  useEffect(() => {
+    setScoreValue(finalScore);
+  }, [finalScore]);
+
+  // One entry celebration burst (self-gated on reduced motion inside the
+  // primitive). `true` triggers a single burst on mount.
+  const showEntryBurst = !instant;
+
+  const skipAll = () => {
+    skip();
+    setWasSkipped(true);
+  };
+  const handleSkipInteraction = () => {
+    if (!isComplete) skipAll();
+  };
+  const handleSkipKey = () => {
+    if (!isComplete) skipAll();
+  };
+
+  // Score-breakdown cells, in reveal order. Each is a fact that must always be
+  // shown (information parity with the pre-PR static layout).
+  const breakdownCells = [
+    { value: campaignResults.scoreBreakdown.money, label: 'Money', color: 'text-money' },
+    { value: campaignResults.scoreBreakdown.reputation, label: 'Reputation', color: 'text-neon-lilac' },
+    { value: campaignResults.scoreBreakdown.artistsSuccessful, label: 'Artist Success', color: 'text-positive' },
+    { value: campaignResults.scoreBreakdown.projectsCompleted, label: 'Projects', color: 'text-neon-amber' },
+    { value: campaignResults.scoreBreakdown.accessTierBonus, label: 'Access Bonus', color: 'text-neon-cyan' },
+  ];
+
   return (
     <Dialog open={true} onOpenChange={onClose}>
-      <DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto hud-ticks">
-        <DialogHeader className="border-b border-white/10 pb-6 text-center">
-          <div className="mb-4 text-6xl">
+      <DialogContent
+        className="max-h-[90vh] max-w-4xl overflow-y-auto hud-ticks"
+        onClickCapture={handleSkipInteraction}
+        onKeyDownCapture={handleSkipKey}
+      >
+        <DialogHeader className="relative border-b border-white/10 pb-6 text-center">
+          {/* Entry celebration particles (self-gated on reduced motion). */}
+          <ParticleBurst
+            trigger={showEntryBurst}
+            colors={['#ff4fd8', '#a855f7', '#22d3ee', '#fbbf24']}
+            particleCount={28}
+          />
+          <div className="relative mb-4 text-6xl">
             {getVictoryTypeIcon(campaignResults.victoryType)}
           </div>
-          <DialogTitle className="font-display text-2xl font-normal lowercase tracking-wide text-aberration">
+          <DialogTitle className="relative font-display text-2xl font-normal lowercase tracking-wide text-aberration">
             Campaign Complete!
           </DialogTitle>
-          <div className="mt-4">
+          <div className="relative mt-4">
             <Badge
               className={`border-0 px-4 py-2 text-lg text-white ${getVictoryTypeColor(campaignResults.victoryType)}`}
             >
               {campaignResults.victoryType}
             </Badge>
             <div className="mt-2 font-mono text-3xl font-semibold text-white/90">
-              Final Score: {campaignResults.finalScore}
+              Final Score:{' '}
+              <AnimatedNumber
+                value={scoreValue}
+                skipAnimation={instant || wasSkipped}
+                format={(n) => `${Math.round(n)}`}
+              />
             </div>
           </div>
         </DialogHeader>
@@ -105,36 +204,19 @@ export function CampaignResultsModal({ campaignResults, onClose, onNewGame }: Ca
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
-                <div className="text-center">
-                  <div className="font-mono text-xl font-semibold leading-none text-money">
-                    {campaignResults.scoreBreakdown.money}
-                  </div>
-                  <div className="mt-1.5 text-[11.5px] text-white/50">Money</div>
-                </div>
-                <div className="text-center">
-                  <div className="font-mono text-xl font-semibold leading-none text-neon-lilac">
-                    {campaignResults.scoreBreakdown.reputation}
-                  </div>
-                  <div className="mt-1.5 text-[11.5px] text-white/50">Reputation</div>
-                </div>
-                <div className="text-center">
-                  <div className="font-mono text-xl font-semibold leading-none text-positive">
-                    {campaignResults.scoreBreakdown.artistsSuccessful}
-                  </div>
-                  <div className="mt-1.5 text-[11.5px] text-white/50">Artist Success</div>
-                </div>
-                <div className="text-center">
-                  <div className="font-mono text-xl font-semibold leading-none text-neon-amber">
-                    {campaignResults.scoreBreakdown.projectsCompleted}
-                  </div>
-                  <div className="mt-1.5 text-[11.5px] text-white/50">Projects</div>
-                </div>
-                <div className="text-center">
-                  <div className="font-mono text-xl font-semibold leading-none text-neon-cyan">
-                    {campaignResults.scoreBreakdown.accessTierBonus}
-                  </div>
-                  <div className="mt-1.5 text-[11.5px] text-white/50">Access Bonus</div>
-                </div>
+                {breakdownCells.map((cell, index) => (
+                  <RevealCell
+                    key={cell.label}
+                    revealed={currentStage >= index + 1}
+                    instant={instant}
+                    className="text-center"
+                  >
+                    <div className={`font-mono text-xl font-semibold leading-none ${cell.color}`}>
+                      {cell.value}
+                    </div>
+                    <div className="mt-1.5 text-[11.5px] text-white/50">{cell.label}</div>
+                  </RevealCell>
+                ))}
               </div>
             </CardContent>
           </Card>

--- a/client/src/components/WeekSummary.tsx
+++ b/client/src/components/WeekSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { motion, useReducedMotion } from 'motion/react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -8,7 +8,9 @@ import { TrendingUp, TrendingDown, DollarSign, Music, Trophy, Zap, X, BarChart3,
 import { ChartPerformanceCard } from './ChartPerformanceCard';
 import { AnimatedNumber } from './motion-primitives/animated-number';
 import { GlowEffect } from './motion-primitives/glow-effect';
+import { ParticleBurst } from './motion-primitives/particle-burst';
 import { useStagedReveal } from '@/hooks/useStagedReveal';
+import { playSound } from '@/lib/audio';
 import { classifyChartUpdate } from '@shared/utils/changeImportance';
 import { WeekSummary as WeekSummaryType, GameChange, ChartUpdate } from '../../../shared/types/gameTypes';
 
@@ -230,6 +232,36 @@ export function WeekSummary({ weeklyStats, onAdvanceWeek, isAdvancing, isWeekRes
     instant,
   });
 
+  // --- Celebration tier (Phase 4 PR-5) -------------------------------------
+  // The hero stage gets a distinct fanfare when a No. 1 chart update lands:
+  // a single ParticleBurst over the Milestone Moments card. The store already
+  // plays the week's priority sting (hero-fanfare / campaign-end / etc.) once
+  // per advance, so we DO NOT add sound to the hero stage here (that would
+  // double up). The two previously-unwired stage stings are handled below.
+  const hasNo1 = heroChartUpdates.length > 0;
+  // Fire particles once the hero stage reveals, only when there's a No. 1 and
+  // we're not in instant/skip mode. `heroStageRevealed` flips true exactly once
+  // and never back, so ParticleBurst emits a single burst.
+  const heroStageRevealed = !instant && currentStage >= STAGE_HERO;
+  const fireHeroParticles = heroStageRevealed && hasNo1;
+
+  // Notable-stage sting: when the NOTABLE stage reveals with notable content
+  // (chart highlights or non-unlock achievements), play the notable-chime once.
+  // Suppressed under instant/reduced-motion and when skipped (the reveal jumps
+  // straight to complete, so the staged chime is intentionally silent). The
+  // audio manager itself de-dupes to the highest-priority sound; notable-chime
+  // is not one the store fires, so there is no conflict with the week sting.
+  const hasNotableContent = playerChartUpdates.length > 0 || nonUnlockAchievements.length > 0;
+  const notableChimePlayed = useRef(false);
+  useEffect(() => {
+    if (instant) return; // reduced-motion / skip toggle → no stage chime
+    if (notableChimePlayed.current) return;
+    if (currentStage >= STAGE_NOTABLE && !isComplete && hasNotableContent) {
+      notableChimePlayed.current = true;
+      playSound('notable-chime');
+    }
+  }, [currentStage, isComplete, instant, hasNotableContent]);
+
   // Net-income hero count-up. AnimatedNumber renders STATICALLY on first mount
   // (by PR-1 design) and only animates on value CHANGES — so mounting with
   // netIncome already final meant the count-up never played. Instead, start a
@@ -307,6 +339,13 @@ export function WeekSummary({ weeklyStats, onAdvanceWeek, isAdvancing, isWeekRes
                 blur="stronger"
                 colors={['#ff4fd8', '#a855f7', '#22d3ee']}
                 className="opacity-[0.18]"
+              />
+              {/* Celebration particles: one burst when the hero stage reveals a
+                  No. 1 chart update. Self-gated on reduced motion. */}
+              <ParticleBurst
+                trigger={fireHeroParticles}
+                colors={['#ff4fd8', '#a855f7', '#22d3ee', '#fbbf24']}
+                particleCount={26}
               />
               <CardHeader className="relative">
                 <CardTitle className="flex items-center space-x-2 text-sm">

--- a/client/src/components/motion-primitives/particle-burst.tsx
+++ b/client/src/components/motion-primitives/particle-burst.tsx
@@ -1,0 +1,167 @@
+'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import { motion, useReducedMotion } from 'motion/react';
+import { cn } from '@/lib/utils';
+
+/**
+ * ParticleBurst (Phase 4 PR-5) — a lightweight, self-contained SVG confetti
+ * emitter for celebrating hero moments (a No. 1 chart update, campaign end).
+ *
+ * NO new dependency: it renders a handful of small SVG circles animated with
+ * `motion/react` (already a project dep) and auto-cleans ~1.5s after each
+ * burst. It fires ONCE per change of the `trigger` prop (a truthy toggle or a
+ * changing token) — mounting with `trigger` already truthy fires the first
+ * burst, and flipping it to a new value fires another.
+ *
+ * Colors come from props (v2 neon palette, passed by the caller — never random
+ * hexes baked in here), mirroring how GlowEffect takes a `colors` prop. The
+ * scatter directions are deterministic-per-count (evenly distributed radial
+ * angles with a fixed per-index jitter), so there is no RNG and the visual is
+ * stable across renders.
+ *
+ * Accessibility: renders NOTHING under `prefers-reduced-motion` — the
+ * reduced-motion bail is baked into the primitive itself, so callers never
+ * have to gate it. Purely decorative, so it is `aria-hidden` and
+ * `pointer-events-none`.
+ */
+export interface ParticleBurstProps {
+  /**
+   * Fires one burst whenever this value changes (and once on mount if truthy).
+   * Pass a boolean toggle or an incrementing/changing token.
+   */
+  trigger: unknown;
+  /** Particle colors (v2 neon palette). Cycled across the particles. */
+  colors?: string[];
+  /** Number of particles per burst (~20–30 recommended). */
+  particleCount?: number;
+  className?: string;
+}
+
+// v2 neon defaults (magenta / purple / cyan / amber). Callers may override.
+const DEFAULT_COLORS = ['#ff4fd8', '#a855f7', '#22d3ee', '#fbbf24'];
+
+const BURST_LIFETIME_MS = 1500;
+
+interface Particle {
+  id: number;
+  color: string;
+  angle: number; // radians
+  distance: number; // px travelled
+  size: number; // radius px
+}
+
+// Deterministic per-index scatter: even radial spread plus a small fixed
+// jitter derived from the index (no RNG, stable across renders).
+function buildParticles(count: number, colors: string[], seed: number): Particle[] {
+  const safeCount = Math.max(1, Math.floor(count));
+  const palette = colors.length > 0 ? colors : DEFAULT_COLORS;
+  const particles: Particle[] = [];
+  for (let i = 0; i < safeCount; i++) {
+    const base = (i / safeCount) * Math.PI * 2;
+    // Fixed, index-derived jitter so bursts vary a touch without RNG.
+    const jitter = ((i * 2654435761) % 1000) / 1000; // 0..1, hashed from index
+    const angle = base + (jitter - 0.5) * 0.6;
+    const distance = 42 + (jitter * 34); // 42..76px
+    const size = 2 + ((i % 3)); // 2..4px radius
+    particles.push({
+      id: seed * 1000 + i,
+      color: palette[i % palette.length],
+      angle,
+      distance,
+      size,
+    });
+  }
+  return particles;
+}
+
+export function ParticleBurst({
+  trigger,
+  colors = DEFAULT_COLORS,
+  particleCount = 24,
+  className,
+}: ParticleBurstProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  // Each burst is a keyed generation of particles. `burstSeed` increments per
+  // trigger change; when it is 0 no burst has fired yet.
+  const [burstSeed, setBurstSeed] = useState(0);
+  const [particles, setParticles] = useState<Particle[]>([]);
+  const prevTrigger = useRef<unknown>(undefined);
+  const firstRun = useRef(true);
+  const cleanupRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // Reduced motion: never emit particles.
+    if (prefersReducedMotion) return;
+
+    const changed = firstRun.current
+      ? !!trigger // on mount, only fire if trigger is truthy
+      : trigger !== prevTrigger.current;
+
+    prevTrigger.current = trigger;
+    firstRun.current = false;
+
+    if (!changed) return;
+
+    setBurstSeed((s) => {
+      const next = s + 1;
+      setParticles(buildParticles(particleCount, colors, next));
+      return next;
+    });
+
+    if (cleanupRef.current) clearTimeout(cleanupRef.current);
+    cleanupRef.current = setTimeout(() => {
+      setParticles([]);
+    }, BURST_LIFETIME_MS);
+
+    // colors/particleCount are treated as stable config; the trigger drives it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trigger, prefersReducedMotion]);
+
+  useEffect(() => {
+    return () => {
+      if (cleanupRef.current) clearTimeout(cleanupRef.current);
+    };
+  }, []);
+
+  // Reduced motion or nothing to show → render nothing.
+  if (prefersReducedMotion || particles.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-none absolute inset-0 z-10 flex items-center justify-center overflow-visible',
+        className
+      )}
+      aria-hidden="true"
+      data-testid="particle-burst"
+    >
+      <svg
+        className="overflow-visible"
+        width="1"
+        height="1"
+        viewBox="0 0 1 1"
+        style={{ overflow: 'visible' }}
+      >
+        {particles.map((p) => {
+          const dx = Math.cos(p.angle) * p.distance;
+          const dy = Math.sin(p.angle) * p.distance;
+          return (
+            <motion.circle
+              key={p.id}
+              cx={0.5}
+              cy={0.5}
+              r={p.size}
+              fill={p.color}
+              initial={{ x: 0, y: 0, opacity: 1, scale: 1 }}
+              animate={{ x: dx, y: dy, opacity: 0, scale: 0.4 }}
+              transition={{ duration: BURST_LIFETIME_MS / 1000, ease: 'easeOut' }}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+export default ParticleBurst;

--- a/client/src/lib/audio.ts
+++ b/client/src/lib/audio.ts
@@ -214,7 +214,12 @@ class AudioManager {
 
 export const audioManager = new AudioManager();
 
-// TODO(phase4): wire notable-chime/warning in PR-3 reveal sequence.
+// Phase 4 PR-5: `notable-chime` is wired in WeekSummary's staged reveal — it
+// plays once when the NOTABLE stage reveals with notable content (chart
+// highlights / non-unlock achievements), suppressed under reduced-motion/skip.
+// `warning` remains intentionally unwired: there is no clean, non-noisy trigger
+// for it in the current reveal flow (a "bad week" has no single hero-style
+// beat), so leaving it silent is deliberate rather than an oversight.
 
 /** Convenience free function mirroring `audioManager.playSound`. */
 export function playSound(key: SoundKey): void {

--- a/tests/client/CampaignResultsModal.test.tsx
+++ b/tests/client/CampaignResultsModal.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * CampaignResultsModal staged-treatment tests (Phase 4 PR-5).
+ *
+ * jsdom can't verify motion quality, so these assert observable states:
+ * every campaign fact is still displayed (information parity), a click skips
+ * the sequence to fully-revealed instantly, and reduced motion renders the
+ * final content statically. The entry ParticleBurst is self-gated on reduced
+ * motion inside the primitive.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const mockUseReducedMotion = vi.fn(() => false);
+vi.mock('motion/react', async () => {
+  const actual = await vi.importActual<typeof import('motion/react')>('motion/react');
+  return {
+    ...actual,
+    useReducedMotion: () => mockUseReducedMotion(),
+  };
+});
+
+import { CampaignResultsModal } from '@/components/CampaignResultsModal';
+
+const RESULTS = {
+  campaignCompleted: true,
+  finalScore: 8421,
+  scoreBreakdown: {
+    money: 1200,
+    reputation: 340,
+    artistsSuccessful: 3,
+    projectsCompleted: 7,
+    accessTierBonus: 55,
+  },
+  victoryType: 'Commercial Success' as const,
+  summary: 'You built a thriving label from nothing.',
+  achievements: ['First No. 1', 'Millionaire'],
+};
+
+const renderModal = () =>
+  render(
+    <CampaignResultsModal
+      campaignResults={RESULTS}
+      onClose={() => {}}
+      onNewGame={() => {}}
+    />
+  );
+
+// Assert every fact from RESULTS is present in the DOM.
+const expectAllFactsPresent = () => {
+  expect(screen.getByText('Campaign Complete!')).toBeInTheDocument();
+  expect(screen.getByText('Commercial Success')).toBeInTheDocument();
+  expect(screen.getByText(RESULTS.summary)).toBeInTheDocument();
+  // Score breakdown values + labels
+  expect(screen.getByText(String(RESULTS.scoreBreakdown.money))).toBeInTheDocument();
+  expect(screen.getByText('Money')).toBeInTheDocument();
+  expect(screen.getByText(String(RESULTS.scoreBreakdown.reputation))).toBeInTheDocument();
+  expect(screen.getByText('Reputation')).toBeInTheDocument();
+  expect(screen.getByText(String(RESULTS.scoreBreakdown.artistsSuccessful))).toBeInTheDocument();
+  expect(screen.getByText('Artist Success')).toBeInTheDocument();
+  expect(screen.getByText(String(RESULTS.scoreBreakdown.projectsCompleted))).toBeInTheDocument();
+  expect(screen.getByText('Projects')).toBeInTheDocument();
+  expect(screen.getByText(String(RESULTS.scoreBreakdown.accessTierBonus))).toBeInTheDocument();
+  expect(screen.getByText('Access Bonus')).toBeInTheDocument();
+  // Achievements
+  RESULTS.achievements.forEach((a) => {
+    expect(screen.getByText(a)).toBeInTheDocument();
+  });
+};
+
+describe('CampaignResultsModal (staged treatment)', () => {
+  beforeEach(() => {
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('displays every campaign fact (information parity)', () => {
+    renderModal();
+    // All breakdown values live in the DOM from the start (staged only by
+    // opacity), so parity holds regardless of reveal progress.
+    expectAllFactsPresent();
+  });
+
+  it('shows the final score after mount (count-up target reached)', () => {
+    renderModal();
+    // The score value updates post-mount toward the final; the label is static.
+    expect(screen.getByText(/Final Score:/)).toBeInTheDocument();
+  });
+
+  it('a click skips the sequence and shows everything fully revealed', () => {
+    renderModal();
+    const dialog = screen.getByText('Campaign Complete!').closest('[role="dialog"]')!;
+    fireEvent.click(dialog);
+    // After skip, the final score is displayed and every fact remains present.
+    expect(screen.getByText(String(RESULTS.finalScore))).toBeInTheDocument();
+    expectAllFactsPresent();
+  });
+
+  it('renders statically under reduced motion (final score, all facts)', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    renderModal();
+    // Reduced motion → score is final immediately, no count-up from 0.
+    expect(screen.getByText(String(RESULTS.finalScore))).toBeInTheDocument();
+    expectAllFactsPresent();
+    // No particle burst under reduced motion.
+    expect(document.querySelector('[data-testid="particle-burst"]')).not.toBeInTheDocument();
+  });
+});

--- a/tests/client/WeekSummary.notable-chime.test.tsx
+++ b/tests/client/WeekSummary.notable-chime.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * WeekSummary notable-stage chime tests (Phase 4 PR-5).
+ *
+ * The NOTABLE stage of the staged reveal plays `notable-chime` once — but only
+ * when there is notable content, and never under reduced motion or when the
+ * player skips the sequence (both collapse straight to the final state). The
+ * store owns the week's priority sting (hero-fanfare/campaign-end/etc.), so the
+ * stage chime here is additive, not a duplicate.
+ *
+ * jsdom drives the setTimeout-based reveal via fake timers.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+
+const mockUseReducedMotion = vi.fn(() => false);
+vi.mock('motion/react', async () => {
+  const actual = await vi.importActual<typeof import('motion/react')>('motion/react');
+  return {
+    ...actual,
+    useReducedMotion: () => mockUseReducedMotion(),
+  };
+});
+
+const playSound = vi.fn();
+vi.mock('@/lib/audio', () => ({
+  playSound: (key: string) => playSound(key),
+}));
+
+import { WeekSummary } from '@/components/WeekSummary';
+
+// A player-facing top-10 chart update with upward movement classifies as
+// `notable` (not hero, not routine) — driving the notable stage's content.
+const NOTABLE_STATS = {
+  week: 12,
+  revenue: 5000,
+  expenses: 2000,
+  changes: [],
+  chartUpdates: [
+    {
+      songTitle: 'Neon Nights',
+      artistName: 'Aurora',
+      position: 5,
+      movement: 3,
+      isDebut: false,
+      isCompetitorSong: false,
+    },
+  ],
+} as any;
+
+// Time to reach the NOTABLE stage (index 3): STAGE_DELAYS = [0,450,500,450,400]
+// → cumulative before stage 3 = 450 + 500 + 450 = 1400ms.
+const TIME_TO_NOTABLE = 1400;
+// Beyond that reaches routine/complete.
+const TIME_TO_COMPLETE = 2000;
+
+const renderSummary = () =>
+  render(
+    <WeekSummary
+      weeklyStats={NOTABLE_STATS}
+      onAdvanceWeek={() => {}}
+      isWeekResults
+    />
+  );
+
+describe('WeekSummary notable-stage chime', () => {
+  beforeEach(() => {
+    mockUseReducedMotion.mockReturnValue(false);
+    playSound.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('plays notable-chime once when the NOTABLE stage reveals with notable content', () => {
+    vi.useFakeTimers();
+    renderSummary();
+
+    expect(playSound).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(TIME_TO_NOTABLE);
+    });
+
+    expect(playSound).toHaveBeenCalledWith('notable-chime');
+    expect(playSound).toHaveBeenCalledTimes(1);
+
+    // Does not re-fire as the sequence completes.
+    act(() => {
+      vi.advanceTimersByTime(TIME_TO_COMPLETE);
+    });
+    expect(playSound).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT play the chime under reduced motion (instant render)', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    vi.useFakeTimers();
+    renderSummary();
+
+    act(() => {
+      vi.advanceTimersByTime(TIME_TO_COMPLETE);
+    });
+
+    expect(playSound).not.toHaveBeenCalled();
+  });
+
+  it('does NOT play the chime when the sequence is skipped before the notable stage', () => {
+    vi.useFakeTimers();
+    renderSummary();
+
+    // Skip immediately (before the notable stage would naturally reveal).
+    const panel = screen.getByText(/Week 12 Results/).closest('div')!;
+    act(() => {
+      fireEvent.click(panel);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(TIME_TO_COMPLETE);
+    });
+
+    expect(playSound).not.toHaveBeenCalled();
+  });
+});

--- a/tests/client/particle-burst.test.tsx
+++ b/tests/client/particle-burst.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * ParticleBurst motion primitive test (Phase 4 PR-5).
+ *
+ * jsdom can't verify motion quality, so these assert observable states:
+ * particles render on a trigger change, nothing renders under reduced motion,
+ * and a burst auto-cleans after its lifetime.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+
+// Mock useReducedMotion so we can flip it per-test.
+const mockUseReducedMotion = vi.fn(() => false);
+vi.mock('motion/react', async () => {
+  const actual = await vi.importActual<typeof import('motion/react')>('motion/react');
+  return {
+    ...actual,
+    useReducedMotion: () => mockUseReducedMotion(),
+  };
+});
+
+import { ParticleBurst } from '@/components/motion-primitives/particle-burst';
+
+const countParticles = (container: HTMLElement) =>
+  container.querySelectorAll('circle').length;
+
+describe('ParticleBurst', () => {
+  beforeEach(() => {
+    mockUseReducedMotion.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('renders particles when mounted with a truthy trigger', () => {
+    const { container } = render(<ParticleBurst trigger={true} particleCount={20} />);
+    expect(container.querySelector('[data-testid="particle-burst"]')).toBeInTheDocument();
+    expect(countParticles(container)).toBe(20);
+  });
+
+  it('honors particleCount', () => {
+    const { container } = render(<ParticleBurst trigger={true} particleCount={30} />);
+    expect(countParticles(container)).toBe(30);
+  });
+
+  it('does not render a burst when mounted with a falsy trigger', () => {
+    const { container } = render(<ParticleBurst trigger={false} particleCount={20} />);
+    expect(container.querySelector('[data-testid="particle-burst"]')).not.toBeInTheDocument();
+    expect(countParticles(container)).toBe(0);
+  });
+
+  it('fires a new burst when the trigger changes to a new value', () => {
+    const { container, rerender } = render(
+      <ParticleBurst trigger={false} particleCount={22} />
+    );
+    expect(countParticles(container)).toBe(0);
+
+    rerender(<ParticleBurst trigger={true} particleCount={22} />);
+    expect(countParticles(container)).toBe(22);
+  });
+
+  it('renders NOTHING under reduced motion, even with a truthy trigger', () => {
+    mockUseReducedMotion.mockReturnValue(true);
+    const { container } = render(<ParticleBurst trigger={true} particleCount={26} />);
+    expect(container.querySelector('[data-testid="particle-burst"]')).not.toBeInTheDocument();
+    expect(countParticles(container)).toBe(0);
+  });
+
+  it('auto-cleans the burst after its lifetime', () => {
+    vi.useFakeTimers();
+    const { container } = render(<ParticleBurst trigger={true} particleCount={20} />);
+    expect(countParticles(container)).toBe(20);
+
+    act(() => {
+      vi.advanceTimersByTime(1600);
+    });
+    expect(countParticles(container)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What this adds

Phase 4 PR-5: a distinct fanfare for hero moments, built ON the PR-3 staged reveal (no restructuring of it).

### New primitive: `motion-primitives/particle-burst.tsx`
Self-contained SVG confetti emitter — **no new dependency**. One burst of ~20-30 small `motion.circle` particles scattered radially. Colors come from props (v2 neon palette, never random hexes baked in), mirroring how `glow-effect.tsx` takes a `colors` prop. Fires once per `trigger` change (and on mount if truthy), auto-cleans after ~1.5s. Renders **nothing** under `prefers-reduced-motion` — that bail is baked into the primitive itself. Deterministic scatter (index-hashed jitter, no RNG).

## Celebration map — what celebrates when

| Moment | Treatment |
|---|---|
| WeekSummary hero stage reveals **a No. 1 chart update** | one `ParticleBurst` over the Milestone Moments card |
| WeekSummary **NOTABLE** stage reveals with notable content (chart highlights / non-unlock achievements) | `playSound('notable-chime')` once |
| WeekSummary hero stage | **no new sound** — the store already plays the week's priority sting (hero-fanfare/campaign-end/tier-unlock/week-advance), so adding one here would double up |
| CampaignResultsModal on entry | final-score `AnimatedNumber` count-up (0→score post-mount), staggered score-breakdown cells, one `ParticleBurst` |

All of the above are suppressed under reduced-motion / skip.

## Sound wiring decisions
- `notable-chime`: **wired** in WeekSummary's staged reveal — plays once when the NOTABLE stage reveals with notable content, suppressed under reduced-motion and when the player skips (the reveal jumps straight to complete, so the staged chime is intentionally silent). `notable-chime` is not a sound the store fires, so there is no conflict with the week's priority sting.
- `warning`: **left intentionally unwired.** There is no clean, non-noisy trigger for it in the current reveal flow (a "bad week" has no single hero-style beat). Leaving it silent is deliberate; the `// TODO(phase4)` note in `audio.ts` was updated to say so rather than deleted-and-forgotten.

## Information parity
Every fact CampaignResultsModal displayed before is still displayed: victory type + icon, final score, full summary, all five score-breakdown values with labels, and all achievements. The staging only affects opacity/timing; nothing is gated out of the DOM. A characterization test asserts all facts are present.

## Respecting skip / reduced motion
- Reduced motion → both modals render fully static (no count-up, no particles, no stage chime).
- Click/keypress during a running sequence → collapses to final state instantly (WeekSummary + CampaignResultsModal), no particles/chime after skip.
- Total added mandatory sequence in CampaignResultsModal = 1050ms (sum of stage delays), under the ~3s budget.

## Tests (13 new, jsdom)
- `particle-burst.test.tsx` (6): renders particles on trigger, honors `particleCount`, nothing on falsy trigger, new burst on trigger change, **nothing under reduced motion**, auto-clean after lifetime.
- `CampaignResultsModal.test.tsx` (4): all facts present (parity), final score shown, click skips to fully-revealed, reduced-motion static + no burst.
- `WeekSummary.notable-chime.test.tsx` (3): chime fires once at the notable stage (mock `@/lib/audio`), **not** under reduced motion, **not** when skipped.

Validation: `npx vitest run tests/client client/src` → **259 passed** (both paths). `npm run check` → clean.

## Not touched
GameHeader.tsx, gameStore.ts, CommandDock.tsx, Dashboard.tsx, holo-disc.tsx, the engine, shared/. No new deps, no layout redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
