### PR TITLE
fix: Tier 2 playtest round 1 - engine-event week semantics + AUTO used-exec exclusion

### DIFF
--- a/client/src/components/executive-meetings/ExecutiveMeetings.tsx
+++ b/client/src/components/executive-meetings/ExecutiveMeetings.tsx
@@ -100,6 +100,24 @@ export function ExecutiveMeetings({
   const arOfficeStatusForInput = arOfficeStatusProp ?? getAROfficeStatus();
   const arOfficeSlotUsedInitial = !!arOfficeStatusForInput?.arOfficeSlotUsed;
 
+  // Track which executives have already been used this week (queued actions),
+  // computed BEFORE the machine mounts so AUTO's exclusion list is threaded in
+  // from the first render (playtest round-1 bug: manual Marcus pick + AUTO for
+  // the remaining slots re-proposed Marcus).
+  const usedExecutiveRoles = new Set<string>();
+  selectedActions.forEach(actionString => {
+    try {
+      const action = JSON.parse(actionString);
+      if (action.roleId) {
+        usedExecutiveRoles.add(action.roleId);
+      }
+    } catch (e) {
+      // Ignore invalid action strings
+    }
+  });
+  // Stable, order-independent key so effects don't re-fire on Set identity.
+  const usedExecutiveRolesKey = Array.from(usedExecutiveRoles).sort().join(',');
+
   const [state, send] = useMachine(executiveMeetingMachine, {
     input: {
       gameId,
@@ -107,6 +125,7 @@ export function ExecutiveMeetings({
       focusSlotsTotal: focusSlots.total,
       creativeCapital,
       arOfficeSlotUsed: arOfficeSlotUsedInitial,
+      usedExecutiveRoles: Array.from(usedExecutiveRoles),
       onActionSelected,
       fetchExecutives: cachedFetchExecutives,
       fetchRoleMeetings,
@@ -126,20 +145,8 @@ export function ExecutiveMeetings({
   const executivesLoading = state.matches('loadingExecutives') || state.matches('refreshingExecutives');
   const executivesError = context.error;
 
-  // Track which executives have already been used this week
-  const usedExecutiveRoles = new Set<string>();
-  selectedActions.forEach(actionString => {
-    try {
-      const action = JSON.parse(actionString);
-      if (action.roleId) {
-        usedExecutiveRoles.add(action.roleId);
-      }
-    } catch (e) {
-      // Ignore invalid action strings
-    }
-  });
-
-  // Helper to check if an executive has been used
+  // Helper to check if an executive has been used (set computed above the
+  // machine mount — see usedExecutiveRoles).
   const isExecutiveUsed = (role: string) => usedExecutiveRoles.has(role);
 
   useEffect(() => {
@@ -198,7 +205,8 @@ export function ExecutiveMeetings({
     };
   }, [gameId, currentWeek]);
 
-  // Sync focus slots (and the Creative Capital budget for AUTO) with the machine
+  // Sync focus slots (plus the Creative Capital budget and AUTO's exclusion
+  // lists — AR-busy and already-used roles) with the machine
   useEffect(() => {
     send({
       type: 'SYNC_SLOTS',
@@ -206,8 +214,10 @@ export function ExecutiveMeetings({
       total: focusSlots.total,
       creativeCapital,
       arOfficeSlotUsed,
+      usedExecutiveRoles: usedExecutiveRolesKey ? usedExecutiveRolesKey.split(',') : [],
     });
-  }, [focusSlots.used, focusSlots.total, creativeCapital, arOfficeSlotUsed, send]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- usedExecutiveRolesKey stands in for the Set (stable, order-independent)
+  }, [focusSlots.used, focusSlots.total, creativeCapital, arOfficeSlotUsed, usedExecutiveRolesKey, send]);
 
   // Sync current week with the machine (clears cache when week changes)
   useEffect(() => {

--- a/client/src/machines/executiveMeetingMachine.ts
+++ b/client/src/machines/executiveMeetingMachine.ts
@@ -53,6 +53,15 @@ export interface ExecutiveMeetingContext {
    * creativeCapital), read by the prepareAutoSelections actor.
    */
   arOfficeSlotUsed: boolean;
+  /**
+   * Roles that already have a queued action this week (manual picks or prior
+   * AUTO confirms). AUTO_SELECT must NOT re-propose them — the manual UI
+   * already disables their cards (`isExecutiveUsed`). Threaded in via
+   * SYNC_SLOTS (same channel as arOfficeSlotUsed), read by the
+   * prepareAutoSelections actor. Playtest round-1 bug (2026-07-05): manual
+   * Marcus pick + AUTO for the remaining slots re-proposed Marcus.
+   */
+  usedExecutiveRoles: string[];
   error: string | null;
   autoOptions: AutoOption[];
   impactPreview: {
@@ -77,7 +86,7 @@ export type ExecutiveMeetingEvent =
   | { type: 'BACK_TO_EXECUTIVES' }
   | { type: 'BACK_TO_MEETINGS' }
   | { type: 'RESET' }
-  | { type: 'SYNC_SLOTS'; used: number; total: number; creativeCapital?: number; arOfficeSlotUsed?: boolean }
+  | { type: 'SYNC_SLOTS'; used: number; total: number; creativeCapital?: number; arOfficeSlotUsed?: boolean; usedExecutiveRoles?: string[] }
   | { type: 'SYNC_WEEK'; currentWeek: number }
   | { type: 'AUTO_SELECT' }
   // Meeting-relevance PR-3 (AUTO Option A: propose-then-confirm). AUTO now
@@ -98,6 +107,8 @@ interface ExecutiveMeetingInput {
   creativeCapital?: number;
   /** A&R office slot in use → AUTO must not propose head_ar (see context field). */
   arOfficeSlotUsed?: boolean;
+  /** Roles with a queued action this week → AUTO must not re-propose them (see context field). */
+  usedExecutiveRoles?: string[];
   onActionSelected: (action: string) => void;
   fetchExecutives?: ExecutiveServices['fetchExecutives'];
   fetchRoleMeetings?: ExecutiveServices['fetchRoleMeetings'];
@@ -153,6 +164,9 @@ export const executiveMeetingMachine = setup({
               : {}),
             ...(typeof event.arOfficeSlotUsed === 'boolean'
               ? { arOfficeSlotUsed: event.arOfficeSlotUsed }
+              : {}),
+            ...(Array.isArray(event.usedExecutiveRoles)
+              ? { usedExecutiveRoles: event.usedExecutiveRoles }
               : {}),
           }
         : {}
@@ -390,6 +404,9 @@ export const executiveMeetingMachine = setup({
       // AUTO never proposes an exec the manual UI already blocks (playtest bug).
       const allOptions = prepareAutoSelectOptions(context.executives, meetingsByRole, {
         arOfficeSlotUsed: context.arOfficeSlotUsed,
+        // Already-used exclusion (playtest round-1): never re-propose an exec
+        // who already has a queued action this week.
+        usedExecutiveRoles: context.usedExecutiveRoles,
       });
       const topOptions = selectTopOptions(allOptions, slotsRemaining, context.creativeCapital);
 
@@ -504,6 +521,7 @@ export const executiveMeetingMachine = setup({
     focusSlotsTotal: input.focusSlotsTotal,
     creativeCapital: input.creativeCapital ?? Infinity,
     arOfficeSlotUsed: input.arOfficeSlotUsed ?? false,
+    usedExecutiveRoles: input.usedExecutiveRoles ?? [],
     error: null,
     autoOptions: [],
     impactPreview: { immediate: {}, delayed: {}, selectedChoices: [] },

--- a/client/src/services/executiveAutoSelect.ts
+++ b/client/src/services/executiveAutoSelect.ts
@@ -226,6 +226,15 @@ export function findEligibleMeeting(meetings: RoleMeeting[]): RoleMeeting | null
  */
 export interface PrepareAutoSelectOptionsConfig {
   arOfficeSlotUsed?: boolean;
+  /**
+   * Roles that already have a queued action this week (manual picks or prior
+   * AUTO confirms) — AUTO must NOT re-propose them. Playtest round-1 bug
+   * (2026-07-05): Nes picked Marcus manually, hit AUTO for the remaining
+   * slots, and AUTO proposed Marcus again. Mirrors the manual UI's
+   * `isExecutiveUsed` disable. Absent/empty = no exclusions (existing
+   * callers/tests unchanged).
+   */
+  usedExecutiveRoles?: readonly string[];
 }
 
 /**
@@ -249,6 +258,10 @@ export function prepareAutoSelectOptions(
     // AUTO must not propose him (manual UI already blocks him). Playtest bug: AUTO
     // grabbed Marcus while the A&R office slot was in use.
     if (config.arOfficeSlotUsed && executive.role === 'head_ar') continue;
+
+    // Already-used exclusion: an exec with a queued action this week can't
+    // meet twice — never re-propose them (manual UI already disables the card).
+    if (config.usedExecutiveRoles?.includes(executive.role)) continue;
 
     const meetings = meetingsByRole[executive.role] || [];
     // Meeting-relevance Tier 0 (PR-1): an exec whose eligible pool is empty

--- a/server/routes/executives.ts
+++ b/server/routes/executives.ts
@@ -66,20 +66,20 @@ router.get("/api/roles/:roleId", requireClerkUser, async (req, res) => {
             recencyWindowWeeks: tuning.recency_window_weeks,
           });
 
-          // Tier 2 (PR-1, dark launch): derive last week's happenings from
-          // persisted data — mood_events (week N-1) + chart_entries (week N-1,
-          // isDebut) — so the injection stage can offer a reactive meeting
-          // in place of the normal weighted draw. With zero authored
-          // reactive_trigger meetings in data/actions.json today, this never
-          // matches anything; the pipeline below falls through unchanged.
+          // Tier 2: derive fresh happenings from persisted data so the
+          // injection stage can offer a reactive meeting in place of the
+          // normal weighted draw. Engine-stamped events (mood_events,
+          // chart_entries, releases) carry the CURRENT week — they were
+          // written during the advance INTO this week (see the week-semantics
+          // note on deriveWeekHappenings; playtest round-1 fix, 2026-07-05:
+          // querying week N−1 here made release/chart/mood reactions land a
+          // decision phase late).
           const [moodEvents, chartEntries] = await Promise.all([
-            storage.getMoodEventsByWeekRange(gameId as string, weekNum - 1, weekNum - 1),
-            weekNum - 1 >= 1
-              ? storage.getChartEntriesByWeekAndGame(
-                  new Date(ChartService.generateChartWeekFromGameWeek(weekNum - 1)),
-                  gameId as string
-                )
-              : Promise.resolve([]),
+            storage.getMoodEventsByWeekRange(gameId as string, weekNum, weekNum),
+            storage.getChartEntriesByWeekAndGame(
+              new Date(ChartService.generateChartWeekFromGameWeek(weekNum)),
+              gameId as string
+            ),
           ]);
           const songsById = new Map(songs.map((s: any) => [s.id, s]));
           const happenings = deriveWeekHappenings(

--- a/shared/engine/weekHappenings.ts
+++ b/shared/engine/weekHappenings.ts
@@ -94,10 +94,12 @@ export interface DeriveWeekHappeningsInput {
   moodEvents: HappeningMoodEventInput[];
   /**
    * FRESHNESS CONTRACT: chart rows carry no game-week number (chart_entries
-   * stores a DATE `chartWeek`), so the CALLER must pass exactly the week-N−1
-   * chart snapshot — the route fetches it by
-   * `ChartService.generateChartWeekFromGameWeek(currentWeek - 1)`. All other
-   * inputs are week-filtered inside this function.
+   * stores a DATE `chartWeek`), so the CALLER must pass exactly the
+   * CURRENT week's chart snapshot — the route fetches it by
+   * `ChartService.generateChartWeekFromGameWeek(currentWeek)` (charts are an
+   * engine-stamped event class; see the week-semantics note on
+   * `deriveWeekHappenings`). All other inputs are week-filtered inside this
+   * function.
    */
   chartEntries: HappeningChartEntryInput[];
 }
@@ -123,44 +125,64 @@ export const MOOD_CRATER_THRESHOLD = 20;
 
 /**
  * Pure derivation: given plain rows and the CURRENT week, return every
- * happening whose underlying event occurred at exactly `currentWeek - 1`
- * (the strict 1-week freshness window — spec §1).
+ * happening in its freshest window — a strict ONE-week window per trigger
+ * (spec §1), but the window differs by the event's STAMP CLASS (playtest
+ * round-1 fix, 2026-07-05):
+ *
+ * - PLAYER-ACTION events (`recent_signing`) happen DURING a decision week and
+ *   are stamped with it (`artists.signedWeek` = the week the player signed).
+ *   The soonest they can be reacted to is the NEXT decision week, so the
+ *   window is `week === currentWeek - 1`.
+ * - ENGINE events (`release_out`, `chart_debut`, `mood_crater`) are processed
+ *   inside `advanceWeek` AFTER `currentWeek` increments (game-engine.ts:172),
+ *   so they are stamped with the week the player ARRIVES at
+ *   (`releases.releaseWeek`/`mood_events.weekOccurred` = post-increment week;
+ *   ReleaseProcessor.ts:1121, ArtistStateProcessor.ts:128). Their numbers are
+ *   in the WeekSummary the player reads at the START of `currentWeek`, so the
+ *   reactive decision belongs to `week === currentWeek` — the same decision
+ *   phase, not one later. (The original uniform `currentWeek - 1` window made
+ *   these fire a week late — Nes's playtest caught it.)
  */
 export function deriveWeekHappenings(
   input: DeriveWeekHappeningsInput,
   currentWeek: number
 ): WeekHappening[] {
-  const targetWeek = currentWeek - 1;
+  /** Window for player-action events (stamped with the prior decision week). */
+  const playerActionWeek = currentWeek - 1;
+  /** Window for engine events (stamped with the arrival week during advance). */
+  const engineEventWeek = currentWeek;
   const happenings: WeekHappening[] = [];
-  if (targetWeek < 0) return happenings;
+  if (currentWeek < 1) return happenings;
 
   const artistsById = new Map(input.artists.map((a) => [a.id, a]));
 
-  // recent_signing: artists.signedWeek === currentWeek - 1
+  // recent_signing: artists.signedWeek === currentWeek - 1 (player-action class)
   for (const artist of input.artists) {
-    if (artist.signedWeek === targetWeek) {
+    if (artist.signedWeek === playerActionWeek) {
       happenings.push({
         type: 'recent_signing',
-        week: targetWeek,
+        week: playerActionWeek,
         artistId: artist.id,
         artistName: artist.name ?? undefined,
       });
     }
   }
 
-  // release_out: releases.releaseWeek === currentWeek - 1 AND the release
-  // actually went out (status released/catalog — set by the engine's release
-  // pipeline). A stale still-'planned' release whose scheduled week slipped
-  // past must NOT read as "went out last week".
+  // release_out: releases.releaseWeek === currentWeek (engine class — the
+  // release went out during the advance INTO this week; its first numbers are
+  // in this week's summary) AND the release actually went out (status
+  // released/catalog — set by the engine's release pipeline). A stale
+  // still-'planned' release whose scheduled week slipped past must NOT read
+  // as "just went out".
   for (const release of input.releases) {
     if (
-      release.releaseWeek === targetWeek &&
+      release.releaseWeek === engineEventWeek &&
       (release.status === 'released' || release.status === 'catalog')
     ) {
       const artist = release.artistId ? artistsById.get(release.artistId) : undefined;
       happenings.push({
         type: 'release_out',
-        week: targetWeek,
+        week: engineEventWeek,
         releaseId: release.id,
         artistId: release.artistId ?? undefined,
         artistName: artist?.name ?? undefined,
@@ -168,25 +190,28 @@ export function deriveWeekHappenings(
     }
   }
 
-  // mood_crater: discrete mood_events rows at week N-1 whose mood straddles
-  // the boundary DOWNWARD (moodBefore > threshold >= moodAfter). See
-  // HappeningMoodEventInput doc comment for the derivation-completeness
+  // mood_crater: discrete mood_events rows at the CURRENT week (engine class —
+  // ArtistStateProcessor writes them during the advance INTO this week) whose
+  // mood straddles the boundary DOWNWARD (moodBefore > threshold >= moodAfter).
+  // See HappeningMoodEventInput doc comment for the derivation-completeness
   // narrowing this implements.
   for (const event of input.moodEvents) {
-    if (event.weekOccurred !== targetWeek) continue;
+    if (event.weekOccurred !== engineEventWeek) continue;
     if (event.moodBefore > MOOD_CRATER_THRESHOLD && event.moodAfter <= MOOD_CRATER_THRESHOLD) {
       const artist = artistsById.get(event.artistId);
       happenings.push({
         type: 'mood_crater',
-        week: targetWeek,
+        week: engineEventWeek,
         artistId: event.artistId,
         artistName: artist?.name ?? undefined,
       });
     }
   }
 
-  // chart_debut: chart_entries rows at week N-1 with isDebut === true
-  // (player songs only — competitor songs never set isDebut, ChartService.ts:326).
+  // chart_debut: chart_entries rows at the CURRENT week (engine class — the
+  // caller passes the currentWeek chart snapshot; charts generate during the
+  // advance INTO this week) with isDebut === true (player songs only —
+  // competitor songs never set isDebut, ChartService.ts:326).
   for (const entry of input.chartEntries) {
     if (entry.isCompetitorSong) continue;
     if (entry.isDebut !== true) continue;
@@ -194,7 +219,7 @@ export function deriveWeekHappenings(
     const artist = entry.artistId ? artistsById.get(entry.artistId) : undefined;
     happenings.push({
       type: 'chart_debut',
-      week: targetWeek,
+      week: engineEventWeek,
       songId: entry.songId,
       songTitle: entry.songTitle ?? undefined,
       artistId: entry.artistId ?? undefined,

--- a/tests/endpoints/roles-meeting-selection.characterization.test.ts
+++ b/tests/endpoints/roles-meeting-selection.characterization.test.ts
@@ -221,7 +221,7 @@ describe('GET /api/roles/:roleId — Tier 2 reactive injection (synthetic reacti
     });
   }
 
-  it('a mood_crater happening at week N-1 selects the synthetic reactive meeting and attaches reactiveContext', async () => {
+  it('a mood_crater happening this week (engine-stamped) selects the synthetic reactive meeting and attaches reactiveContext', async () => {
     injectSyntheticReactiveMeeting();
 
     const gameId = await seedGame();
@@ -236,8 +236,9 @@ describe('GET /api/roles/:roleId — Tier 2 reactive injection (synthetic reacti
       energy: 50,
       signed: true,
     });
-    // A discrete mood-lowering event straddling the crater threshold at week 4
-    // (so it fires for a week-5 request, freshness window N-1).
+    // A discrete mood-lowering event straddling the crater threshold at week 5
+    // — mood events are ENGINE-stamped (written during the advance INTO week 5),
+    // so the reaction window is the CURRENT week (playtest round-1 fix).
     await db.insert(moodEvents).values({
       artistId,
       gameId,
@@ -246,7 +247,7 @@ describe('GET /api/roles/:roleId — Tier 2 reactive injection (synthetic reacti
       moodBefore: MOOD_CRATER_THRESHOLD + 5,
       moodAfter: MOOD_CRATER_THRESHOLD,
       description: 'Test mood crater event',
-      weekOccurred: 4,
+      weekOccurred: 5,
     });
 
     const res = await request(app).get('/api/roles/cco').query({ gameId, week: '5' });
@@ -373,7 +374,7 @@ describe('GET /api/roles/:roleId — PR-2 real authored reactive meetings (no mo
     });
   });
 
-  it('cmo and ceo both offer their real chart_debut reactive meetings when a song debuted last week (cross-exec duplication permitted)', async () => {
+  it('cmo and ceo both offer their real chart_debut reactive meetings when a song just debuted (cross-exec duplication permitted)', async () => {
     const gameId = await seedGame();
     const artistId = crypto.randomUUID();
     await db.insert(artists).values({
@@ -395,7 +396,9 @@ describe('GET /api/roles/:roleId — PR-2 real authored reactive meetings (no mo
       quality: 70,
       isRecorded: true,
     });
-    const chartWeekDate = (await import('@shared/engine/ChartService')).ChartService.generateChartWeekFromGameWeek(4);
+    // Charts are ENGINE-stamped: the week-5 snapshot is what a week-5 request
+    // reacts to (playtest round-1 fix — was week 4, a phase late).
+    const chartWeekDate = (await import('@shared/engine/ChartService')).ChartService.generateChartWeekFromGameWeek(5);
     await db.insert(chartEntries).values({
       gameId,
       songId,
@@ -426,7 +429,7 @@ describe('GET /api/roles/:roleId — PR-2 real authored reactive meetings (no mo
     });
   });
 
-  it('head_distribution picks the real distribution_release_out_numbers meeting when a release went out last week', async () => {
+  it('head_distribution picks the real distribution_release_out_numbers meeting when a release just went out', async () => {
     const gameId = await seedGame();
     const artistId = crypto.randomUUID();
     await db.insert(artists).values({
@@ -455,7 +458,7 @@ describe('GET /api/roles/:roleId — PR-2 real authored reactive meetings (no mo
       title: 'Debut EP',
       type: 'ep',
       status: 'released',
-      releaseWeek: 4, // week-5 request → targetWeek 4 → fires
+      releaseWeek: 5, // engine-stamped: went out during the advance INTO week 5 → fires for a week-5 request
     });
 
     const res = await request(app).get('/api/roles/head_distribution').query({ gameId, week: '5' });
@@ -468,7 +471,7 @@ describe('GET /api/roles/:roleId — PR-2 real authored reactive meetings (no mo
     });
   });
 
-  it('cco picks the real cco_mood_crater_intervention meeting when an artist craters last week', async () => {
+  it('cco picks the real cco_mood_crater_intervention meeting when an artist just cratered', async () => {
     const gameId = await seedGame();
     const artistId = crypto.randomUUID();
     await db.insert(artists).values({
@@ -489,7 +492,7 @@ describe('GET /api/roles/:roleId — PR-2 real authored reactive meetings (no mo
       moodBefore: MOOD_CRATER_THRESHOLD + 5,
       moodAfter: MOOD_CRATER_THRESHOLD,
       description: 'Real catalog mood crater event',
-      weekOccurred: 4,
+      weekOccurred: 5, // engine-stamped during the advance INTO week 5
     });
 
     const res = await request(app).get('/api/roles/cco').query({ gameId, week: '5' });

--- a/tests/engine/weekHappenings.test.ts
+++ b/tests/engine/weekHappenings.test.ts
@@ -8,8 +8,18 @@ import {
 } from '@shared/engine/weekHappenings';
 
 /**
- * Tier 2 (PR-1) — unit tests for the pure happening-derivation function
+ * Tier 2 — unit tests for the pure happening-derivation function
  * (shared/engine/weekHappenings.ts). Pure, no DB.
+ *
+ * WEEK SEMANTICS (playtest round-1 fix, 2026-07-05 — direction pin): the
+ * freshness window differs by stamp class.
+ * - PLAYER-ACTION events (recent_signing) are stamped with the decision week
+ *   they happened in → window `week === currentWeek - 1`.
+ * - ENGINE events (release_out, chart_debut, mood_crater) are stamped with
+ *   the post-increment week during advance (game-engine.ts:172) — their
+ *   numbers are in the summary read at the START of currentWeek → window
+ *   `week === currentWeek`. The original uniform N−1 window made these fire
+ *   a decision phase late (Nes's playtest caught it).
  */
 
 const EMPTY_INPUT: DeriveWeekHappeningsInput = {
@@ -19,11 +29,11 @@ const EMPTY_INPUT: DeriveWeekHappeningsInput = {
   chartEntries: [],
 };
 
-describe('deriveWeekHappenings — freshness window', () => {
+describe('deriveWeekHappenings — freshness window (player-action class: recent_signing)', () => {
   it('week N-2 is excluded (too stale)', () => {
     const happenings = deriveWeekHappenings(
       { ...EMPTY_INPUT, artists: [{ id: 'a1', name: 'Artist', signedWeek: 3 }] },
-      6 // targetWeek = 5, signedWeek = 3 → excluded
+      6 // playerActionWeek = 5, signedWeek = 3 → excluded
     );
     expect(happenings).toEqual([]);
   });
@@ -37,7 +47,7 @@ describe('deriveWeekHappenings — freshness window', () => {
     expect(happenings[0]).toMatchObject({ type: 'recent_signing', week: 5, artistId: 'a1' });
   });
 
-  it('week N (this week) is excluded (not last week)', () => {
+  it('week N (this week) is excluded — a signing is a player action stamped with its decision week', () => {
     const happenings = deriveWeekHappenings(
       { ...EMPTY_INPUT, artists: [{ id: 'a1', name: 'Artist', signedWeek: 6 }] },
       6
@@ -45,8 +55,33 @@ describe('deriveWeekHappenings — freshness window', () => {
     expect(happenings).toEqual([]);
   });
 
-  it('currentWeek 0 or negative targetWeek never throws, returns empty', () => {
+  it('currentWeek 0 or negative never throws, returns empty', () => {
     expect(deriveWeekHappenings(EMPTY_INPUT, 0)).toEqual([]);
+  });
+});
+
+describe('deriveWeekHappenings — freshness window (engine class: currentWeek, not N-1)', () => {
+  it('an engine event stamped currentWeek IS included (release_out)', () => {
+    const happenings = deriveWeekHappenings(
+      { ...EMPTY_INPUT, releases: [{ id: 'r1', releaseWeek: 5, status: 'released' }] },
+      5
+    );
+    expect(happenings).toHaveLength(1);
+    expect(happenings[0]).toMatchObject({ type: 'release_out', week: 5 });
+  });
+
+  it('an engine event stamped N-1 is EXCLUDED — its reaction window was last week (direction pin)', () => {
+    const happenings = deriveWeekHappenings(
+      {
+        ...EMPTY_INPUT,
+        releases: [{ id: 'r1', releaseWeek: 4, status: 'released' }],
+        moodEvents: [
+          { artistId: 'a1', weekOccurred: 4, moodBefore: MOOD_CRATER_THRESHOLD + 5, moodAfter: MOOD_CRATER_THRESHOLD },
+        ],
+      },
+      5
+    );
+    expect(happenings).toEqual([]);
   });
 });
 
@@ -69,17 +104,17 @@ describe('deriveWeekHappenings — recent_signing', () => {
 });
 
 describe('deriveWeekHappenings — release_out', () => {
-  it('fires for a release whose releaseWeek is exactly last week, carries artist name via join', () => {
+  it('fires for a release whose releaseWeek is the CURRENT week (went out during the advance into it), carries artist name via join', () => {
     const happenings = deriveWeekHappenings(
       {
         ...EMPTY_INPUT,
         artists: [{ id: 'a1', name: 'Release Artist' }],
-        releases: [{ id: 'r1', releaseWeek: 4, artistId: 'a1', status: 'released' }],
+        releases: [{ id: 'r1', releaseWeek: 5, artistId: 'a1', status: 'released' }],
       },
       5
     );
     expect(happenings).toEqual([
-      { type: 'release_out', week: 4, releaseId: 'r1', artistId: 'a1', artistName: 'Release Artist' },
+      { type: 'release_out', week: 5, releaseId: 'r1', artistId: 'a1', artistName: 'Release Artist' },
     ]);
   });
 
@@ -93,15 +128,15 @@ describe('deriveWeekHappenings — release_out', () => {
 
   it('does NOT fire for a stale still-planned release whose week slipped past', () => {
     const happenings = deriveWeekHappenings(
-      { ...EMPTY_INPUT, releases: [{ id: 'r1', releaseWeek: 4, status: 'planned' }] },
+      { ...EMPTY_INPUT, releases: [{ id: 'r1', releaseWeek: 5, status: 'planned' }] },
       5
     );
     expect(happenings).toEqual([]);
   });
 
-  it('fires for a catalog-status release that went out last week', () => {
+  it('fires for a catalog-status release that went out this week', () => {
     const happenings = deriveWeekHappenings(
-      { ...EMPTY_INPUT, releases: [{ id: 'r1', releaseWeek: 4, status: 'catalog' }] },
+      { ...EMPTY_INPUT, releases: [{ id: 'r1', releaseWeek: 5, status: 'catalog' }] },
       5
     );
     expect(happenings).toHaveLength(1);
@@ -110,7 +145,7 @@ describe('deriveWeekHappenings — release_out', () => {
 });
 
 describe('deriveWeekHappenings — chart_debut', () => {
-  it('fires for a player song with isDebut true at week N-1', () => {
+  it('fires for a player song with isDebut true in the CURRENT week snapshot', () => {
     const happenings = deriveWeekHappenings(
       {
         ...EMPTY_INPUT,
@@ -122,7 +157,7 @@ describe('deriveWeekHappenings — chart_debut', () => {
       5
     );
     expect(happenings).toEqual([
-      { type: 'chart_debut', week: 4, songId: 's1', songTitle: 'Hit Single', artistId: 'a1', artistName: 'Chart Artist' },
+      { type: 'chart_debut', week: 5, songId: 's1', songTitle: 'Hit Single', artistId: 'a1', artistName: 'Chart Artist' },
     ]);
   });
 
@@ -147,19 +182,19 @@ describe('deriveWeekHappenings — chart_debut', () => {
 });
 
 describe('deriveWeekHappenings — mood_crater (boundary-straddle)', () => {
-  it('fires when moodBefore > threshold and moodAfter <= threshold (crossing INTO low band)', () => {
+  it('fires when moodBefore > threshold and moodAfter <= threshold (crossing INTO low band) in the CURRENT week', () => {
     const happenings = deriveWeekHappenings(
       {
         ...EMPTY_INPUT,
         artists: [{ id: 'a1', name: 'Burning Out' }],
         moodEvents: [
-          { artistId: 'a1', weekOccurred: 4, moodBefore: MOOD_CRATER_THRESHOLD + 5, moodAfter: MOOD_CRATER_THRESHOLD },
+          { artistId: 'a1', weekOccurred: 5, moodBefore: MOOD_CRATER_THRESHOLD + 5, moodAfter: MOOD_CRATER_THRESHOLD },
         ],
       },
       5
     );
     expect(happenings).toEqual([
-      { type: 'mood_crater', week: 4, artistId: 'a1', artistName: 'Burning Out' },
+      { type: 'mood_crater', week: 5, artistId: 'a1', artistName: 'Burning Out' },
     ]);
   });
 
@@ -168,7 +203,7 @@ describe('deriveWeekHappenings — mood_crater (boundary-straddle)', () => {
       {
         ...EMPTY_INPUT,
         moodEvents: [
-          { artistId: 'a1', weekOccurred: 4, moodBefore: MOOD_CRATER_THRESHOLD, moodAfter: MOOD_CRATER_THRESHOLD - 5 },
+          { artistId: 'a1', weekOccurred: 5, moodBefore: MOOD_CRATER_THRESHOLD, moodAfter: MOOD_CRATER_THRESHOLD - 5 },
         ],
       },
       5
@@ -181,7 +216,7 @@ describe('deriveWeekHappenings — mood_crater (boundary-straddle)', () => {
       {
         ...EMPTY_INPUT,
         moodEvents: [
-          { artistId: 'a1', weekOccurred: 4, moodBefore: MOOD_CRATER_THRESHOLD - 5, moodAfter: MOOD_CRATER_THRESHOLD + 5 },
+          { artistId: 'a1', weekOccurred: 5, moodBefore: MOOD_CRATER_THRESHOLD - 5, moodAfter: MOOD_CRATER_THRESHOLD + 5 },
         ],
       },
       5
@@ -214,16 +249,16 @@ describe('deriveWeekHappenings — mood_crater (boundary-straddle)', () => {
 });
 
 describe('deriveWeekHappenings — multiple simultaneous happenings', () => {
-  it('returns one entry per distinct happening in the same week', () => {
+  it('returns one entry per distinct happening in the same decision phase (mixed stamp classes)', () => {
     const happenings = deriveWeekHappenings(
       {
         artists: [
-          { id: 'a1', name: 'Signee', signedWeek: 4 },
+          { id: 'a1', name: 'Signee', signedWeek: 4 }, // player action: last week
           { id: 'a2', name: 'Craterer' },
         ],
-        releases: [{ id: 'r1', releaseWeek: 4, artistId: 'a1', status: 'released' }],
+        releases: [{ id: 'r1', releaseWeek: 5, artistId: 'a1', status: 'released' }], // engine: this week
         moodEvents: [
-          { artistId: 'a2', weekOccurred: 4, moodBefore: MOOD_CRATER_THRESHOLD + 1, moodAfter: MOOD_CRATER_THRESHOLD },
+          { artistId: 'a2', weekOccurred: 5, moodBefore: MOOD_CRATER_THRESHOLD + 1, moodAfter: MOOD_CRATER_THRESHOLD },
         ],
         chartEntries: [{ songId: 's1', artistId: 'a1', isDebut: true }],
       },

--- a/tests/unit/executiveAutoSelect.test.ts
+++ b/tests/unit/executiveAutoSelect.test.ts
@@ -187,6 +187,34 @@ describe('prepareAutoSelectOptions — AR-busy exclusion (playtest bug: AUTO gra
     const options = prepareAutoSelectOptions([arExec, cmoExec], meetingsByRole);
     expect(options.some((o) => o.executive.role === 'head_ar')).toBe(true);
   });
+
+  // Playtest round-1 (2026-07-05): Nes picked Marcus manually, hit AUTO for
+  // the remaining slots, and AUTO proposed Marcus again — execs with a queued
+  // action this week must never be re-proposed (mirrors the manual UI's
+  // isExecutiveUsed disable).
+  it('excludes execs already used this week via usedExecutiveRoles', () => {
+    const options = prepareAutoSelectOptions([arExec, cmoExec], meetingsByRole, {
+      usedExecutiveRoles: ['head_ar'],
+    });
+    expect(options.some((o) => o.executive.role === 'head_ar')).toBe(false);
+    expect(options.some((o) => o.executive.role === 'cmo')).toBe(true);
+  });
+
+  it('empty usedExecutiveRoles excludes nobody', () => {
+    const options = prepareAutoSelectOptions([arExec, cmoExec], meetingsByRole, {
+      usedExecutiveRoles: [],
+    });
+    expect(options.some((o) => o.executive.role === 'head_ar')).toBe(true);
+    expect(options.some((o) => o.executive.role === 'cmo')).toBe(true);
+  });
+
+  it('used-roles and AR-busy exclusions compose', () => {
+    const options = prepareAutoSelectOptions([arExec, cmoExec], meetingsByRole, {
+      arOfficeSlotUsed: true,
+      usedExecutiveRoles: ['cmo'],
+    });
+    expect(options).toEqual([]);
+  });
 });
 
 describe('getChoiceCreativeCapitalCost', () => {


### PR DESCRIPTION
Two live-playtest findings from Nes, both root-caused:

1. **Reactions landed a decision phase late** (release_out/chart_debut/mood_crater). `currentWeek` increments at the top of `advanceWeek`, so engine events are stamped with the arrival week — the summary you read at the start of week N contains week-N-stamped events. The derivation now uses per-stamp-class windows: `recent_signing` (player action) keeps N−1; engine events use `currentWeek`. Direction-pinned in both directions so neither regression can slip back silently.

2. **AUTO re-proposed an already-picked exec** (manual Marcus pick → AUTO for remaining slots → Marcus proposed again). `usedExecutiveRoles` now threads through `SYNC_SLOTS` into the machine (same channel as the #126 `arOfficeSlotUsed` fix) and `prepareAutoSelectOptions` excludes them.

Gates: tsc clean; suite 1,398 → 1,403 green; golden master double-run zero deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)