### PR TITLE
fix: C72 ar_genre_shift copy overclaims roster size and genre

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -249,11 +249,11 @@
       "category": "talent",
       "target_scope": "global",
       "requires": ["artist_signed"],
-      "prompt": "Rock is dying in the charts. Should we push our guitar bands toward pop-rock crossover?",
+      "prompt": "The charts are moving away from our sound. Should we push toward what's trending?",
       "choices": [
         {
           "id": "chase_trends",
-          "label": "Follow the money - pivot to pop",
+          "label": "Follow the money - chase the trend",
           "effects_immediate": {
             "artist_mood": -3,
             "executive_mood": 8
@@ -265,7 +265,7 @@
         },
         {
           "id": "double_down_rock",
-          "label": "Double down - rock will come back",
+          "label": "Double down - our sound will come back",
           "effects_immediate": {
             "creative_capital": -2,
             "money": -5000
@@ -276,7 +276,7 @@
         },
         {
           "id": "gradual_evolution",
-          "label": "Gradual evolution - keep the rock soul",
+          "label": "Gradual evolution - keep our soul",
           "effects_immediate": {
             "money": -2000
           },

--- a/docs/01-planning/implementation-specs/REFERENCES AND ANALYSIS/[REFERENCE] executive-meetings-system-complete-reference.md
+++ b/docs/01-planning/implementation-specs/REFERENCES AND ANALYSIS/[REFERENCE] executive-meetings-system-complete-reference.md
@@ -85,7 +85,7 @@ Legend: **Imm** = `effects_immediate`, **Del** = `effects_delayed`. Money values
 | **ar_discovery** (global) — "I found our next superstar… her parents want creative control." | `accept_terms` | money −15000, creative_capital −3, executive_mood +8 | reputation +2, artist_mood −2 | Priciest, biggest exec-mood payoff, real artist-mood cost |
 | | `negotiate_compromise` | money −8000 | reputation +1, artist_mood +1 | Middle path — cheaper, smaller but positive payoff on both axes |
 | | `pass_on_talent` | reputation −1, executive_mood +2 | (none) | Free of money cost, but a guaranteed reputation hit |
-| **ar_genre_shift** (global) — "Rock is dying in the charts. Pivot to pop-rock?" | `chase_trends` | artist_mood −3, executive_mood +8 | awareness_boost +2, artist_mood −1 | Biggest awareness gain, biggest cumulative mood cost |
+| **ar_genre_shift** (global) — "The charts are moving away from our sound. Push toward what's trending?" | `chase_trends` | artist_mood −3, executive_mood +8 | awareness_boost +2, artist_mood −1 | Biggest awareness gain, biggest cumulative mood cost |
 | | `double_down_rock` | creative_capital −2, money −5000 | award_chances +1 | Only choice banking prestige; costliest immediate spend |
 | | `gradual_evolution` | money −2000 | awareness_boost +1, artist_mood +1 | Cheapest, smallest payoff, but net-positive mood |
 


### PR DESCRIPTION
## Summary
Resolves technical-debt ledger item **C72** (content-honesty wart in `data/actions.json`).

The `ar_genre_shift` meeting prompt said "our guitar bands" — plural AND genre-specific — while its relevance tag is the honest minimum `artist_signed` (one artist, any genre). A player with a single signed pop artist could be offered a meeting about "our guitar bands."

## Changes (copy only)
| Field | Before | After |
|---|---|---|
| prompt | Rock is dying in the charts. Should we push our guitar bands toward pop-rock crossover? | The charts are moving away from our sound. Should we push toward what's trending? |
| `chase_trends` label | Follow the money - pivot to pop | Follow the money - chase the trend |
| `double_down_rock` label | Double down - rock will come back | Double down - our sound will come back |
| `gradual_evolution` label | Gradual evolution - keep the rock soul | Gradual evolution - keep our soul |

No changes to `requires`, effects, choice ids/effect keys, or structure. Also synced the verbatim prompt quote in the executive-meetings reference doc (CLAUDE.md doc-sync rule). The ledger tick in technical-debt-backlog.md is handled separately by the orchestrator.

## Testing
- `npm run check` clean
- `npm run test:run` green: 127 files, 1334 tests passed (incl. data-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
