### PR TITLE
feat(client): Phase 4 PR-7 - HoloDisc ambient pulse

### DIFF
--- a/client/src/components/CommandDock.pulse.test.tsx
+++ b/client/src/components/CommandDock.pulse.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * CommandDock HoloDisc ambient pulse (Phase 4 PR-7).
+ *
+ * Two independent triggers drive the dock's HoloDisc `pulse` prop, both pure
+ * garnish with no gameplay effect:
+ *   (1) a NEW weeklyOutcome (tracked by week number) carrying a hero/notable
+ *       change or chart update (or, absent `importance`, a `type: 'unlock'`
+ *       change) -> pulse ~6s.
+ *   (2) selectedActions.length growing -> a brief ~1s acknowledgment pulse.
+ *
+ * The dock pulls in Clerk, wouter, TanStack Query dropdown/tooltip primitives,
+ * the audio manager, and both game-state hooks. All are mocked so this test
+ * exercises only the pulse-trigger logic added in PR-7.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/game', vi.fn()],
+}));
+
+vi.mock('@clerk/clerk-react', () => ({
+  useUser: () => ({ user: { username: 'tester', primaryEmailAddress: { emailAddress: 't@example.com' } } }),
+  UserButton: () => React.createElement('div', { 'data-testid': 'user-button' }),
+}));
+
+vi.mock('@/auth/useCurrentUser', () => ({
+  useIsAdmin: () => ({ isAdmin: false, loading: false }),
+}));
+
+vi.mock('@/contexts/GameContext', () => ({
+  useGameContext: () => ({ gameId: 'game-1' }),
+}));
+
+vi.mock('./BugReportModal', () => ({
+  BugReportModal: () => null,
+}));
+
+vi.mock('@/lib/audio', () => ({
+  audioManager: {
+    getSettings: () => ({ muted: false, volume: 0.5 }),
+    subscribe: () => () => {},
+    setMuted: vi.fn(),
+    setVolume: vi.fn(),
+  },
+}));
+
+// Fake gameState spine — only fields CommandDock reads.
+const fakeGameState = {
+  focusSlots: 3,
+  usedFocusSlots: 0,
+  currentWeek: 5,
+};
+vi.mock('@/hooks/useGameState', () => ({
+  useGameState: () => fakeGameState,
+}));
+
+// Store mock: mimic the harness pattern from the task brief — selector-aware
+// mockImplementation so `useGameStore()` (no selector) and any selector usage
+// both resolve against the same fake state object, which the test mutates
+// between renders to simulate weeklyOutcome/selectedActions changes.
+let fakeStoreState: { weeklyOutcome: any; selectedActions: string[] };
+const useGameStoreMock = vi.fn((selector?: (s: typeof fakeStoreState) => unknown) =>
+  selector ? selector(fakeStoreState) : fakeStoreState,
+);
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: (selector?: any) => useGameStoreMock(selector),
+}));
+
+import { CommandDock } from './CommandDock';
+
+function makeChange(overrides: Record<string, any> = {}) {
+  return { type: 'mood_change', description: 'routine', ...overrides };
+}
+
+describe('CommandDock HoloDisc ambient pulse', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeStoreState = { weeklyOutcome: null, selectedActions: [] };
+  });
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+  });
+
+  function getHoloDiscPulseState(container: HTMLElement) {
+    // The dock HoloDisc renders the pulse halo via data-testid when active.
+    return container.querySelector('[data-testid="holo-disc-pulse"]');
+  }
+
+  it('does not pulse on a routine-only weeklyOutcome', () => {
+    const { container, rerender } = render(<CommandDock />);
+    expect(getHoloDiscPulseState(container)).toBeNull();
+
+    act(() => {
+      fakeStoreState = {
+        weeklyOutcome: { week: 1, changes: [makeChange({ importance: 'routine' })], chartUpdates: [] },
+        selectedActions: [],
+      };
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).toBeNull();
+  });
+
+  it('pulses on a hero-bearing weeklyOutcome and expires after ~6s', () => {
+    const { container, rerender } = render(<CommandDock />);
+
+    act(() => {
+      fakeStoreState = {
+        weeklyOutcome: {
+          week: 1,
+          changes: [makeChange({ importance: 'hero', type: 'chart_debut' })],
+          chartUpdates: [],
+        },
+        selectedActions: [],
+      };
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).toBeNull();
+  });
+
+  it('pulses on a notable chart update even without a hero change', () => {
+    const { container, rerender } = render(<CommandDock />);
+
+    act(() => {
+      fakeStoreState = {
+        weeklyOutcome: {
+          week: 2,
+          changes: [makeChange({ importance: 'routine' })],
+          chartUpdates: [{ importance: 'notable', position: 8 }],
+        },
+        selectedActions: [],
+      };
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).not.toBeNull();
+  });
+
+  it('falls back to type === "unlock" when importance is absent', () => {
+    const { container, rerender } = render(<CommandDock />);
+
+    act(() => {
+      fakeStoreState = {
+        weeklyOutcome: {
+          week: 3,
+          changes: [makeChange({ type: 'unlock', importance: undefined })],
+          chartUpdates: [],
+        },
+        selectedActions: [],
+      };
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).not.toBeNull();
+  });
+
+  it('does not re-pulse for the same week rendered again', () => {
+    const { container, rerender } = render(<CommandDock />);
+
+    act(() => {
+      fakeStoreState = {
+        weeklyOutcome: { week: 4, changes: [makeChange({ importance: 'hero' })], chartUpdates: [] },
+        selectedActions: [],
+      };
+    });
+    rerender(<CommandDock />);
+    expect(getHoloDiscPulseState(container)).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    rerender(<CommandDock />);
+    expect(getHoloDiscPulseState(container)).toBeNull();
+
+    // Same weeklyOutcome object/week re-rendered (e.g. an unrelated parent
+    // re-render) must not re-trigger the pulse.
+    act(() => {
+      fakeStoreState = { ...fakeStoreState };
+    });
+    rerender(<CommandDock />);
+    expect(getHoloDiscPulseState(container)).toBeNull();
+  });
+
+  it('gives a brief ~1s acknowledgment pulse when selectedActions grows', () => {
+    const { container, rerender } = render(<CommandDock />);
+    expect(getHoloDiscPulseState(container)).toBeNull();
+
+    act(() => {
+      fakeStoreState = { weeklyOutcome: null, selectedActions: ['action-1'] };
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).toBeNull();
+  });
+
+  it('does not pulse when selectedActions shrinks (deselecting an action)', () => {
+    fakeStoreState = { weeklyOutcome: null, selectedActions: ['action-1'] };
+    const { container, rerender } = render(<CommandDock />);
+
+    act(() => {
+      fakeStoreState = { weeklyOutcome: null, selectedActions: [] };
+    });
+    rerender(<CommandDock />);
+
+    expect(getHoloDiscPulseState(container)).toBeNull();
+  });
+});

--- a/client/src/components/CommandDock.tsx
+++ b/client/src/components/CommandDock.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'wouter';
 import { UserButton, useUser } from '@clerk/clerk-react';
 import { useIsAdmin } from '@/auth/useCurrentUser';
@@ -117,13 +117,61 @@ function DockItem({
 export function CommandDock({ onShowSaveModal }: CommandDockProps) {
   const [location, setLocation] = useLocation();
   const gameState = useGameState();
-  const { weeklyOutcome } = useGameStore();
+  const { weeklyOutcome, selectedActions } = useGameStore();
   const { gameId } = useGameContext();
   const { user } = useUser();
   const { isAdmin } = useIsAdmin();
 
   const [showWeekSummary, setShowWeekSummary] = useState(false);
   const [showBugReportModal, setShowBugReportModal] = useState(false);
+
+  // Phase 4 PR-7: ambient HoloDisc pulse — pure garnish, no gameplay effect.
+  // Two independent triggers, each a simple on/~duration/off timer:
+  //  (1) a NEW weeklyOutcome lands (tracked by week number) carrying a
+  //      hero/notable change or chart update -> pulse for ~6s.
+  //  (2) the player grows their selectedActions -> a brief ~1s acknowledgment
+  //      pulse. Both share one `pulse` boolean; whichever fires last wins the
+  //      dock's visual state (deliberately simple).
+  const [pulse, setPulse] = useState(false);
+  const lastPulsedWeekRef = useRef<number | null>(null);
+  const prevSelectedCountRef = useRef(selectedActions.length);
+  const pulseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const firePulse = (durationMs: number) => {
+    if (pulseTimeoutRef.current) clearTimeout(pulseTimeoutRef.current);
+    setPulse(true);
+    pulseTimeoutRef.current = setTimeout(() => {
+      setPulse(false);
+      pulseTimeoutRef.current = null;
+    }, durationMs);
+  };
+
+  useEffect(() => {
+    const week = weeklyOutcome?.week;
+    if (typeof week !== 'number' || week === lastPulsedWeekRef.current) return;
+    lastPulsedWeekRef.current = week;
+
+    const changes = Array.isArray(weeklyOutcome?.changes) ? weeklyOutcome.changes : [];
+    const chartUpdates = Array.isArray(weeklyOutcome?.chartUpdates) ? weeklyOutcome.chartUpdates : [];
+    const isNotable = (entry: any) =>
+      entry?.importance === 'hero'
+      || entry?.importance === 'notable'
+      || (entry?.importance === undefined && entry?.type === 'unlock');
+
+    const hasNotableMoment = changes.some(isNotable) || chartUpdates.some(isNotable);
+    if (hasNotableMoment) firePulse(6000);
+  }, [weeklyOutcome]);
+
+  useEffect(() => {
+    if (selectedActions.length > prevSelectedCountRef.current) {
+      firePulse(1000);
+    }
+    prevSelectedCountRef.current = selectedActions.length;
+  }, [selectedActions.length]);
+
+  useEffect(() => () => {
+    if (pulseTimeoutRef.current) clearTimeout(pulseTimeoutRef.current);
+  }, []);
 
   // Phase 4 PR-6: sound settings (mute + volume), independent of the motion
   // preference. Local state mirrors the audio manager's persisted settings so
@@ -265,6 +313,7 @@ export function CommandDock({ onShowSaveModal }: CommandDockProps) {
                 <HoloDisc
                   size={60}
                   spinSeconds={12}
+                  pulse={pulse}
                   className="relative"
                   style={{
                     boxShadow:

--- a/client/src/components/ui/holo-disc.test.tsx
+++ b/client/src/components/ui/holo-disc.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * HoloDisc pulse prop (Phase 4 PR-7 — ambient feedback).
+ *
+ * The primitive itself owns no timers: `pulse` is a pure on/off render prop.
+ * These tests only assert the halo element's presence/absence — duration and
+ * caller-driven timing are exercised in CommandDock.test.tsx.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { HoloDisc } from './holo-disc';
+
+describe('HoloDisc pulse halo', () => {
+  it('renders the pulse halo element when pulse=true', () => {
+    render(<HoloDisc pulse />);
+    expect(screen.getByTestId('holo-disc-pulse')).toBeInTheDocument();
+  });
+
+  it('does not render the pulse halo when pulse=false', () => {
+    render(<HoloDisc pulse={false} />);
+    expect(screen.queryByTestId('holo-disc-pulse')).not.toBeInTheDocument();
+  });
+
+  it('does not render the pulse halo by default (prop omitted)', () => {
+    render(<HoloDisc />);
+    expect(screen.queryByTestId('holo-disc-pulse')).not.toBeInTheDocument();
+  });
+
+  it('halo is aria-hidden (pure decoration, no a11y noise)', () => {
+    render(<HoloDisc pulse />);
+    expect(screen.getByTestId('holo-disc-pulse')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('halo uses the animate-ds-ring utility (disabled globally under prefers-reduced-motion)', () => {
+    render(<HoloDisc pulse />);
+    expect(screen.getByTestId('holo-disc-pulse').className).toContain('animate-ds-ring');
+  });
+});

--- a/client/src/components/ui/holo-disc.tsx
+++ b/client/src/components/ui/holo-disc.tsx
@@ -11,6 +11,15 @@ import { cn } from "@/lib/utils"
  *
  * Respects prefers-reduced-motion (the spin animation is disabled via the shared
  * `.animate-ds-spin` reduced-motion rule in index.css).
+ *
+ * Phase 4 PR-7: an optional `pulse` prop renders a `ds-ring`-style pulsing halo
+ * around the disc — pure ambient garnish for "something notable happened"
+ * moments. This primitive only renders the halo when `pulse` is true; it owns
+ * no timers or duration logic — the CALLER decides how long `pulse` stays true
+ * (e.g. CommandDock flips it on for ~6s after a hero/notable week). The halo is
+ * absolutely positioned so it never affects layout. Like the spin animation,
+ * `.animate-ds-ring` is disabled under `prefers-reduced-motion: reduce` by the
+ * shared rule in index.css (§10) — no extra guard is needed here.
  */
 export interface HoloDiscProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Diameter in px. */
@@ -22,17 +31,23 @@ export interface HoloDiscProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Vinyl dressing: concentric groove rings + specular highlight + inner darkening
    *  (splash-disc.html recipe). For large hero discs; too fine to read below ~100px. */
   grooves?: boolean
+  /** Render a pulsing halo ring around the disc (Phase 4 PR-7 ambient feedback).
+   *  Purely presentational on/off — the caller owns the duration. Default false. */
+  pulse?: boolean
 }
 
 const SPECTRUM =
   "repeating-conic-gradient(from 0deg at 50% 50%, #ff3d6e 0deg, #ff9a3d 22deg, #ffe14d 42deg, #57ff8f 66deg, #37d6ff 92deg, #4a6bff 118deg, #b45cff 146deg, #ff3d6e 180deg)"
 
 const HoloDisc = React.forwardRef<HTMLDivElement, HoloDiscProps>(
-  ({ size = 40, spinSeconds = 14, sheen = true, grooves = false, className, style, ...props }, ref) => {
+  (
+    { size = 40, spinSeconds = 14, sheen = true, grooves = false, pulse = false, className, style, ...props },
+    ref
+  ) => {
     return (
       <div
         ref={ref}
-        className={cn("relative shrink-0 overflow-hidden rounded-full", className)}
+        className={cn("relative shrink-0 overflow-visible rounded-full", className)}
         style={{
           width: size,
           height: size,
@@ -42,67 +57,88 @@ const HoloDisc = React.forwardRef<HTMLDivElement, HoloDiscProps>(
         }}
         {...props}
       >
-        {/* spectral spinning layer */}
-        <div
-          className="animate-ds-spin absolute inset-0"
-          style={{
-            background: SPECTRUM,
-            animationDuration: `${spinSeconds}s`,
-          }}
-        />
-        {/* optional brushed-sheen soft-light layer, slightly slower + reversed feel */}
-        {sheen && (
-          <div
-            className="animate-ds-spin absolute inset-0"
+        {/* pulsing halo ring (Phase 4 PR-7) — absolutely positioned outside the
+            disc's own bounds, bounded by the caller's `pulse` prop; no layout
+            shift (the halo overflows visually only, never affects flow), no
+            internal timer. Rendered first so it sits behind the disc content. */}
+        {pulse && (
+          <span
+            aria-hidden="true"
+            data-testid="holo-disc-pulse"
+            className="pointer-events-none absolute left-1/2 top-1/2 -z-10 animate-ds-ring rounded-full blur-[10px]"
             style={{
-              mixBlendMode: "soft-light",
-              opacity: 0.5,
+              width: size * 1.8,
+              height: size * 1.8,
+              marginLeft: -(size * 0.9),
+              marginTop: -(size * 0.9),
               background:
-                "conic-gradient(from 90deg at 50% 50%, rgba(255,255,255,0.6), rgba(255,255,255,0) 30%, rgba(255,255,255,0.5) 55%, rgba(255,255,255,0) 80%, rgba(255,255,255,0.6))",
-              animationDuration: `${spinSeconds * 1.6}s`,
+                "radial-gradient(circle, rgba(160,90,240,0.55) 0%, rgba(160,90,240,0.28) 42%, rgba(160,90,240,0) 72%)",
             }}
           />
         )}
-        {/* vinyl dressing: grooves + specular highlight + inner darkening */}
-        {grooves && (
-          <>
+        <div className="absolute inset-0 overflow-hidden rounded-full">
+          {/* spectral spinning layer */}
+          <div
+            className="animate-ds-spin absolute inset-0"
+            style={{
+              background: SPECTRUM,
+              animationDuration: `${spinSeconds}s`,
+            }}
+          />
+          {/* optional brushed-sheen soft-light layer, slightly slower + reversed feel */}
+          {sheen && (
             <div
-              className="absolute inset-0"
+              className="animate-ds-spin absolute inset-0"
               style={{
+                mixBlendMode: "soft-light",
+                opacity: 0.5,
                 background:
-                  "repeating-radial-gradient(circle at 50% 50%, rgba(0,0,0,0.16) 0px, rgba(0,0,0,0) 1.5px, rgba(0,0,0,0) 4px, rgba(0,0,0,0.1) 5.5px)",
+                  "conic-gradient(from 90deg at 50% 50%, rgba(255,255,255,0.6), rgba(255,255,255,0) 30%, rgba(255,255,255,0.5) 55%, rgba(255,255,255,0) 80%, rgba(255,255,255,0.6))",
+                animationDuration: `${spinSeconds * 1.6}s`,
               }}
             />
-            <div
-              className="absolute inset-0"
-              style={{
-                mixBlendMode: "screen",
-                background:
-                  "radial-gradient(circle at 40% 34%, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0) 34%)",
-              }}
-            />
-            <div
-              className="absolute inset-0"
-              style={{
-                background:
-                  "radial-gradient(circle at 50% 50%, rgba(5,3,8,0.65) 0%, rgba(5,3,8,0) 30%)",
-              }}
-            />
-          </>
-        )}
-        {/* dark spindle center */}
-        <div
-          className="absolute rounded-full"
-          style={{
-            top: "50%",
-            left: "50%",
-            width: "32%",
-            height: "32%",
-            margin: "-16% 0 0 -16%",
-            background: "#0a0814",
-            boxShadow: "inset 0 0 0 1px rgba(160,90,240,0.5)",
-          }}
-        />
+          )}
+          {/* vinyl dressing: grooves + specular highlight + inner darkening */}
+          {grooves && (
+            <>
+              <div
+                className="absolute inset-0"
+                style={{
+                  background:
+                    "repeating-radial-gradient(circle at 50% 50%, rgba(0,0,0,0.16) 0px, rgba(0,0,0,0) 1.5px, rgba(0,0,0,0) 4px, rgba(0,0,0,0.1) 5.5px)",
+                }}
+              />
+              <div
+                className="absolute inset-0"
+                style={{
+                  mixBlendMode: "screen",
+                  background:
+                    "radial-gradient(circle at 40% 34%, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0) 34%)",
+                }}
+              />
+              <div
+                className="absolute inset-0"
+                style={{
+                  background:
+                    "radial-gradient(circle at 50% 50%, rgba(5,3,8,0.65) 0%, rgba(5,3,8,0) 30%)",
+                }}
+              />
+            </>
+          )}
+          {/* dark spindle center */}
+          <div
+            className="absolute rounded-full"
+            style={{
+              top: "50%",
+              left: "50%",
+              width: "32%",
+              height: "32%",
+              margin: "-16% 0 0 -16%",
+              background: "#0a0814",
+              boxShadow: "inset 0 0 0 1px rgba(160,90,240,0.5)",
+            }}
+          />
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Phase 4 PR-7 (ambient feedback, per `[READY] phase-4-game-feel-plan.md` row 7) — the HoloDisc pulses briefly on significant week-advance events, plus a light acknowledgment when selecting an action. Deliberately last in the sequence: pure garnish, no gameplay effect.

### `client/src/components/ui/holo-disc.tsx`
- New optional `pulse?: boolean` prop. When true, renders a `ds-ring`-style pulsing halo (absolutely positioned, `-z-10`, `blur-[10px]`, radial purple glow) around the disc.
- The primitive owns **no timers** — it is a pure on/off render prop. The caller decides how long `pulse` stays true.
- No layout shift: the halo overflows the disc's box visually only (outer wrapper switched from `overflow-hidden` to `overflow-visible`, with a new inner `overflow-hidden` layer wrapping the existing spin/sheen/grooves/spindle content, so their clipping behavior is unchanged).
- Reduced motion: `.animate-ds-ring` is already disabled globally under `prefers-reduced-motion: reduce` (`index.css` §10, verified) — no extra guard needed in the primitive.

### `client/src/components/CommandDock.tsx`
- Reads `weeklyOutcome` and `selectedActions` from the Zustand store (session state, as directed).
- **Trigger map** (see table below). Both triggers share one `pulse` boolean and one timeout ref; a new trigger firing resets the timer (deliberately simple — "whichever fires last wins").
- Also fixes a latent bug exposed by the new test: `CommandDock.tsx` was missing its default `React` import (only named imports), which throws under jsdom's classic JSX transform. Trivial, safe, in-scope for this file.

| Trigger | Condition | Duration |
|---|---|---|
| Hero/notable week | New `weeklyOutcome` (by week number) where any `changes`/`chartUpdates` entry has `importance === 'hero' \| 'notable'`, or (no `importance` field) `type === 'unlock'` | ~6000ms |
| Action selected | `selectedActions.length` increases | ~1000ms |

Not touched: `WeekSummary.tsx`, `GameHeader.tsx`, `CampaignResultsModal.tsx`, `gameStore.ts`, `lib/audio.ts`, `motion-primitives/`. The sound-settings menu block and the WeekSummary modal block inside `CommandDock.tsx` are untouched — diff is limited to the import line, `selectedActions` destructure, the new pulse effects/state, and the `pulse` prop on the dock's `HoloDisc`.

## Test plan
- [x] `holo-disc.test.tsx` (5 tests): halo renders when `pulse`, absent when not/default, `aria-hidden`, uses `animate-ds-ring`.
- [x] `CommandDock.pulse.test.tsx` (7 tests, fake timers): pulses on hero change, pulses on notable chart update, falls back to `type: 'unlock'` when `importance` absent, does not pulse on routine-only outcome, does not re-pulse the same week twice, pulses ~1s on action-select growth, does not pulse on action-deselect (shrink).
- [x] `npx vitest run tests/client client/src` — 30 files / 258 tests passed (full client suite, includes the 12 new tests above).
- [x] `npm run check` — clean.

## Deviations
- Fixed the missing `React` default import in `CommandDock.tsx` (pre-existing, unrelated to this feature, only surfaced because this is the first test to render the component directly under jsdom's classic transform).
- `HoloDisc`'s outer wrapper div switched `overflow-hidden` → `overflow-visible` (with the previously-clipped content now in a new inner `overflow-hidden` layer) so the halo can extend past the disc's bounds without a layout-affecting wrapper. Visual output of the disc itself (spin/sheen/grooves/spindle) is unchanged.
- No live browser preview was run in this non-interactive session (no dev server config in the worktree); verification relied on the jsdom test suite plus code review, per the plan's PR-7 "Low risk / visual smoke" note — a manual preview pass is recommended before merge per the plan's general animation-PR guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)