### PR TITLE
fix: C73 soften cco_creative_clash copy (recording-session overclaim)

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -335,14 +335,14 @@
       "name": "CCO: Creative Direction",
       "type": "role_meeting",
       "icon": "fas fa-sliders-h",
-      "description": "Resolve creative differences in production",
+      "description": "Resolve creative differences with an artist",
       "role_id": "cco",
       "meeting_id": "prod_creative_clash",
       "category": "production",
       "target_scope": "user_selected",
       "requires": ["artist_signed"],
       "prompt_before_selection": "Which artist is having creative differences?",
-      "prompt": "{artistName} wants to record everything live in one take. I think we need overdubs to compete.",
+      "prompt": "{artistName} wants to keep everything raw and unpolished—says that's the artistic identity. I think we need a more produced sound to compete.",
       "choices": [
         {
           "id": "artist_vision",
@@ -355,7 +355,7 @@
         },
         {
           "id": "producer_expertise",
-          "label": "Insist on professional overdubs",
+          "label": "Insist on a polished, professional sound",
           "effects_immediate": {
             "money": -3000,
             "artist_mood": -2,
@@ -367,7 +367,7 @@
         },
         {
           "id": "hybrid_approach",
-          "label": "Compromise - live basics, key overdubs",
+          "label": "Compromise - keep the raw edge, polish the hooks",
           "effects_immediate": {
             "money": -1500
           },

--- a/docs/01-planning/implementation-specs/REFERENCES AND ANALYSIS/[REFERENCE] executive-meetings-system-complete-reference.md
+++ b/docs/01-planning/implementation-specs/REFERENCES AND ANALYSIS/[REFERENCE] executive-meetings-system-complete-reference.md
@@ -96,7 +96,7 @@ Legend: **Imm** = `effects_immediate`, **Del** = `effects_delayed`. Money values
 | **cco_timeline** (global) — "Timeline is tight—what's the call?" | `rush` | money +1000, executive_mood −2 | quality_bonus **−5** | Trap-fixed: the windfall now costs real quality |
 | | `standard` | (none) | (none) | True no-op baseline |
 | | `add_revision` | money −1500 | quality_bonus +6, variance_up +1 | Biggest quality bank in the catalog, at a real cost |
-| **cco_creative_clash** (user_selected) — "{artist} wants to record live in one take; I want overdubs." | `artist_vision` | (none) | variance_up +1, artist_mood +2 | Free immediate cost; banks risk and artist goodwill |
+| **cco_creative_clash** (user_selected) — "{artist} wants to keep everything raw and unpolished; I want a more produced sound." | `artist_vision` | (none) | variance_up +1, artist_mood +2 | Free immediate cost; banks risk and artist goodwill |
 | | `producer_expertise` | money −3000, artist_mood −2, executive_mood +8 | quality_bonus +5 | Priciest on mood, but a clean quality payoff |
 | | `hybrid_approach` | money −1500 | quality_bonus +1, artist_mood +1 | Cheap compromise; smaller payoff on both axes |
 | **cco_budget_crisis** (global) — "We're over budget and the vocals still aren't right." | `demand_more_money` | money −10000, reputation +1 | quality_bonus +4 | Most expensive, but reputation AND quality both gain |


### PR DESCRIPTION
## Summary
Resolves technical-debt ledger item **C73** (content-honesty wart) via the **copy-softening** fix.

`cco_creative_clash` is a `user_selected` meeting (player picks the artist) whose `requires` tag is the honest minimum `artist_signed` — yet its copy had the chosen artist "want[ing] to record everything live in one take", presuming an active recording session the artist may not have. The copy is rewritten as a general creative-direction clash (raw/unpolished identity vs. a more produced sound) that reads true whether or not a recording project is active, keeping the CCO's voice and the artist-vs-producer tension.

## Changes (copy only)
| Field | Before | After |
|---|---|---|
| `description` | Resolve creative differences in production | Resolve creative differences with an artist |
| `prompt` | {artistName} wants to record everything live in one take. I think we need overdubs to compete. | {artistName} wants to keep everything raw and unpolished—says that's the artistic identity. I think we need a more produced sound to compete. |
| `producer_expertise` label | Insist on professional overdubs | Insist on a polished, professional sound |
| `hybrid_approach` label | Compromise - live basics, key overdubs | Compromise - keep the raw edge, polish the hooks |

Unchanged: `requires` tag, all effects, choice ids/effect keys, `artist_vision` label, and the artist picker (`MeetingSelector.tsx` — verified it hardcodes no copy). Reference doc `[REFERENCE] executive-meetings-system-complete-reference.md` row updated per the doc-sync rule.

## Road not taken
The alternative fix — restricting the artist picker and tightening the tag to `recording_project_active` — was deliberately **not** done; the orchestrator chose the lighter copy-softening option.

## Gates
- `npm run check` clean
- `npm run test:run`: 127 files / 1334 tests passed (incl. data-lint and meeting-dominance guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)