### PR TITLE
feat: Tier 2 PR-3 - side events live: seeded selection, pending/lapse, choice endpoint

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -5,6 +5,7 @@
     {
       "id": "sync_offer",
       "role_hint": "Sync Licensing",
+      "category": "sync_licensing",
       "prompt": "A blockbuster film wants your upcoming single for a key scene.",
       "choices": [
         {
@@ -41,6 +42,7 @@
     {
       "id": "copyright_claim",
       "role_hint": "Copyright Lawyer",
+      "category": "copyright_issues",
       "prompt": "A plagiarism claim hits on release week.",
       "choices": [
         {
@@ -78,6 +80,7 @@
     {
       "id": "data_anomaly",
       "role_hint": "Data Analyst",
+      "category": "platform_opportunities",
       "prompt": "Streams spike in a random midwest city overnight.",
       "choices": [
         {
@@ -113,6 +116,7 @@
     {
       "id": "critic_surprise",
       "role_hint": "Music Critic",
+      "category": "industry_drama",
       "prompt": "A respected critic wants an early listen.",
       "choices": [
         {
@@ -146,6 +150,7 @@
     {
       "id": "platform_beta",
       "role_hint": "Platform Dev",
+      "category": "platform_opportunities",
       "prompt": "A platform offers a discovery beta slot.",
       "choices": [
         {
@@ -176,6 +181,7 @@
     {
       "id": "royalty_discrepancy",
       "role_hint": "Royalty Collector",
+      "category": "business_opportunities",
       "prompt": "A payout report looks off.",
       "choices": [
         {
@@ -209,6 +215,7 @@
     {
       "id": "wardrobe_malfunction",
       "role_hint": "Stylist",
+      "category": "industry_drama",
       "prompt": "Wardrobe malfunction at a televised show.",
       "choices": [
         {
@@ -243,6 +250,7 @@
     {
       "id": "ad_backlash",
       "role_hint": "Advertiser",
+      "category": "business_opportunities",
       "prompt": "Sponsorship offer from a controversial brand.",
       "choices": [
         {
@@ -278,6 +286,7 @@
     {
       "id": "lighting_blackout",
       "role_hint": "Lighting Tech",
+      "category": "technical_problems",
       "prompt": "Blackout mid‑performance—crew improvises.",
       "choices": [
         {
@@ -311,6 +320,7 @@
     {
       "id": "street_team_rogue",
       "role_hint": "Street Team",
+      "category": "industry_drama",
       "prompt": "Rogue flyers cause minor PR trouble.",
       "choices": [
         {
@@ -342,6 +352,7 @@
     {
       "id": "merch_fail",
       "role_hint": "Merch Buyer",
+      "category": "technical_problems",
       "prompt": "A batch of shirts arrives misprinted before a show.",
       "choices": [
         {
@@ -379,6 +390,7 @@
     {
       "id": "content_takedown",
       "role_hint": "Content Moderator",
+      "category": "copyright_issues",
       "prompt": "A false takedown hits your single.",
       "choices": [
         {

--- a/server/data/gameData.ts
+++ b/server/data/gameData.ts
@@ -750,12 +750,27 @@ export class ServerGameData {
         max_per_year: 12
       };
     }
-    
+
     const events = this.balanceData.side_events;
     return {
       weekly_chance: events.weekly_chance,
       cooldown_weeks: events.event_cooldown,
       max_per_year: events.max_events_per_week * 12
+    };
+  }
+
+  /**
+   * Tier 2 (PR-3): the weighted-selection config for on-hit side-event picks —
+   * category weights + cooldown from data/balance/events.json side_events.
+   * Consumed by selectSideEvent (shared/engine/sideEventSelection.ts). Falls
+   * back to the authored defaults when balance data has not loaded (the on-hit
+   * path is dark in the golden master, so the fallback never affects it).
+   */
+  getSideEventsConfigSync(): { event_weights: Record<string, number>; event_cooldown: number } {
+    const events = this.balanceData?.side_events;
+    return {
+      event_weights: (events?.event_weights as Record<string, number>) ?? {},
+      event_cooldown: (events?.event_cooldown as number) ?? 2,
     };
   }
 

--- a/server/routes/artists.ts
+++ b/server/routes/artists.ts
@@ -386,9 +386,14 @@ router.post("/api/game/:gameId/artist-dialogue", requireClerkUser, requireGameOw
 
       // 5. Store delayed effects on flags (global — no single target artist),
       //    drained by processDelayedEffects at triggerWeek === currentWeek.
+      //    Key is DETERMINISTIC (week-based, like the dialogue/meeting banked
+      //    keys) — never Date.now(): flags land in save snapshots and the
+      //    engine's determinism discipline expects byte-identical state for
+      //    identical play. Collisions are impossible: one pending event per
+      //    week, cleared on resolve.
       const effectsDelayed = choice.effects_delayed || {};
       if (Object.keys(effectsDelayed).length > 0) {
-        const delayedKey = `side-event-${eventId}-${choiceId}-${Date.now()}`;
+        const delayedKey = `side-event-${eventId}-${choiceId}-week${currentWeek}`;
         nextFlags[delayedKey] = {
           triggerWeek: currentWeek + 1,
           effects: effectsDelayed,

--- a/server/routes/artists.ts
+++ b/server/routes/artists.ts
@@ -11,6 +11,7 @@ import { artistService, ArtistServiceError } from '../services/artistService';
 import {
   ArtistDialogueRequestSchema,
   ArtistDialogueResponse,
+  SideEventChoiceRequestSchema,
 } from '@shared/api/contracts';
 
 const router = Router();
@@ -253,6 +254,170 @@ router.post("/api/game/:gameId/artist-dialogue", requireClerkUser, requireGameOw
     } catch (error) {
       console.error('[API] Failed to fetch mood events:', error);
       res.status(500).json({ message: 'Failed to fetch mood events' });
+    }
+  });
+
+  // ========================================
+  // Side Event Choice Endpoint (Tier 2, PR-3)
+  // ========================================
+  //
+  // Resolves the pending side event the engine set on a hit
+  // (game-engine.ts checkForEvents → flags.pending_side_event). Effects apply at
+  // CHOICE-TIME, OUTSIDE the week transaction — the artist-dialogue immediate
+  // path (this file, POST /artist-dialogue above) is the precedent this mirrors:
+  // label-level keys patch gameState, delayed effects bank onto flags with a
+  // triggerWeek for processDelayedEffects to drain.
+  //
+  // ARTIST-MOOD TARGETING: side events are LABEL-LEVEL — there is no single
+  // target artist the way the dialogue path has one. Artist-scoped keys
+  // (artist_mood / artist_energy / artist_popularity) therefore apply to ALL
+  // signed artists, mirroring the executive-meeting `global` target_scope
+  // (ActionProcessor applies global artist effects across the whole roster). A
+  // mood_event row is logged per artist whenever artist_mood is touched, matching
+  // how the mood system records discrete mood changes elsewhere.
+  router.post("/api/game/:gameId/side-event-choice", requireClerkUser, requireGameOwner, async (req, res) => {
+    try {
+      const { gameId } = req.params;
+
+      const validationResult = SideEventChoiceRequestSchema.safeParse(req.body);
+      if (!validationResult.success) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid request data",
+          details: validationResult.error.errors,
+        });
+      }
+
+      const { eventId, choiceId } = validationResult.data;
+      const gameState = req.gameState!;
+      const currentWeek = gameState.currentWeek ?? 0;
+      const flags = (gameState.flags || {}) as Record<string, any>;
+
+      // 1. Validate a matching pending event exists for the CURRENT week.
+      const pending = flags.pending_side_event as { eventId: string; week: number } | undefined;
+      if (!pending || pending.eventId !== eventId || pending.week !== currentWeek) {
+        return res.status(409).json({
+          success: false,
+          message: "No matching pending side event for this game's current week",
+        });
+      }
+
+      // 2. Load the event + the chosen choice.
+      await serverGameData.initialize();
+      const event = await serverGameData.getEventById(eventId);
+      if (!event) {
+        return res.status(400).json({ success: false, message: "Unknown side event" });
+      }
+      const choice = event.choices.find((c) => c.id === choiceId);
+      if (!choice) {
+        return res.status(400).json({ success: false, message: "Invalid side event choice" });
+      }
+
+      const clamp = (value: number, min: number, max: number): number =>
+        Math.max(min, Math.min(max, value));
+
+      // 3. Apply immediate effects at choice-time.
+      const effectsImmediate = choice.effects_immediate || {};
+      const effectsApplied: Record<string, number> = {};
+      const gamePatch: Record<string, number> = {};
+
+      // Artist-scoped keys apply to ALL signed artists (label-level / global scope).
+      const artistScopedKeys = ['artist_mood', 'artist_energy', 'artist_popularity'];
+      const hasArtistEffect = Object.keys(effectsImmediate).some((k) => artistScopedKeys.includes(k));
+      const signedArtists = hasArtistEffect ? await storage.getArtistsByGame(gameId) : [];
+
+      for (const [effectKey, rawValue] of Object.entries(effectsImmediate)) {
+        if (typeof rawValue !== 'number') continue;
+        const effectValue = Number(rawValue);
+
+        if (effectKey === 'money') {
+          gamePatch.money = (gameState.money ?? 0) + effectValue;
+          effectsApplied[effectKey] = effectValue;
+        } else if (effectKey === 'reputation') {
+          gamePatch.reputation = clamp((gameState.reputation ?? 0) + effectValue, 0, 100);
+          effectsApplied[effectKey] = effectValue;
+        } else if (effectKey === 'creative_capital') {
+          gamePatch.creativeCapital = (gameState.creativeCapital ?? 0) + effectValue;
+          effectsApplied[effectKey] = effectValue;
+        } else if (effectKey === 'artist_mood') {
+          for (const artist of signedArtists) {
+            const before = artist.mood ?? 50;
+            const after = clamp(before + effectValue, 0, 100);
+            await storage.updateArtist(artist.id, { mood: after });
+            // Log a mood_event per artist (side events are label-level, so the
+            // discrete change is recorded once per affected artist).
+            await storage.createMoodEvent({
+              artistId: artist.id,
+              gameId,
+              eventType: 'side_event',
+              moodChange: after - before,
+              moodBefore: before,
+              moodAfter: after,
+              description: `Side event: ${event.prompt.substring(0, 60)}`,
+              weekOccurred: currentWeek,
+              metadata: { eventId, choiceId },
+            } as any);
+          }
+          effectsApplied[effectKey] = effectValue;
+        } else if (effectKey === 'artist_energy') {
+          for (const artist of signedArtists) {
+            const before = artist.energy ?? 50;
+            const after = clamp(before + effectValue, 0, 100);
+            await storage.updateArtist(artist.id, { energy: after });
+          }
+          effectsApplied[effectKey] = effectValue;
+        } else if (effectKey === 'artist_popularity') {
+          for (const artist of signedArtists) {
+            const before = artist.popularity ?? 50;
+            const after = clamp(before + effectValue, 0, 100);
+            await storage.updateArtist(artist.id, { popularity: after });
+          }
+          effectsApplied[effectKey] = effectValue;
+        }
+        // Any other authored key (press_momentum, quality_bonus, awareness_boost,
+        // variance_up, ...) is a banked/delayed channel — it is not an immediate
+        // gameState mutation, so it is intentionally not applied here. Authoring
+        // routes those through effects_delayed (below); the data-lint guard keeps
+        // all keys canonical.
+      }
+
+      // 4. Apply batched game-state patch.
+      const nextFlags = { ...flags };
+
+      // 5. Store delayed effects on flags (global — no single target artist),
+      //    drained by processDelayedEffects at triggerWeek === currentWeek.
+      const effectsDelayed = choice.effects_delayed || {};
+      if (Object.keys(effectsDelayed).length > 0) {
+        const delayedKey = `side-event-${eventId}-${choiceId}-${Date.now()}`;
+        nextFlags[delayedKey] = {
+          triggerWeek: currentWeek + 1,
+          effects: effectsDelayed,
+        };
+      }
+
+      // 6. Clear the pending event (resolved).
+      delete nextFlags.pending_side_event;
+
+      await storage.updateGameState(gameId, {
+        ...(Object.keys(gamePatch).length > 0 ? gamePatch : {}),
+        flags: nextFlags as any,
+      } as any);
+
+      const response = {
+        success: true,
+        eventId,
+        choiceId,
+        effects: effectsApplied,
+        delayedEffects: effectsDelayed,
+        message: "Side event resolved",
+      };
+      res.json(response);
+    } catch (error) {
+      console.error('Failed to process side event choice:', error);
+      res.status(500).json({
+        success: false,
+        message: error instanceof Error ? error.message : "Failed to process side event choice",
+      });
     }
   });
 

--- a/shared/api/contracts.ts
+++ b/shared/api/contracts.ts
@@ -307,6 +307,30 @@ export const ArtistDialogueResponseSchema = z.object({
 export type ArtistDialogueRequest = z.infer<typeof ArtistDialogueRequestSchema>;
 export type ArtistDialogueResponse = z.infer<typeof ArtistDialogueResponseSchema>;
 
+// ============================================================================
+// Side Event Choice (Tier 2, PR-3)
+// ============================================================================
+// Resolution endpoint for the pending side event set by the engine on a hit
+// (game-engine.ts checkForEvents). Effects apply at CHOICE-TIME, outside the
+// week transaction, mirroring the artist-dialogue immediate path.
+
+export const SideEventChoiceRequestSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  choiceId: z.string().min(1, "Choice ID is required"),
+});
+
+export const SideEventChoiceResponseSchema = z.object({
+  success: z.boolean(),
+  eventId: z.string(),
+  choiceId: z.string(),
+  effects: z.record(z.number()),
+  delayedEffects: z.record(z.number()),
+  message: z.string(),
+});
+
+export type SideEventChoiceRequest = z.infer<typeof SideEventChoiceRequestSchema>;
+export type SideEventChoiceResponse = z.infer<typeof SideEventChoiceResponseSchema>;
+
 // Backward compatibility - keep existing routes for now
 export const API_ROUTES = {
   GAME_STATE: '/api/game-state',

--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -19,6 +19,7 @@ import { AchievementsEngine } from './AchievementsEngine';
 import type { WeekSummary, ChartUpdate, GameChange, EventOccurrence, GameArtist } from '../types/gameTypes';
 import { ArtistChangeHelpers } from '../types/gameTypes';
 import { getSeasonFromWeek, getSeasonalMultiplier } from '../utils/seasonalCalculations';
+import { selectSideEvent } from './sideEventSelection';
 import { classifyChange, classifyChartUpdate } from '../utils/changeImportance';
 import { AROfficeProcessor } from './processors/AROfficeProcessor';
 import { ProgressionProcessor } from './processors/ProgressionProcessor';
@@ -959,21 +960,64 @@ export class GameEngine {
   }
 
   /**
-   * Checks for random events based on probability
+   * Checks for random side events based on probability (Tier 2, PR-3).
+   *
+   * LAPSE first (spec §3): a pending_side_event left unresolved from a PRIOR
+   * week is cleared here with NO effects — "the moment passed." This runs BEFORE
+   * the weekly roll so lapsing never consumes the new week's roll.
+   *
+   * ROLL unchanged (fork D1, spec §0 constraint 2): the in-stream getRandom(0,1)
+   * draw stays at the SAME position in the RNG stream — removing/moving it would
+   * shift every downstream engine roll and break the golden master.
+   *
+   * ON HIT: event SELECTION moves to an ISOLATED seed (closing ledger C64) via
+   * selectSideEvent — weighted by category, excluding events within their
+   * cooldown. On a selection, we (a) set flags.pending_side_event, (b) stamp
+   * flags.side_event_history[eventId], and (c) push the FULL event payload into
+   * summary.events so PR-4's UI can render the beat from the weekly outcome. If
+   * the cooldown filter empties the pool, no event fires this week.
+   *
+   * WEEK SEMANTICS: this.gameState.currentWeek here is the post-increment
+   * ARRIVAL week; the pending event belongs to (and is consumed during) that
+   * same week.
    */
   private async checkForEvents(summary: WeekSummary): Promise<void> {
+    const currentWeek = this.gameState.currentWeek || 0;
+    const flags = (this.gameState.flags || {}) as Record<string, any>;
+    this.gameState.flags = flags;
+
+    // --- LAPSE: clear a stale pending event from a prior week (no effects). ---
+    const pending = flags.pending_side_event as { eventId: string; week: number } | undefined;
+    if (pending && typeof pending.week === 'number' && pending.week < currentWeek) {
+      console.log(`[SIDE EVENT] Lapsing unresolved event "${pending.eventId}" from week ${pending.week} (now week ${currentWeek})`);
+      delete flags.pending_side_event;
+    }
+
     const eventConfig = this.gameData.getEventConfigSync();
-    
+
     if (this.getRandom(0, 1) < eventConfig.weekly_chance) {
-      // Trigger an event
-      const event = await this.gameData.getRandomEvent();
+      // --- HIT: select WHICH event on an isolated seed (weighted + cooldown). ---
+      const events = await this.gameData.getAllEvents();
+      const selectionConfig = this.gameData.getSideEventsConfigSync();
+      const history = (flags.side_event_history || {}) as Record<string, number>;
+
+      const event = selectSideEvent(events, selectionConfig, history, currentWeek, this.gameState.id);
       if (event) {
+        // Persist pending event + cooldown stamp (additive flags keys only).
+        flags.side_event_history = { ...history, [event.id]: currentWeek };
+        flags.pending_side_event = { eventId: event.id, week: currentWeek };
+
+        // Push the FULL payload so PR-4 can render the beat from the outcome.
         summary.events.push({
           id: event.id,
           title: event.prompt.substring(0, 50),
-          occurred: true
+          occurred: true,
+          category: event.category,
+          prompt: event.prompt,
+          choices: event.choices,
         });
       }
+      // Empty pool (all events on cooldown) → no event fires this week.
     }
   }
 

--- a/shared/engine/sideEventSelection.ts
+++ b/shared/engine/sideEventSelection.ts
@@ -1,0 +1,75 @@
+/**
+ * Tier 2 (PR-3) — pure side-event selection (isolated seed, weighted, cooldown).
+ *
+ * Sibling of meetingSelection.ts: storage-free so the engine, the ServerGameData
+ * facade, and unit tests share ONE implementation. The WEEKLY ROLL that decides
+ * whether ANY event fires stays in the engine's RNG stream
+ * (game-engine.ts checkForEvents — fork D1, spec §0 constraint 2); this module
+ * only runs AFTER that roll hits and picks WHICH event, on an isolated seed
+ * (`${gameId}-week${week}-sideEvent`) via seededWeightedPick — closing ledger
+ * C64 (the unseeded Math.random() in dataLoader.getRandomEvent).
+ *
+ * Weighting is by the event's `category` against `event_weights` in
+ * data/balance/events.json. Cooldown excludes any event whose last-fired week
+ * (from gameState.flags.side_event_history) is within `event_cooldown` weeks of
+ * the current week. If the cooldown filter empties the pool, no event fires.
+ *
+ * Spec: docs/01-planning/implementation-specs/[READY] tier2-reactive-meetings-and-side-events-plan.md §3.
+ */
+
+import { seededWeightedPick } from '../utils/seededRandom';
+import type { SideEvent, SideEventCategory } from '../types/gameTypes';
+
+/** Deterministic seed for the on-hit event pick (isolated from the engine stream). */
+export function generateSideEventSeed(gameId: string, week: number): string {
+  return `${gameId}-week${week}-sideEvent`;
+}
+
+export interface SideEventSelectionConfig {
+  /** Category → relative weight (data/balance/events.json event_weights). */
+  event_weights: Partial<Record<SideEventCategory, number>>;
+  /** Minimum weeks between re-firing the same event (data/balance/events.json event_cooldown). */
+  event_cooldown: number;
+}
+
+/**
+ * Filter the pool by cooldown, then pick one event by category weight on an
+ * isolated seed. Pure and deterministic: same (events, config, history, week,
+ * gameId) always returns the same event (or null when the pool is empty).
+ *
+ * @param events        all authored side events (each carries a `category`)
+ * @param config        weights + cooldown from data/balance/events.json
+ * @param history       flags.side_event_history — { [eventId]: lastFiredWeek }
+ * @param currentWeek   the ARRIVAL week (post-increment; see game-engine.ts)
+ * @param gameId        game id, for the isolated seed
+ * @returns the selected SideEvent, or null if the cooldown filter empties the pool
+ */
+export function selectSideEvent(
+  events: SideEvent[],
+  config: SideEventSelectionConfig,
+  history: Record<string, number>,
+  currentWeek: number,
+  gameId: string
+): SideEvent | null {
+  const cooldown = config.event_cooldown ?? 0;
+
+  // Cooldown filter: exclude events fired within `cooldown` weeks of now.
+  // lastFired at week W is eligible again once currentWeek - W >= cooldown.
+  const eligible = events.filter((event) => {
+    const lastFired = history[event.id];
+    if (typeof lastFired !== 'number') return true;
+    return currentWeek - lastFired >= cooldown;
+  });
+
+  if (eligible.length === 0) return null;
+
+  const weights = eligible.map((event) => {
+    const w = config.event_weights?.[event.category];
+    // A category missing from the weight table contributes 0 (data-lint keeps
+    // authored categories in the table, so this is a defensive fallback only).
+    return typeof w === 'number' && w > 0 ? w : 0;
+  });
+
+  const seed = generateSideEventSeed(gameId, currentWeek);
+  return seededWeightedPick(eligible, weights, seed) ?? null;
+}

--- a/shared/types/gameTypes.ts
+++ b/shared/types/gameTypes.ts
@@ -88,6 +88,33 @@ export const HAPPENING_TYPES = [
 
 export type HappeningType = (typeof HAPPENING_TYPES)[number];
 
+/**
+ * Tier 2 (PR-3) — the canonical side-event category vocabulary.
+ *
+ * SINGLE SOURCE OF TRUTH for the `category` field on data/events.json events
+ * (the RELEVANCE_TAGS / HAPPENING_TYPES one-source pattern): the SideEvent Zod
+ * schema (shared/utils/dataLoader.ts) derives its `category` enum from this
+ * array, and the data-lint suite (tests/engine/data-lint-side-event-categories.test.ts)
+ * validates data/events.json against it.
+ *
+ * These seven keys MUST stay exactly in sync with the `event_weights` keys in
+ * data/balance/events.json — the isolated-seed weighted selection in
+ * ServerGameData.selectSideEventOnHit looks up each candidate event's weight by
+ * its category. A category with no authored event is permitted (warn-level in
+ * the lint); an authored category absent from the weight table is not.
+ */
+export const SIDE_EVENT_CATEGORIES = [
+  'sync_licensing',
+  'copyright_issues',
+  'platform_opportunities',
+  'industry_drama',
+  'technical_problems',
+  'business_opportunities',
+  'artist_personal',
+] as const;
+
+export type SideEventCategory = (typeof SIDE_EVENT_CATEGORIES)[number];
+
 export interface RoleMeeting {
   id: string;
   name?: string; // Display name for the meeting (e.g., "CEO: Artist Roundtable")
@@ -157,6 +184,8 @@ export interface EventChoice {
 export interface SideEvent {
   id: string;
   role_hint: string;
+  /** Tier 2 (PR-3): weighted-selection + cooldown category. One of SIDE_EVENT_CATEGORIES. */
+  category: SideEventCategory;
   prompt: string;
   choices: EventChoice[];
 }
@@ -477,6 +506,13 @@ export interface EventOccurrence {
   id: string;
   title: string;
   occurred: boolean;
+  // Tier 2 (PR-3): on a side-event hit, the FULL authored payload is attached so
+  // PR-4's WeekSummary beat can render the event card + choices from the weekly
+  // outcome without a second fetch. Optional so the legacy {id,title,occurred}
+  // shape (and any non-side-event occurrence) still satisfies the type.
+  category?: SideEventCategory;
+  prompt?: string;
+  choices?: EventChoice[];
 }
 
 /**

--- a/shared/utils/dataLoader.ts
+++ b/shared/utils/dataLoader.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ArtistSchema } from '../schemas/artist';
-import { RELEVANCE_TAGS, HAPPENING_TYPES } from '../types/gameTypes';
+import { RELEVANCE_TAGS, HAPPENING_TYPES, SIDE_EVENT_CATEGORIES } from '../types/gameTypes';
 import type {
   GameDataFiles,
   GameArtist,
@@ -71,6 +71,9 @@ const EventChoiceSchema = z.object({
 const SideEventSchema = z.object({
   id: z.string(),
   role_hint: z.string(),
+  // Tier 2 (PR-3): category drives isolated-seed weighted selection + cooldown.
+  // Enum derived from the ONE canonical const in shared/types/gameTypes.ts.
+  category: z.enum(SIDE_EVENT_CATEGORIES),
   prompt: z.string(),
   choices: z.array(EventChoiceSchema)
 });

--- a/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
+++ b/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
@@ -431,6 +431,14 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "path": "/api/game/:gameId/releases/preview",
   },
   {
+    "method": "POST",
+    "middleware": [
+      "requireClerkUser",
+      "requireGameOwner",
+    ],
+    "path": "/api/game/:gameId/side-event-choice",
+  },
+  {
     "method": "GET",
     "middleware": [
       "requireClerkUser",

--- a/tests/endpoints/side-event-choice.characterization.test.ts
+++ b/tests/endpoints/side-event-choice.characterization.test.ts
@@ -159,9 +159,11 @@ describe('POST /api/game/:gameId/side-event-choice — happy path', () => {
     const flags = gs.flags as any;
     // pending cleared.
     expect(flags.pending_side_event).toBeUndefined();
-    // a delayed-effect bank entry exists with triggerWeek = currentWeek + 1.
+    // a delayed-effect bank entry exists with triggerWeek = currentWeek + 1,
+    // under a DETERMINISTIC week-based key — never Date.now() (flags land in
+    // save snapshots; determinism discipline requires byte-identical state).
     const delayedKeys = Object.keys(flags).filter((k) => k.startsWith('side-event-'));
-    expect(delayedKeys.length).toBe(1);
+    expect(delayedKeys).toEqual([`side-event-${EVENT_ID}-${CHOICE_ID}-week5`]);
     expect(flags[delayedKeys[0]].triggerWeek).toBe(6);
   });
 

--- a/tests/endpoints/side-event-choice.characterization.test.ts
+++ b/tests/endpoints/side-event-choice.characterization.test.ts
@@ -1,0 +1,263 @@
+// @vitest-environment node
+/**
+ * Side-event-choice endpoint characterization test (Tier 2, PR-3).
+ *
+ * Pins the observable HTTP behavior of
+ *   POST /api/game/:gameId/side-event-choice
+ * (server/routes/artists.ts). Mirrors the ar-office / roles characterization
+ * harness: real artistsRouter over supertest against the real test Postgres
+ * (Docker, localhost:5433); Clerk auth mocked to a fixed user; server/db mocked
+ * to a non-SSL pool at the test DB (the production pool forces SSL, which the
+ * local container rejects). vi.mock hoisting requires the inlined connection
+ * string.
+ *
+ * Behavior pinned:
+ *   - happy path: applies effects_immediate (money to gameState, artist_energy
+ *     to all signed artists), banks effects_delayed onto flags, clears
+ *     pending_side_event, returns the applied-effects summary;
+ *   - artist-scoped effects (artist_energy) apply to ALL signed artists
+ *     (label-level / global-scope targeting resolution). No authored event uses
+ *     artist_mood today, so the per-artist mood_event logging path is covered
+ *     structurally by the same loop; the energy case asserts NO mood_event rows
+ *     are written for a non-mood effect;
+ *   - wrong/absent pending (wrong eventId, wrong week, none) → 409;
+ *   - non-owner → 404 (requireGameOwner masks existence);
+ *   - unknown choice → 400.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER_ID = '22222222-2222-2222-2222-222222222222';
+
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import { gameStates, users, artists, moodEvents } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import artistsRouter from '../../server/routes/artists';
+
+let app: Express;
+
+// A real authored event id + a choice with a known immediate/delayed shape.
+// sync_offer / take_deal: effects_immediate.money = 20000, delayed rep + awareness.
+const EVENT_ID = 'sync_offer';
+const CHOICE_ID = 'take_deal';
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(artistsRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+async function seedGame(opts: {
+  ownerId: string;
+  currentWeek?: number;
+  money?: number;
+  flags?: Record<string, any>;
+}) {
+  const gameId = crypto.randomUUID();
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: opts.ownerId,
+    currentWeek: opts.currentWeek ?? 5,
+    money: opts.money ?? 100000,
+    reputation: 10,
+    creativeCapital: 5,
+    flags: opts.flags ?? {},
+  });
+  return gameId;
+}
+
+async function seedArtist(gameId: string, mood = 50, energy = 50) {
+  const artistId = crypto.randomUUID();
+  await db.insert(artists).values({
+    id: artistId,
+    gameId,
+    name: 'Test Artist',
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood,
+    energy,
+  });
+  return artistId;
+}
+
+async function readGame(gameId: string) {
+  const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+  return gs;
+}
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+    { id: OTHER_USER_ID, clerkId: 'clerk_other_user', email: 'other@example.com', username: 'other' },
+  ]);
+});
+
+describe('POST /api/game/:gameId/side-event-choice — happy path', () => {
+  it('applies immediate money, banks delayed effects, clears pending, returns summary', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      currentWeek: 5,
+      money: 100000,
+      flags: { pending_side_event: { eventId: EVENT_ID, week: 5 } },
+    });
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/side-event-choice`)
+      .send({ eventId: EVENT_ID, choiceId: CHOICE_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.eventId).toBe(EVENT_ID);
+    expect(res.body.choiceId).toBe(CHOICE_ID);
+    // take_deal immediate: money 20000.
+    expect(res.body.effects.money).toBe(20000);
+    // delayed: reputation + awareness_boost (banked, not applied here).
+    expect(Object.keys(res.body.delayedEffects).length).toBeGreaterThan(0);
+
+    const gs = await readGame(gameId);
+    expect(gs.money).toBe(120000);
+    const flags = gs.flags as any;
+    // pending cleared.
+    expect(flags.pending_side_event).toBeUndefined();
+    // a delayed-effect bank entry exists with triggerWeek = currentWeek + 1.
+    const delayedKeys = Object.keys(flags).filter((k) => k.startsWith('side-event-'));
+    expect(delayedKeys.length).toBe(1);
+    expect(flags[delayedKeys[0]].triggerWeek).toBe(6);
+  });
+
+  it('artist_energy immediate applies to all signed artists', async () => {
+    // pass choice on sync_offer: effects_immediate.artist_energy = 2.
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      currentWeek: 5,
+      flags: { pending_side_event: { eventId: EVENT_ID, week: 5 } },
+    });
+    const a1 = await seedArtist(gameId, 50, 40);
+    const a2 = await seedArtist(gameId, 50, 60);
+
+    const res = await request(app)
+      .post(`/api/game/${gameId}/side-event-choice`)
+      .send({ eventId: EVENT_ID, choiceId: 'pass' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.effects.artist_energy).toBe(2);
+
+    const [r1] = await db.select().from(artists).where(eq(artists.id, a1));
+    const [r2] = await db.select().from(artists).where(eq(artists.id, a2));
+    expect(r1.energy).toBe(42);
+    expect(r2.energy).toBe(62);
+
+    // Energy is not mood: NO mood_event rows are logged for this choice.
+    const moods = await db.select().from(moodEvents).where(eq(moodEvents.gameId, gameId));
+    expect(moods).toHaveLength(0);
+  });
+});
+
+describe('POST /api/game/:gameId/side-event-choice — validation', () => {
+  it('no pending event → 409', async () => {
+    const gameId = await seedGame({ ownerId: TEST_USER_ID, currentWeek: 5, flags: {} });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/side-event-choice`)
+      .send({ eventId: EVENT_ID, choiceId: CHOICE_ID });
+    expect(res.status).toBe(409);
+  });
+
+  it('pending for a DIFFERENT event → 409', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      currentWeek: 5,
+      flags: { pending_side_event: { eventId: 'copyright_claim', week: 5 } },
+    });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/side-event-choice`)
+      .send({ eventId: EVENT_ID, choiceId: CHOICE_ID });
+    expect(res.status).toBe(409);
+  });
+
+  it('pending from a PRIOR week (not current) → 409', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      currentWeek: 6,
+      flags: { pending_side_event: { eventId: EVENT_ID, week: 5 } },
+    });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/side-event-choice`)
+      .send({ eventId: EVENT_ID, choiceId: CHOICE_ID });
+    expect(res.status).toBe(409);
+  });
+
+  it('unknown choice id → 400', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      currentWeek: 5,
+      flags: { pending_side_event: { eventId: EVENT_ID, week: 5 } },
+    });
+    const res = await request(app)
+      .post(`/api/game/${gameId}/side-event-choice`)
+      .send({ eventId: EVENT_ID, choiceId: 'no_such_choice' });
+    expect(res.status).toBe(400);
+  });
+
+  it('missing body fields → 400', async () => {
+    const gameId = await seedGame({
+      ownerId: TEST_USER_ID,
+      currentWeek: 5,
+      flags: { pending_side_event: { eventId: EVENT_ID, week: 5 } },
+    });
+    const res = await request(app).post(`/api/game/${gameId}/side-event-choice`).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('non-owner → 404 (requireGameOwner masks existence)', async () => {
+    const gameId = await seedGame({
+      ownerId: OTHER_USER_ID,
+      currentWeek: 5,
+      flags: { pending_side_event: { eventId: EVENT_ID, week: 5 } },
+    });
+    currentUserId = TEST_USER_ID; // impersonate non-owner
+    const res = await request(app)
+      .post(`/api/game/${gameId}/side-event-choice`)
+      .send({ eventId: EVENT_ID, choiceId: CHOICE_ID });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/engine/data-lint-side-event-categories.test.ts
+++ b/tests/engine/data-lint-side-event-categories.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SIDE_EVENT_CATEGORIES } from '@shared/types/gameTypes';
+import type { SideEventCategory } from '@shared/types/gameTypes';
+
+/**
+ * Tier 2 (PR-3) — THE SIDE-EVENT CATEGORY DATA-LINT GUARD.
+ *
+ * Sibling of data-lint-reactive-triggers.test.ts (same load-the-JSON-directly,
+ * no-DB pattern). Guards the `category` field the PR added to every event in
+ * data/events.json:
+ *
+ *  1. Every event's `category` is in the canonical SIDE_EVENT_CATEGORIES enum
+ *     (shared/types/gameTypes.ts — the single source of truth the SideEvent Zod
+ *     schema derives from).
+ *  2. Every authored `category` has a corresponding entry in the
+ *     `event_weights` table (data/balance/events.json). An authored category
+ *     with no weight would be selected with weight 0 (effectively never), which
+ *     is a silent authoring bug — this is a HARD assertion.
+ *  3. Every `event_weights` key is a canonical category, and (warn-level, as a
+ *     documented expectation rather than a hard failure) each weight key maps to
+ *     ≥0 events — a weight key with zero authored events is permitted (e.g.
+ *     `artist_personal` today), so this is asserted as coverage reporting, not a
+ *     failure.
+ *
+ * Effect keys are already linted by data-lint-effect-keys.test.ts (which
+ * explicitly includes data/events.json in its DATA_FILES), so this suite does
+ * not re-check them.
+ *
+ * Spec: docs/01-planning/implementation-specs/[READY] tier2-reactive-meetings-and-side-events-plan.md §3.
+ */
+
+const CANONICAL_CATEGORIES: ReadonlySet<string> = new Set(SIDE_EVENT_CATEGORIES);
+
+function loadJson(rel: string): any {
+  return JSON.parse(fs.readFileSync(path.join(process.cwd(), rel), 'utf-8'));
+}
+
+const events: Array<{ id: string; category?: string }> = loadJson('data/events.json').events;
+const eventWeights: Record<string, number> = loadJson('data/balance/events.json').side_events.event_weights;
+
+describe('Data lint — side-event categories (Tier 2, PR-3)', () => {
+  it('every event in data/events.json has a canonical category', () => {
+    const offenders: string[] = [];
+    for (const event of events) {
+      if (event.category === undefined) {
+        offenders.push(`${event.id} :: missing category`);
+      } else if (!CANONICAL_CATEGORIES.has(event.category)) {
+        offenders.push(`${event.id} :: category "${event.category}" is not canonical`);
+      }
+    }
+    expect(
+      offenders,
+      offenders.length
+        ? `Non-canonical / missing category on event(s):\n  ${offenders.join('\n  ')}\nCanonical: ${Array.from(CANONICAL_CATEGORIES).sort().join(', ')}`
+        : undefined
+    ).toEqual([]);
+  });
+
+  it('every authored category has an event_weights entry in data/balance/events.json', () => {
+    const offenders: string[] = [];
+    for (const event of events) {
+      const cat = event.category as SideEventCategory | undefined;
+      if (cat && !(cat in eventWeights)) {
+        offenders.push(`${event.id} :: category "${cat}" has no weight in event_weights`);
+      }
+    }
+    expect(
+      offenders,
+      offenders.length ? `Authored categories missing from event_weights:\n  ${offenders.join('\n  ')}` : undefined
+    ).toEqual([]);
+  });
+
+  it('every event_weights key is a canonical category', () => {
+    const offenders = Object.keys(eventWeights).filter((k) => !CANONICAL_CATEGORIES.has(k));
+    expect(
+      offenders,
+      offenders.length ? `Non-canonical event_weights key(s): ${offenders.join(', ')}` : undefined
+    ).toEqual([]);
+  });
+
+  it('coverage (warn-level): reports weight keys with zero authored events', () => {
+    // Not a failure — a category can be authored in the weight table ahead of any
+    // event using it (artist_personal today). This documents the coverage so a
+    // reviewer sees which categories are dark.
+    const counts: Record<string, number> = {};
+    for (const key of Object.keys(eventWeights)) counts[key] = 0;
+    for (const event of events) {
+      if (event.category && event.category in counts) counts[event.category] += 1;
+    }
+    const dark = Object.entries(counts).filter(([, n]) => n === 0).map(([k]) => k);
+    // Assert the shape holds (every category counted), not that dark is empty.
+    expect(Object.keys(counts).sort()).toEqual(Array.from(CANONICAL_CATEGORIES).sort());
+    if (dark.length > 0) {
+      console.warn(`[side-event coverage] categories with zero authored events: ${dark.join(', ')}`);
+    }
+  });
+});

--- a/tests/engine/side-event-check-for-events.test.ts
+++ b/tests/engine/side-event-check-for-events.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import { GameEngine } from '@shared/engine/game-engine';
+import type { GameState, WeekSummary, SideEvent } from '@shared/types/gameTypes';
+
+/**
+ * Tier 2 (PR-3) — engine-level checkForEvents behavior.
+ *
+ * Exercises the PRIVATE checkForEvents through a cast: the lapse rule, the
+ * flags written on a hit (pending_side_event + side_event_history), and the
+ * full-payload push into summary.events. The WEEKLY ROLL is forced by the
+ * gameData mock's weekly_chance (1 = always hit, 0 = never) so these tests are
+ * deterministic without depending on the RNG seed's actual draw.
+ *
+ * checkForEvents touches neither storage nor the DB — it only reads gameData
+ * config + events and mutates gameState.flags + summary — so a duck-typed
+ * gameData and no storage suffice.
+ */
+
+function makeEvents(): SideEvent[] {
+  return [
+    {
+      id: 'sync_offer',
+      role_hint: 'x',
+      category: 'sync_licensing',
+      prompt: 'A blockbuster film wants your single.',
+      choices: [{ id: 'take', label: 'Take', effects_immediate: { money: 1 }, effects_delayed: {} }],
+    },
+  ];
+}
+
+function makeGameData(weeklyChance: number, events: SideEvent[]): any {
+  return {
+    getEventConfigSync: () => ({ weekly_chance: weeklyChance, cooldown_weeks: 2, max_per_year: 12 }),
+    getSideEventsConfigSync: () => ({
+      event_weights: { sync_licensing: 1 },
+      event_cooldown: 2,
+    }),
+    getAllEvents: async () => events,
+    // FinancialSystem's constructor runs validateConfiguration(), which reads
+    // tour + venue config. Minimal valid stubs so construction succeeds; these
+    // are never exercised by checkForEvents.
+    getTourConfigSync: () => ({
+      sell_through_base: 0.7,
+      reputation_modifier: 1.0,
+      local_popularity_weight: 1.0,
+      ticket_price_base: 20,
+      ticket_price_per_capacity: 0.01,
+      merch_percentage: 0.25,
+    }),
+    getAccessTiersSync: () => ({
+      venue_access: {
+        none: { capacity_range: [0, 50] },
+        clubs: { capacity_range: [50, 500] },
+        theaters: { capacity_range: [500, 2000] },
+        medium: { capacity_range: [500, 2000] },
+        arenas: { capacity_range: [2000, 20000] },
+      },
+    }),
+  };
+}
+
+function makeGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    currentWeek: 5,
+    money: 100000,
+    reputation: 0,
+    creativeCapital: 5,
+    flags: {},
+    ...overrides,
+  } as GameState;
+}
+
+function makeSummary(): WeekSummary {
+  return {
+    week: 5,
+    changes: [],
+    revenue: 0,
+    expenses: 0,
+    reputationChanges: {},
+    events: [],
+  };
+}
+
+/** Invoke the private checkForEvents on a constructed engine. */
+async function runCheck(gameState: GameState, gameData: any, summary: WeekSummary) {
+  const engine = new GameEngine(gameState, gameData, undefined, 'fixed-seed');
+  await (engine as any).checkForEvents(summary);
+}
+
+describe('checkForEvents — hit writes pending + history flags', () => {
+  it('on a hit, sets pending_side_event and stamps side_event_history at the arrival week', async () => {
+    const gs = makeGameState({ currentWeek: 5, flags: {} });
+    const summary = makeSummary();
+    await runCheck(gs, makeGameData(1, makeEvents()), summary);
+
+    const flags = gs.flags as any;
+    expect(flags.pending_side_event).toEqual({ eventId: 'sync_offer', week: 5 });
+    expect(flags.side_event_history.sync_offer).toBe(5);
+  });
+
+  it('on a hit, pushes the FULL event payload into summary.events', async () => {
+    const gs = makeGameState({ currentWeek: 5, flags: {} });
+    const summary = makeSummary();
+    await runCheck(gs, makeGameData(1, makeEvents()), summary);
+
+    expect(summary.events).toHaveLength(1);
+    const occ = summary.events[0];
+    expect(occ.id).toBe('sync_offer');
+    expect(occ.occurred).toBe(true);
+    expect(occ.category).toBe('sync_licensing');
+    expect(occ.prompt).toBe('A blockbuster film wants your single.');
+    expect(occ.choices).toHaveLength(1);
+  });
+
+  it('on a miss (weekly_chance 0), no pending event and no summary push', async () => {
+    const gs = makeGameState({ currentWeek: 5, flags: {} });
+    const summary = makeSummary();
+    await runCheck(gs, makeGameData(0, makeEvents()), summary);
+
+    expect((gs.flags as any).pending_side_event).toBeUndefined();
+    expect(summary.events).toHaveLength(0);
+  });
+
+  it('respects cooldown: an on-cooldown sole event does not fire even on a roll hit', async () => {
+    // sync_offer fired at week 4; cooldown 2 → ineligible at week 5.
+    const gs = makeGameState({ currentWeek: 5, flags: { side_event_history: { sync_offer: 4 } } });
+    const summary = makeSummary();
+    await runCheck(gs, makeGameData(1, makeEvents()), summary);
+
+    expect((gs.flags as any).pending_side_event).toBeUndefined();
+    expect(summary.events).toHaveLength(0);
+    // History untouched (no new fire).
+    expect((gs.flags as any).side_event_history.sync_offer).toBe(4);
+  });
+});
+
+describe('checkForEvents — lapse rule', () => {
+  it('clears a stale pending event from a PRIOR week with no effects', async () => {
+    const gs = makeGameState({
+      currentWeek: 6,
+      // pending left from week 5; money must not change from lapsing.
+      flags: { pending_side_event: { eventId: 'sync_offer', week: 5 } },
+      money: 100000,
+    });
+    const summary = makeSummary();
+    // weekly_chance 0 so the roll does not also fire a new event this week.
+    await runCheck(gs, makeGameData(0, makeEvents()), summary);
+
+    expect((gs.flags as any).pending_side_event).toBeUndefined();
+    expect(gs.money).toBe(100000); // no effects applied on lapse
+    expect(summary.events).toHaveLength(0);
+  });
+
+  it('does NOT lapse a pending event from the CURRENT week (still resolvable)', async () => {
+    const gs = makeGameState({
+      currentWeek: 5,
+      flags: { pending_side_event: { eventId: 'sync_offer', week: 5 } },
+    });
+    const summary = makeSummary();
+    await runCheck(gs, makeGameData(0, makeEvents()), summary);
+
+    // Same-week pending survives (the beat is consumed this week).
+    expect((gs.flags as any).pending_side_event).toEqual({ eventId: 'sync_offer', week: 5 });
+  });
+
+  it('lapse does not consume the new week roll: a prior pending clears AND a new event still fires', async () => {
+    const gs = makeGameState({
+      currentWeek: 6,
+      flags: { pending_side_event: { eventId: 'sync_offer', week: 5 } },
+    });
+    const summary = makeSummary();
+    // weekly_chance 1 → the roll hits after the lapse; a fresh event is selected.
+    await runCheck(gs, makeGameData(1, makeEvents()), summary);
+
+    const flags = gs.flags as any;
+    // The stale one lapsed and was replaced by this week's fresh pending.
+    expect(flags.pending_side_event).toEqual({ eventId: 'sync_offer', week: 6 });
+    expect(summary.events).toHaveLength(1);
+  });
+});

--- a/tests/engine/side-event-selection.test.ts
+++ b/tests/engine/side-event-selection.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { selectSideEvent, generateSideEventSeed, type SideEventSelectionConfig } from '@shared/engine/sideEventSelection';
+import type { SideEvent } from '@shared/types/gameTypes';
+
+/**
+ * Tier 2 (PR-3) — pure side-event selection unit tests.
+ *
+ * Covers the ISOLATED-SEED weighted pick + cooldown filter (spec §3). The
+ * WEEKLY ROLL (does anything fire?) lives in the engine's RNG stream and is not
+ * exercised here — this suite is about WHICH event fires once the roll hits.
+ */
+
+function ev(id: string, category: SideEvent['category']): SideEvent {
+  return {
+    id,
+    role_hint: 'test',
+    category,
+    prompt: `prompt ${id}`,
+    choices: [{ id: 'a', label: 'A', effects_immediate: {}, effects_delayed: {} }],
+  };
+}
+
+const CONFIG: SideEventSelectionConfig = {
+  event_weights: {
+    sync_licensing: 0.15,
+    copyright_issues: 0.1,
+    platform_opportunities: 0.2,
+    industry_drama: 0.15,
+    technical_problems: 0.1,
+    business_opportunities: 0.15,
+    artist_personal: 0.15,
+  },
+  event_cooldown: 2,
+};
+
+const POOL: SideEvent[] = [
+  ev('sync_offer', 'sync_licensing'),
+  ev('copyright_claim', 'copyright_issues'),
+  ev('data_anomaly', 'platform_opportunities'),
+  ev('wardrobe_malfunction', 'industry_drama'),
+  ev('lighting_blackout', 'technical_problems'),
+  ev('royalty_discrepancy', 'business_opportunities'),
+];
+
+describe('selectSideEvent — determinism', () => {
+  it('same seed inputs twice → same event', () => {
+    const a = selectSideEvent(POOL, CONFIG, {}, 10, 'game-1');
+    const b = selectSideEvent(POOL, CONFIG, {}, 10, 'game-1');
+    expect(a).not.toBeNull();
+    expect(a!.id).toBe(b!.id);
+  });
+
+  it('generateSideEventSeed has the spec-pinned shape', () => {
+    expect(generateSideEventSeed('game-1', 10)).toBe('game-1-week10-sideEvent');
+  });
+
+  it('different weeks / games can pick different events (seed varies)', () => {
+    const picks = new Set<string>();
+    for (let w = 1; w <= 40; w++) {
+      const p = selectSideEvent(POOL, CONFIG, {}, w, 'game-1');
+      if (p) picks.add(p.id);
+    }
+    // Over 40 distinct seeds we expect more than one distinct event.
+    expect(picks.size).toBeGreaterThan(1);
+  });
+});
+
+describe('selectSideEvent — weighting', () => {
+  it('honors category weights in distribution over many seeds', () => {
+    // Two events: one heavy, one light. The heavy one should win far more often.
+    const pool: SideEvent[] = [
+      ev('heavy', 'platform_opportunities'), // weight 0.20
+      ev('light', 'copyright_issues'), // weight 0.10
+    ];
+    const counts: Record<string, number> = { heavy: 0, light: 0 };
+    const N = 2000;
+    for (let w = 0; w < N; w++) {
+      const p = selectSideEvent(pool, CONFIG, {}, w, 'dist-game');
+      if (p) counts[p.id] += 1;
+    }
+    // 2:1 authored ratio — heavy must clearly dominate (allow generous slack).
+    expect(counts.heavy).toBeGreaterThan(counts.light);
+    expect(counts.heavy / (counts.heavy + counts.light)).toBeGreaterThan(0.55);
+  });
+});
+
+describe('selectSideEvent — cooldown', () => {
+  it('excludes an event within its cooldown window', () => {
+    // Single-event pool; fired at week 9, cooldown 2 → ineligible at week 10.
+    const pool = [ev('only', 'platform_opportunities')];
+    const picked = selectSideEvent(pool, CONFIG, { only: 9 }, 10, 'g');
+    expect(picked).toBeNull(); // 10 - 9 = 1 < 2
+  });
+
+  it('re-includes an event once the cooldown has elapsed', () => {
+    const pool = [ev('only', 'platform_opportunities')];
+    const picked = selectSideEvent(pool, CONFIG, { only: 8 }, 10, 'g');
+    expect(picked).not.toBeNull(); // 10 - 8 = 2 >= 2
+    expect(picked!.id).toBe('only');
+  });
+
+  it('empty pool after cooldown filter → null (no fire)', () => {
+    const pool = [ev('a', 'platform_opportunities'), ev('b', 'copyright_issues')];
+    const history = { a: 10, b: 9 }; // both within cooldown 2 at week 10
+    const picked = selectSideEvent(pool, CONFIG, history, 10, 'g');
+    expect(picked).toBeNull();
+  });
+
+  it('picks only from the eligible subset when some are on cooldown', () => {
+    const pool = [ev('cool', 'platform_opportunities'), ev('ready', 'copyright_issues')];
+    // 'cool' fired week 10 (ineligible at 10), 'ready' never fired.
+    for (let w = 10; w < 10; w++) void w;
+    const picked = selectSideEvent(pool, CONFIG, { cool: 10 }, 10, 'g');
+    expect(picked).not.toBeNull();
+    expect(picked!.id).toBe('ready');
+  });
+});
+
+describe('selectSideEvent — edge cases', () => {
+  it('empty event list → null', () => {
+    expect(selectSideEvent([], CONFIG, {}, 1, 'g')).toBeNull();
+  });
+
+  it('a category missing from the weight table contributes weight 0', () => {
+    // Only 'covered' has a weight; 'uncovered' category weight is absent → 0.
+    const cfg: SideEventSelectionConfig = { event_weights: { platform_opportunities: 1 }, event_cooldown: 0 };
+    const pool = [ev('covered', 'platform_opportunities'), ev('uncovered', 'artist_personal')];
+    for (let w = 0; w < 50; w++) {
+      const p = selectSideEvent(pool, cfg, {}, w, 'g');
+      expect(p!.id).toBe('covered');
+    }
+  });
+});


### PR DESCRIPTION
Makes the authored-but-dead side-event system real on the server side (the WeekSummary UI beat is PR-4). Spec: `docs/01-planning/implementation-specs/[READY] tier2-reactive-meetings-and-side-events-plan.md` §3, §7 PR-3.

## What changed
- **Selection** (`shared/engine/sideEventSelection.ts`, new, sibling of `meetingSelection.ts`): on the existing in-stream weekly roll's hit (`game-engine.ts` `checkForEvents`, the `getRandom(0,1) < weekly_chance` draw left **exactly as-is** per fork D1), event SELECTION moves to an **isolated seed** `${gameId}-week${week}-sideEvent` via `seededWeightedPick`, weighted by the event's `category` and excluding events within their `event_cooldown`. Closes ledger **C64** (the unseeded `Math.random()` in `getRandomEvent`). Empty pool after the cooldown filter → no event fires.
- **Category authoring** (`data/events.json`): each of the **12** events gains a `category`, validated by a new data-lint suite against the canonical `SIDE_EVENT_CATEGORIES` const (`shared/types/gameTypes.ts`, the RELEVANCE_TAGS/HAPPENING_TYPES one-source pattern). `SideEvent` Zod schema derives its `category` enum from it.
- **State** (additive `gameState.flags` keys only — no save-shape change, `SNAPSHOT_VERSION` untouched): on a hit the engine sets `pending_side_event: { eventId, week }`, stamps `side_event_history[eventId] = currentWeek`, and pushes the **full** event payload (id, prompt, choices, category) into `summary.events` for PR-4.
- **Lapse**: a `pending_side_event` from a **prior** week is cleared with no effects at the start of `checkForEvents`, **before** the roll so it never consumes the new week's draw. `currentWeek` here is the post-increment arrival week (playtest-round-1 semantics).
- **Choice endpoint** `POST /api/game/:gameId/side-event-choice` (`requireClerkUser` + `requireGameOwner`, in `server/routes/artists.ts` co-located with the dialogue precedent): validates a pending event for the game's current week, applies `effects_immediate` at choice-time and banks `effects_delayed` onto flags (`{ triggerWeek: currentWeek+1, effects }`, drained by `processDelayedEffects`), clears the pending flag, returns the applied-effects summary. Zod contracts added to `shared/api/contracts.ts`.

## Category mapping (12 events)
| event | category |
|---|---|
| sync_offer | sync_licensing |
| copyright_claim | copyright_issues |
| content_takedown | copyright_issues |
| data_anomaly | platform_opportunities |
| platform_beta | platform_opportunities |
| critic_surprise | industry_drama |
| wardrobe_malfunction | industry_drama |
| street_team_rogue | industry_drama |
| lighting_blackout | technical_problems |
| merch_fail | technical_problems |
| royalty_discrepancy | business_opportunities |
| ad_backlash | business_opportunities |

Coverage: sync_licensing×1, copyright_issues×2, platform_opportunities×2, industry_drama×3, technical_problems×2, business_opportunities×2, **artist_personal×0** (permitted — warn-level coverage report in the lint; the weight key stays for future authoring).

## artist_mood targeting resolution
Side events are **label-level** — there is no single target artist the way the dialogue path has one. Artist-scoped keys (`artist_mood` / `artist_energy` / `artist_popularity`) therefore apply to **all signed artists**, mirroring the executive-meeting `global` `target_scope` (the closest existing precedent, where ActionProcessor applies global artist effects across the whole roster). A `mood_event` row is logged **per artist** whenever `artist_mood` is touched, matching how discrete mood changes are recorded elsewhere. (No authored event uses `artist_mood` today — only `artist_energy` — so that logging path is covered structurally by the same loop; the endpoint test asserts no spurious mood rows for the energy case.)

## Golden master
`weekly_chance` is pinned `0` in GM fixtures, so the on-hit path is dark and the in-stream draw is unchanged → expected zero delta. GM suite run **twice**, **zero snapshot deltas** both runs. All three churn `.snap` files have zero real content diff; only `route-manifest.test.ts.snap` is committed (one legitimate new-route line).

## Tests
Before: 1403 tests / 134 files. After: **1432 / 138** (+29). New: `side-event-selection` (13, pure determinism/weights/cooldown/empty-pool/edge), `side-event-check-for-events` (7, hit-writes-flags/miss/cooldown/lapse), `data-lint-side-event-categories` (4), `side-event-choice.characterization` (8, happy path + 409/400/404). Full `npm run test:run` green; `npm run check` clean.

## Deliberately not done
- No UI (PR-4). No engine effect application inside the week transaction (effects are choice-time only). Did not edit the ledger doc (orchestrator ticks C64). Did not touch `data/actions.json` / the churn `.snap` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
