### PR TITLE
fix: C70 residual 12-week campaign copy rot (52-week game)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -89,7 +89,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use(gameLoopRouter);
 
   // OLD ENDPOINT REMOVED - Use /api/advance-week instead
-  // This endpoint did not have 12-week campaign completion logic
+  // This endpoint did not have campaign completion logic (52-week campaign; see
+  // data/balance/projects.json time_progression.campaign_length_weeks)
 
   // Save endpoints extracted to server/routes/saves.ts (PR-14)
   // Mounted at the original position of GET /api/saves to preserve registration order.

--- a/server/services/advanceWeekService.ts
+++ b/server/services/advanceWeekService.ts
@@ -189,7 +189,9 @@ export class AdvanceWeekService {
             accessTierBonus: 0
           },
           victoryType: gameState.money && gameState.money > 0 ? 'Survival' : 'Failure',
-          summary: 'Your 12-week campaign has ended. Time to start fresh!',
+          // C70: campaign length sourced from balance config (data/balance/projects.json
+          // time_progression.campaign_length_weeks, currently 52) — was stale "12-week" copy.
+          summary: `Your ${balanceConfig.time_progression.campaign_length_weeks}-week campaign has ended. Time to start fresh!`,
           achievements: ['📅 Campaign Completed']
         };
 

--- a/tests/endpoints/advance-week.characterization.test.ts
+++ b/tests/endpoints/advance-week.characterization.test.ts
@@ -197,6 +197,12 @@ describe('POST /api/advance-week (characterization)', () => {
     expect(res.body.campaignResults).toHaveProperty('finalScore');
     expect(res.body.campaignResults).toHaveProperty('scoreBreakdown');
     expect(res.body.campaignResults).toHaveProperty('victoryType');
+    // C70: summary copy must reflect the configured campaign length
+    // (data/balance/projects.json time_progression.campaign_length_weeks = 52),
+    // not the stale "12-week" text.
+    expect(res.body.campaignResults.summary).toBe(
+      'Your 52-week campaign has ended. Time to start fresh!'
+    );
     expect(res.body.summary).toHaveProperty('week');
 
     // Early return path persists the game state unchanged: week stays 52.


### PR DESCRIPTION
## Summary

Resolves technical-debt ledger item **C70** (residual "12-week campaign" copy rot outside AchievementsEngine — same rot class as C62 sub-item 3, found by the PR #120 Group-D verifier).

- `server/services/advanceWeekService.ts` — the campaign-completed early-return `campaignResults.summary` said "Your 12-week campaign has ended" in a 52-week game. Now sources the number from the balance config already loaded on the line above (`balanceConfig.time_progression.campaign_length_weeks`, i.e. `data/balance/projects.json`), so the copy can never rot again — one better than C62's hardcoded-with-comment approach, which was forced only because AchievementsEngine doesn't receive the balance config.
- `server/routes.ts` — historical comment updated (non-player-facing, same rot class).
- `tests/endpoints/advance-week.characterization.test.ts` — the existing campaign-completed early-return characterization test now pins the corrected summary string ("Your 52-week campaign has ended. Time to start fresh!").

No snapshots pinned the old copy (verified by repo-wide grep for `12-week`/`12 week`, including `__snapshots__`); the only other hits are docs/legacy and the C62 achievements test which asserts the *absence* of the stale copy.

## Test plan

- `npm run check` clean
- Full `npm run test:run` green: **127 files / 1334 tests passed** (Docker test DB on 5433)

🤖 Generated with [Claude Code](https://claude.com/claude-code)