### PR TITLE
fix(client): WeekSummary auto-open never fired (dead since month-to-week conversion)

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -33,7 +33,12 @@ export function Dashboard({
   useEffect(() => {
     // Only auto-show if this is a fresh weekly outcome (not from page refresh)
     if (weeklyOutcome && !isAdvancingWeek && gameState) {
-      const isCurrentWeekResult = weeklyOutcome.week === (gameState.currentWeek ?? 1) - 1;
+      // The engine stamps summary.week with the week being advanced TO and then
+      // increments currentWeek to that same value (game-engine.ts:156,172), so a
+      // fresh outcome satisfies week === currentWeek. The previous `- 1`
+      // comparison (carried over from the 2025 month->week conversion) could
+      // never be true, so this auto-open had been silently dead.
+      const isCurrentWeekResult = weeklyOutcome.week === (gameState.currentWeek ?? 1);
       const isNewResult = lastProcessedWeek !== weeklyOutcome.week;
 
       if (isCurrentWeekResult && isNewResult) {


### PR DESCRIPTION
Found during the Phase 4 live preview pass: the WeekSummary modal NEVER auto-opens after advancing a week — the player only ever sees results via More > Weekly Results.

Root cause: Dashboard.tsx compared weeklyOutcome.week === currentWeek - 1, but the engine stamps summary.week with the week being advanced TO and then increments currentWeek to that same value (game-engine.ts:156 and :172), so a fresh outcome satisfies week === currentWeek and the old comparison was mathematically always false. git log -L dates the off-by-one to the Sept 2025 month-to-week conversion (8e5cdbe) — dead for ~10 months, masked by the old sequential toasts (removed in #113 in favor of in-modal hero placement, which made this fix load-bearing).

Fix: compare against currentWeek, with a comment documenting the engine week semantics.

Verified live in the running app: advancing a week now auto-opens the modal and the full Phase 4 staged reveal plays (count-up, Milestone Moments, HoloDisc pulse) — screenshots in the session log. tsc clean. Note: no jsdom regression test included — Dashboard has no existing test harness and the predicate is live-verified; flagging test coverage for Dashboard as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)