### PR TITLE
fix: disable meeting choices the player cannot afford in Creative Capital

### DIFF
--- a/client/src/components/executive-meetings/DialogueInterface.tsx
+++ b/client/src/components/executive-meetings/DialogueInterface.tsx
@@ -9,6 +9,7 @@ import { TrendingUp, TrendingDown, Clock, Zap, ArrowLeft, Shuffle } from 'lucide
 import type { DialogueChoice } from '../../../../shared/types/gameTypes';
 import { LIVE_EFFECT_KEYS } from '@shared/engine/processors/ActionProcessor';
 import { EffectBadgeTooltip } from './EffectBadgeTooltip';
+import { getChoiceCreativeCapitalCost } from '../../services/executiveAutoSelect';
 
 // Badge honesty (exec-meetings-revival PR-2): only render a badge for a key the
 // engine actually implements (LIVE_EFFECT_KEYS) or 'executive_mood' (handled
@@ -28,6 +29,18 @@ interface DialogueInterfaceProps {
   onBack: () => void;
   targetScope?: 'global' | 'predetermined' | 'user_selected';
   selectedArtistName?: string;
+  /**
+   * CC affordability gate (playtest bug, 2026-07-05): the player's current
+   * Creative Capital. When provided, a choice whose CC cost (immediate +
+   * delayed, via the same getChoiceCreativeCapitalCost helper AUTO budgets
+   * with) exceeds it is DISABLED with an explanatory note — previously a
+   * CC-costing choice was selectable at 0 CC and the engine's Math.max(0, …)
+   * clamp silently erased the cost (free lunch). Absent = no gating (other
+   * render sites / tests keep their existing behavior). Server clamp remains
+   * the backstop. Known limitation: gates against CURRENT CC only, not net of
+   * other already-queued choices this week (ledger C75).
+   */
+  availableCreativeCapital?: number;
 }
 
 function EffectBadge({
@@ -211,7 +224,8 @@ export function DialogueInterface({
   onSelectChoice,
   onBack,
   targetScope,
-  selectedArtistName
+  selectedArtistName,
+  availableCreativeCapital
 }: DialogueInterfaceProps) {
   // Replace {artistName} placeholder with actual artist name
   const displayPrompt = selectedArtistName
@@ -242,7 +256,13 @@ export function DialogueInterface({
           }}
         >
           <CarouselContent>
-            {dialogue.choices.map((choice) => (
+            {dialogue.choices.map((choice) => {
+              // CC affordability gate: disable a choice the player can't pay
+              // for (same cost math AUTO budgets with). undefined prop = no gate.
+              const ccCost = getChoiceCreativeCapitalCost(choice);
+              const cannotAfford =
+                typeof availableCreativeCapital === 'number' && ccCost > availableCreativeCapital;
+              return (
               <CarouselItem key={choice.id}>
                 <Card className="glass-panel chromatic-hairline relative border-0 transition-all duration-200 hover:shadow-glow-lilac">
                   <BorderTrail
@@ -266,9 +286,21 @@ export function DialogueInterface({
                         selectedArtistName={selectedArtistName}
                       />
 
+                      {cannotAfford && (
+                        <div
+                          data-testid={`cc-gate-${choice.id}`}
+                          className="flex items-center gap-1.5 text-xs font-mono text-warning"
+                        >
+                          <Zap className="h-3 w-3 shrink-0" />
+                          <span>
+                            Needs {ccCost} Creative Capital — you have {availableCreativeCapital}
+                          </span>
+                        </div>
+                      )}
                       <Button
                         onClick={() => onSelectChoice(choice)}
-                        className="w-full rounded-button bg-gradient-to-br from-action-pink to-action-purple text-white shadow-action hover:opacity-90"
+                        disabled={cannotAfford}
+                        className="w-full rounded-button bg-gradient-to-br from-action-pink to-action-purple text-white shadow-action hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
                         size="sm"
                       >
                         Choose This Response
@@ -277,7 +309,8 @@ export function DialogueInterface({
                   </CardContent>
                 </Card>
               </CarouselItem>
-            ))}
+              );
+            })}
           </CarouselContent>
           <CarouselPrevious className="bg-neon-lilac/10 hover:bg-neon-lilac/20 border-neon-lilac/40 text-neon-lilac" />
           <CarouselNext className="bg-neon-lilac/10 hover:bg-neon-lilac/20 border-neon-lilac/40 text-neon-lilac" />

--- a/client/src/components/executive-meetings/ExecutiveMeetings.tsx
+++ b/client/src/components/executive-meetings/ExecutiveMeetings.tsx
@@ -419,6 +419,7 @@ export function ExecutiveMeetings({
               dialogue={context.currentDialogue}
               onSelectChoice={(choice) => send({ type: 'SELECT_CHOICE', choice })}
               onBack={() => send({ type: 'BACK_TO_MEETINGS' })}
+              availableCreativeCapital={creativeCapital}
               targetScope={context.selectedMeeting?.target_scope}
               selectedArtistName={
                 context.selectedArtistId

--- a/docs/09-troubleshooting/technical-debt-backlog.md
+++ b/docs/09-troubleshooting/technical-debt-backlog.md
@@ -9,11 +9,11 @@
 
 - **Created**: September 2025 (Artist Mood System Implementation - commit `4991ab3`)
 - **Last Updated**: July 5, 2026
-- **Total Items**: 74 (C1–C74, no gaps; header previously said 68 with buckets summing to 67 — pre-existing drift, the Completed count had never absorbed C54 and C69)
+- **Total Items**: 75 (C1–C75, no gaps; header previously said 68 with buckets summing to 67 — pre-existing drift, the Completed count had never absorbed C54 and C69)
 - **Completed**: 59
 - **Deferred by decision**: 3 (C32, C42, C43)
 - **In Progress**: 0
-- **Pending**: 12 (C50, C52, C53, C55, C56, C57, C59, C61, C62 — remaining scope: zeroed score components only, C63, C65, C66) — C70 (PR #128) + C72 (PR #129) + C73 (PR #130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection) resolved July 5, 2026 (PR #138, Tier 2 MVP-2); C67 (`071c6df`) + C68 (`5b44d9e`) + C69 (`1db5c39`) resolved July 4, 2026 on PR #119; C51 (`6e945e3`) + C58 (`3d8066a`) + C60 (`7898de6`) + C62-partial (`f1b1315`) resolved July 4, 2026 on PR #120; C71 (reference-doc sync) resolved July 5, 2026 in the post-merge docs pass; C74 (header AUTO review-gate + AR-busy AUTO fix) resolved July 5, 2026
+- **Pending**: 13 (C50, C52, C53, C55, C56, C57, C59, C61, C62 — remaining scope: zeroed score components only, C63, C65, C66, C75 — CC gate ignores queued choices, July 5, 2026) — C70 (PR #128) + C72 (PR #129) + C73 (PR #130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection) resolved July 5, 2026 (PR #138, Tier 2 MVP-2); C67 (`071c6df`) + C68 (`5b44d9e`) + C69 (`1db5c39`) resolved July 4, 2026 on PR #119; C51 (`6e945e3`) + C58 (`3d8066a`) + C60 (`7898de6`) + C62-partial (`f1b1315`) resolved July 4, 2026 on PR #120; C71 (reference-doc sync) resolved July 5, 2026 in the post-merge docs pass; C74 (header AUTO review-gate + AR-busy AUTO fix) resolved July 5, 2026
 
 > ⚠️ **Stale-entry corrections (July 3, 2026 interactivity-gap analysis, see `docs/98-research/INTERACTIVITY_GAP_ANALYSIS_2026-07-03.md`)**: C42's premise is outdated — awareness IS live in streaming revenue (`shared/engine/FinancialSystem.ts:983-1013`, config enabled); the remaining gap is player-facing UI only — a first awareness readout (Buzz chip) shipped in SongCatalog in PR #119 (July 3-4, 2026), but the release page and dashboard still show nothing. C43 is half-outdated — a transactional DELETE-release endpoint with server-side refund exists (`server/routes/releases.ts:665-683`); only the client UI is missing. Also in PR #119: a delayed-effect bug where `details?.choiceId` was read incorrectly (never had a C-number) was fixed as PR-1 of that revival branch.
 
@@ -1200,19 +1200,35 @@ Found by the July 5, 2026 fresh-context verifier (finding F1) after the meeting-
 
 ---
 
+### [ ] Comment 75 (C75): CC affordability gate ignores already-queued choices in the same week 🔵
+**Priority**: 🔵 Low
+**Impact**: A player can still stack CC overdraw across MULTIPLE meetings in one week (each individually affordable against CURRENT CC); the engine's `Math.max(0, …)` clamp then silently absorbs the overdraft at advance time — a smaller residue of the free-lunch bug the gate fixed
+**Effort**: Small-Medium (needs queued-CC accounting)
+
+The late-July-5 playtest fix disabled meeting choices whose CC cost exceeds the player's CC (`DialogueInterface` `availableCreativeCapital` gate, reusing AUTO's `getChoiceCreativeCapitalCost`). But CC is only debited when the week advances, and the gate checks the spine's CURRENT `creativeCapital` — it does not subtract CC costs already queued in `selectedActions` this week. Example: at 2 CC, queue two different meetings each costing −2 CC — both pass the gate individually; at advance, the second cost clamps to 0 and evaporates. Fix shape: compute remaining CC = current − Σ(queued choices' CC costs) and pass THAT as `availableCreativeCapital` (the queued actions' JSON doesn't carry effects, so this needs either effect lookup by (roleId, actionId, choiceId) or storing the CC cost in the queued action payload — the latter is simpler). AUTO has the same composition seam post-#126 (a manual pick then AUTO budgets against full current CC). Engine-side rejection was deliberately NOT chosen (golden-master surface + worse UX than prevention).
+
+**Relevant Files**:
+- [client/src/components/executive-meetings/DialogueInterface.tsx](client/src/components/executive-meetings/DialogueInterface.tsx)
+- [client/src/components/executive-meetings/ExecutiveMeetings.tsx](client/src/components/executive-meetings/ExecutiveMeetings.tsx)
+- [shared/engine/processors/ActionProcessor.ts](shared/engine/processors/ActionProcessor.ts)
+
+*Identified July 5, 2026 while fixing the CC free-lunch playtest bug (choices selectable at 0 CC).*
+
+---
+
 ## 📊 **Summary Statistics**
 
 ### By Priority
 - 🔴 Critical: 0 items (all completed! 🎉)
 - 🟡 High: 0 items (all completed! 🎉) — note: C40's header lacks the `~~strikethrough~~` convention despite being fixed (PR #66/#68); cosmetic only
 - 🟢 Medium: 2 deferred (C42, C43 — product decisions, July 3, 2026; see stale-entry corrections in Document Information), 1 pending (C62 — remaining scope: zeroed `artistsSuccessful`/`projectsCompleted` score components only, needs design decision + plumbing) — C67 + C68 + C69 resolved July 4, 2026 (PR #119); C58 (stale-week guard) + C60 (delayed-effect targeting) + C62's other sub-items resolved July 4, 2026 (PR #120); C74 (header AUTO review-gate bypass + AR-busy AUTO fix) resolved July 5, 2026
-- 🔵 Low: 1 deferred (C32 — cap unreachable; surfacing fixed), 11 pending (C50 — client tests' incidental DB dependency; C52–C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5/D6 session findings, July 3, 2026; C61, C63, C65 — interactivity-gap analysis findings, July 3, 2026; C66 — exec-meetings revival Phase A finds) — C51 ("On Tour" badge lag) resolved July 4, 2026 (PR #120); C71 (reference-doc staleness log) resolved July 5, 2026 (post-merge docs pass); C70 (12-week copy rot, PR #128) + C72–C73 (content-honesty warts, PRs #129–#130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection) resolved July 5, 2026 (PR #138, Tier 2 MVP-2)
+- 🔵 Low: 1 deferred (C32 — cap unreachable; surfacing fixed), 12 pending (C50 — client tests' incidental DB dependency; C52–C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5/D6 session findings, July 3, 2026; C61, C63, C65 — interactivity-gap analysis findings, July 3, 2026; C66 — exec-meetings revival Phase A finds; C75 — CC gate ignores queued choices, July 5, 2026) — C51 ("On Tour" badge lag) resolved July 4, 2026 (PR #120); C71 (reference-doc staleness log) resolved July 5, 2026 (post-merge docs pass); C70 (12-week copy rot, PR #128) + C72–C73 (content-honesty warts, PRs #129–#130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection) resolved July 5, 2026 (PR #138, Tier 2 MVP-2)
 
 ### By Status
-- ✅ Completed: 59 items (79.7% of 74; 59 + 3 deferred + 12 pending = 74 ✓)
+- ✅ Completed: 59 items (78.7% of 75; 59 + 3 deferred + 13 pending = 75 ✓)
 - 🚧 In Progress: 0 items
 - ⏸️ Deferred by decision: 3 items (C32, C42, C43)
-- 📋 Pending: 12 items (C50 — logged July 3, 2026; C52, C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5 + D6 session findings; C61, C62 (remaining scope: zeroed score components only), C63, C65 — interactivity-gap analysis, July 3, 2026; C66 — exec-meetings revival Phase A finds; all low except C62 medium, not scheduled). C70 (PR #128) + C72 (PR #129) + C73 (PR #130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection, PR #138) resolved July 5, 2026 (Tier 2 MVP-2); C67 (`071c6df`) + C68 (`5b44d9e`) + C69 (`1db5c39`) resolved July 4, 2026 on PR #119; C51 (`6e945e3`) + C58 (`3d8066a`) + C60 (`7898de6`) + C62-partial (`f1b1315`) resolved July 4, 2026 on PR #120; C71 (reference-doc sync) resolved July 5, 2026 in the post-merge docs pass; C74 (header AUTO review-gate + AR-busy AUTO fix) resolved July 5, 2026
+- 📋 Pending: 13 items (C50 — logged July 3, 2026; C52, C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5 + D6 session findings; C61, C62 (remaining scope: zeroed score components only), C63, C65 — interactivity-gap analysis, July 3, 2026; C66 — exec-meetings revival Phase A finds; C75 — CC gate ignores queued choices, July 5, 2026; all low except C62 medium, not scheduled). C70 (PR #128) + C72 (PR #129) + C73 (PR #130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection, PR #138) resolved July 5, 2026 (Tier 2 MVP-2); C67 (`071c6df`) + C68 (`5b44d9e`) + C69 (`1db5c39`) resolved July 4, 2026 on PR #119; C51 (`6e945e3`) + C58 (`3d8066a`) + C60 (`7898de6`) + C62-partial (`f1b1315`) resolved July 4, 2026 on PR #120; C71 (reference-doc sync) resolved July 5, 2026 in the post-merge docs pass; C74 (header AUTO review-gate + AR-busy AUTO fix) resolved July 5, 2026
 
 ---
 

--- a/tests/client/DialogueInterface.ccGate.test.tsx
+++ b/tests/client/DialogueInterface.ccGate.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * CC affordability gate (playtest bug, 2026-07-05): a meeting choice whose
+ * Creative Capital cost exceeds the player's available CC must be DISABLED
+ * with an explanatory note — previously it was selectable at 0 CC and the
+ * engine's Math.max(0, …) clamp silently erased the cost (free lunch).
+ * Absent prop = no gating (legacy behavior for other render sites).
+ */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+// The decorative motion primitives reference React APIs that break under the
+// test DOM and are irrelevant to the gate — stub them out.
+vi.mock('../../client/src/components/motion-primitives/border-trail', () => ({
+  BorderTrail: () => null,
+}));
+vi.mock('../../client/src/components/motion-primitives/glow-effect', () => ({
+  GlowEffect: () => null,
+}));
+
+import { DialogueInterface } from '../../client/src/components/executive-meetings/DialogueInterface';
+import type { DialogueChoice } from '../../shared/types/gameTypes';
+
+afterEach(() => cleanup());
+
+const ccChoice: DialogueChoice = {
+  id: 'creative_reset',
+  label: 'Creative reset',
+  effects_immediate: { creative_capital: -2, money: -1500 },
+  effects_delayed: { artist_mood: 4 },
+} as DialogueChoice;
+
+const freeChoice: DialogueChoice = {
+  id: 'push_through',
+  label: 'Push through',
+  effects_immediate: {},
+  effects_delayed: { artist_mood: -3 },
+} as DialogueChoice;
+
+function renderDialogue(availableCreativeCapital?: number, choices: DialogueChoice[] = [ccChoice, freeChoice]) {
+  return render(
+    <DialogueInterface
+      dialogue={{ prompt: 'A tense meeting.', choices }}
+      onSelectChoice={vi.fn()}
+      onBack={vi.fn()}
+      availableCreativeCapital={availableCreativeCapital}
+    />
+  );
+}
+
+describe('DialogueInterface — CC affordability gate', () => {
+  it('disables a CC-costing choice at 0 CC and shows the gate note', () => {
+    renderDialogue(0);
+    expect(screen.getByTestId('cc-gate-creative_reset')).toHaveTextContent(
+      'Needs 2 Creative Capital — you have 0'
+    );
+    const buttons = screen.getAllByRole('button', { name: 'Choose This Response' });
+    // Carousel renders both cards; the CC-costing one is disabled, the free one is not.
+    expect(buttons.some((b) => (b as HTMLButtonElement).disabled)).toBe(true);
+    expect(buttons.some((b) => !(b as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  it('does not gate an affordable CC choice', () => {
+    renderDialogue(5);
+    expect(screen.queryByTestId('cc-gate-creative_reset')).toBeNull();
+    const buttons = screen.getAllByRole('button', { name: 'Choose This Response' });
+    expect(buttons.every((b) => !(b as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  it('exactly-affordable is allowed (cost === available)', () => {
+    renderDialogue(2);
+    expect(screen.queryByTestId('cc-gate-creative_reset')).toBeNull();
+  });
+
+  it('absent prop = legacy behavior, nothing gated (other render sites unchanged)', () => {
+    renderDialogue(undefined);
+    expect(screen.queryByTestId('cc-gate-creative_reset')).toBeNull();
+    const buttons = screen.getAllByRole('button', { name: 'Choose This Response' });
+    expect(buttons.every((b) => !(b as HTMLButtonElement).disabled)).toBe(true);
+  });
+});


### PR DESCRIPTION
Playtest find: CC-costing choices selectable at 0 CC; the engine clamp made the cost silently evaporate (free lunch). Fix gates the dialogue UI with the same cost helper AUTO budgets with — unaffordable choices disabled with a "Needs X Creative Capital — you have Y" note. Optional prop, legacy behavior preserved elsewhere; server clamp kept as backstop. Residual queued-stacking seam logged as C75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)