### PR TITLE
fix(client): Phase 4 feel feedback - disc pulse visibility + one-shot auto-open

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -25,28 +25,20 @@ export function Dashboard({
   setShowSaveModal = () => {}
 }: DashboardProps) {
   const gameState = useGameState();
-  const { isAdvancingWeek, advanceWeek, weeklyOutcome, createProject } = useGameStore();
+  const { isAdvancingWeek, advanceWeek, weeklyOutcome, createProject, weeklyOutcomeAutoShow, consumeWeeklyOutcomeAutoShow } = useGameStore();
   const [, setLocation] = useLocation();
   const [showWeekSummary, setShowWeekSummary] = useState(false);
-  const [lastProcessedWeek, setLastProcessedWeek] = useState<number | null>(null);
 
   useEffect(() => {
-    // Only auto-show if this is a fresh weekly outcome (not from page refresh)
-    if (weeklyOutcome && !isAdvancingWeek && gameState) {
-      // The engine stamps summary.week with the week being advanced TO and then
-      // increments currentWeek to that same value (game-engine.ts:156,172), so a
-      // fresh outcome satisfies week === currentWeek. The previous `- 1`
-      // comparison (carried over from the 2025 month->week conversion) could
-      // never be true, so this auto-open had been silently dead.
-      const isCurrentWeekResult = weeklyOutcome.week === (gameState.currentWeek ?? 1);
-      const isNewResult = lastProcessedWeek !== weeklyOutcome.week;
-
-      if (isCurrentWeekResult && isNewResult) {
-        setShowWeekSummary(true);
-        setLastProcessedWeek(weeklyOutcome.week);
-      }
+    // Auto-open the results modal exactly ONCE per advance. The one-shot flag
+    // lives in the store (set by advanceWeek, cleared here) because component
+    // state resets on remount — the previous week-number dedupe re-popped the
+    // modal every time the player navigated back to the dashboard.
+    if (weeklyOutcome && !isAdvancingWeek && weeklyOutcomeAutoShow) {
+      setShowWeekSummary(true);
+      consumeWeeklyOutcomeAutoShow();
     }
-  }, [weeklyOutcome, isAdvancingWeek, gameState, lastProcessedWeek]);
+  }, [weeklyOutcome, isAdvancingWeek, weeklyOutcomeAutoShow, consumeWeeklyOutcomeAutoShow]);
 
   if (!gameState) {
     return (

--- a/client/src/components/ui/holo-disc.tsx
+++ b/client/src/components/ui/holo-disc.tsx
@@ -44,6 +44,11 @@ const HoloDisc = React.forwardRef<HTMLDivElement, HoloDiscProps>(
     { size = 40, spinSeconds = 14, sheen = true, grooves = false, pulse = false, className, style, ...props },
     ref
   ) => {
+    // While pulsing, the disc also spins ~4x faster — the speed change is the
+    // readable part of the reaction (the halo alone proved too subtle in play).
+    // Switching animation-duration snaps the rotation phase, but the snap is
+    // masked by the halo appearing in the same frame.
+    const effectiveSpinSeconds = pulse ? Math.max(0.8, spinSeconds / 4) : spinSeconds
     return (
       <div
         ref={ref}
@@ -65,24 +70,27 @@ const HoloDisc = React.forwardRef<HTMLDivElement, HoloDiscProps>(
           <span
             aria-hidden="true"
             data-testid="holo-disc-pulse"
-            className="pointer-events-none absolute left-1/2 top-1/2 -z-10 animate-ds-ring rounded-full blur-[10px]"
+            className="pointer-events-none absolute left-1/2 top-1/2 z-0 animate-ds-ring rounded-full blur-[10px]"
             style={{
-              width: size * 1.8,
-              height: size * 1.8,
-              marginLeft: -(size * 0.9),
-              marginTop: -(size * 0.9),
+              // transform-centered (not margin-centered) so the halo is dead
+              // behind the disc regardless of the parent's box; z-0 under the
+              // z-[1] disc face but NOT behind ancestor backgrounds (-z-10 let
+              // the dock's glass panel occlude it asymmetrically → looked off).
+              width: size * 2,
+              height: size * 2,
+              transform: "translate(-50%, -50%)",
               background:
-                "radial-gradient(circle, rgba(160,90,240,0.55) 0%, rgba(160,90,240,0.28) 42%, rgba(160,90,240,0) 72%)",
+                "radial-gradient(circle, rgba(180,92,255,0.85) 0%, rgba(160,90,240,0.45) 45%, rgba(160,90,240,0) 72%)",
             }}
           />
         )}
-        <div className="absolute inset-0 overflow-hidden rounded-full">
+        <div className="absolute inset-0 z-[1] overflow-hidden rounded-full">
           {/* spectral spinning layer */}
           <div
             className="animate-ds-spin absolute inset-0"
             style={{
               background: SPECTRUM,
-              animationDuration: `${spinSeconds}s`,
+              animationDuration: `${effectiveSpinSeconds}s`,
             }}
           />
           {/* optional brushed-sheen soft-light layer, slightly slower + reversed feel */}
@@ -94,7 +102,7 @@ const HoloDisc = React.forwardRef<HTMLDivElement, HoloDiscProps>(
                 opacity: 0.5,
                 background:
                   "conic-gradient(from 90deg at 50% 50%, rgba(255,255,255,0.6), rgba(255,255,255,0) 30%, rgba(255,255,255,0.5) 55%, rgba(255,255,255,0) 80%, rgba(255,255,255,0.6))",
-                animationDuration: `${spinSeconds * 1.6}s`,
+                animationDuration: `${effectiveSpinSeconds * 1.6}s`,
               }}
             />
           )}

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -348,7 +348,12 @@ interface GameStore {
   isAdvancingWeek: boolean;
   weeklyOutcome: any | null;
   campaignResults: any | null;
-  
+  /** One-shot: true only between an advanceWeek completing and the Dashboard
+   *  auto-opening the WeekSummary modal for it. Never persisted; load/restore
+   *  paths leave it false so a restored outcome doesn't pop the modal. */
+  weeklyOutcomeAutoShow: boolean;
+  consumeWeeklyOutcomeAutoShow: () => void;
+
   // Actions
   loadGame: (gameId: string) => Promise<void>;
   loadGameFromSave: (saveId: string, snapshot: GameSaveSnapshot, mode?: 'overwrite' | 'fork') => Promise<string>;
@@ -402,6 +407,13 @@ export const useGameStore = create<GameStore>()(
       isAdvancingWeek: false,
       weeklyOutcome: null,
       campaignResults: null,
+      weeklyOutcomeAutoShow: false,
+
+      // Phase 4 feel-feedback fix: the Dashboard consumes this one-shot flag to
+      // auto-open the WeekSummary modal exactly once per advance. The dedupe used
+      // to live in Dashboard component state, which reset on every remount and
+      // re-popped the modal each time the player navigated back to home.
+      consumeWeeklyOutcomeAutoShow: () => set({ weeklyOutcomeAutoShow: false }),
 
       // Load existing game
       loadGame: async (gameId: string) => {
@@ -536,6 +548,7 @@ export const useGameStore = create<GameStore>()(
             selectedActions: [],
             campaignResults: null,
             weeklyOutcome: snapshot.weeklyOutcome ?? null,
+            weeklyOutcomeAutoShow: false,
           });
 
           if (mode !== 'fork') {
@@ -578,6 +591,7 @@ export const useGameStore = create<GameStore>()(
             selectedActions: [],
             campaignResults: null,
             weeklyOutcome: snapshot.weeklyOutcome ?? null,
+            weeklyOutcomeAutoShow: false,
           });
 
           if (!syncedGameState.arOfficeSlotUsed) {
@@ -738,7 +752,8 @@ export const useGameStore = create<GameStore>()(
             moodEvents: [],
             selectedActions: [],
             campaignResults: null,
-            weeklyOutcome: null
+            weeklyOutcome: null,
+            weeklyOutcomeAutoShow: false
           });
 
           // Return the new game state so the UI can update
@@ -945,7 +960,8 @@ export const useGameStore = create<GameStore>()(
             weeklyOutcome: result.summary,
             campaignResults: result.campaignResults,
             selectedActions: [],
-            isAdvancingWeek: false
+            isAdvancingWeek: false,
+            weeklyOutcomeAutoShow: true
           });
 
           // Phase 4 PR-6: single week-advance/tier-unlock/hero-fanfare/


### PR DESCRIPTION
Two player-feedback fixes from the live playtest, both user-verified in the running app:

1. HoloDisc pulse was too subtle and the halo looked off-center: the disc now spins ~4x faster while pulsing (the readable part of the reaction), and the halo is transform-centered, brighter, and no longer occluded by the dock glass panel (z-0 under the disc face instead of -z-10 behind ancestor backgrounds).

2. WeekSummary auto-open re-popped every time the player navigated back to the dashboard: the dedupe lived in Dashboard component state, which resets on remount. Replaced with a one-shot weeklyOutcomeAutoShow flag in the session store — set only by advanceWeek, consumed by the Dashboard, explicitly false on load/restore/new-game paths so a restored outcome never pops the modal. Not persisted (partialize unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)