### PR TITLE
feat: Content Editor - no-code editing for side events & meetings

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,7 @@ import AdminDatabaseHealthPage from '@/pages/AdminDatabaseHealthPage';
 import UXPrototypesPage from '@/pages/UXPrototypesPage';
 import MoodSystemPrototypePage from '@/pages/prototypes/MoodSystemPrototypePage';
 import AdminHome from "@/admin/AdminLayout";
-import ActionsViewer from "@/admin/ActionsViewer";
+import ContentEditorPage from "@/admin/ContentEditorPage";
 import { withAdmin } from "@/admin/withAdmin";
 
 function Router() {
@@ -50,7 +50,7 @@ function Router() {
 
       {/* Admin routes */}
       <Route path="/admin" component={withAdmin(AdminHome)} />
-      <Route path="/admin/actions-viewer" component={withAdmin(ActionsViewer)} />
+      <Route path="/admin/actions-viewer" component={withAdmin(ContentEditorPage)} />
       <Route path="/admin/quality-tester" component={withAdmin(QualityTester)} />
       <Route path="/admin/tour-variance-tester" component={withAdmin(TourVarianceTesterPage)} />
       <Route path="/admin/popularity-tester" component={withAdmin(PopularityTester)} />

--- a/client/src/admin/ActionsViewer.tsx
+++ b/client/src/admin/ActionsViewer.tsx
@@ -1,10 +1,12 @@
 import { useState, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import GameLayout from '@/layouts/GameLayout';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IconPrefix, IconProp } from '@fortawesome/fontawesome-svg-core';
 import {
@@ -27,7 +29,6 @@ import {
 import { Zap, Clock, Edit, Save, X, AlertCircle, Pencil, Trash2, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
-import actionsData from '@/../../data/actions.json';
 import {
   ActionsConfigSchema,
   type WeeklyAction,
@@ -35,6 +36,9 @@ import {
   type ActionsConfig,
   type DialogueChoiceContract,
 } from '@shared/api/contracts';
+import { EFFECT_CHANNEL_DESCRIPTIONS } from '@shared/engine/processors/ActionProcessor';
+import { RELEVANCE_TAGS, HAPPENING_TYPES, type RelevanceTag, type HappeningType } from '@shared/types/gameTypes';
+import { CANONICAL_EFFECT_KEYS, lintMeetings, type LintIssue } from '@/admin/contentLint';
 
 // Use shared types from contracts
 type Effect = Record<string, number>;
@@ -42,7 +46,40 @@ type Choice = DialogueChoiceContract;
 type Action = WeeklyAction;
 type ActionsData = ActionsConfig;
 
-const data = actionsData as ActionsData;
+export const ACTIONS_CONFIG_QUERY_KEY = ['admin:actions-config'] as const;
+
+// Plain-language labels for the `requires` relevance-tag checkbox group.
+const RELEVANCE_TAG_LABELS: Record<RelevanceTag, string> = {
+  artist_signed: 'At least one artist signed',
+  music_exists: 'The label has released music',
+  release_planned: 'A release is currently planned',
+  release_out: 'A release went out this week',
+  recording_project_active: 'A recording project is active',
+  tour_active: 'A tour is currently active',
+};
+
+// Plain-language labels + "why now" explainer copy for the reactive_trigger selector.
+const HAPPENING_TYPE_LABELS: Record<HappeningType, string> = {
+  chart_debut: 'A song debuted on the charts this week',
+  release_out: 'A release went live this week',
+  mood_crater: "An artist's mood cratered this week",
+  recent_signing: 'An artist was signed last week',
+};
+
+/**
+ * Pure helper: given the current set of checked relevance tags, returns the
+ * `requires` value to store on the action — `undefined` (field omitted) when
+ * nothing is checked, since the schema requires nonempty-or-absent and the
+ * engine treats "no requires field" as always-eligible (NOT the same as an
+ * empty array, which the schema rejects outright).
+ */
+export function computeRequiresFromChecked(checked: ReadonlySet<RelevanceTag>): RelevanceTag[] | undefined {
+  if (checked.size === 0) return undefined;
+  // Keep a stable, canonical ordering (RELEVANCE_TAGS order) regardless of
+  // check/uncheck order, so diffs stay predictable.
+  const ordered = RELEVANCE_TAGS.filter((tag) => checked.has(tag));
+  return ordered.length > 0 ? ordered : undefined;
+}
 
 const prefixMap: Record<string, IconPrefix> = {
   fas: 'fas',
@@ -92,9 +129,11 @@ const formatIconLabel = (iconClass: string) => {
   return iconName.replace('fa-', '').replace(/-/g, ' ');
 };
 
-// Effects that are actually implemented in GameEngine.applyEffects()
-const CONNECTED_EFFECTS = ['money', 'reputation', 'creative_capital', 'artist_mood', 'artist_energy', 'artist_popularity'];
-const isEffectConnected = (effectKey: string) => CONNECTED_EFFECTS.includes(effectKey);
+// Canonical effect whitelist: LIVE_EFFECT_KEYS ∪ {executive_mood} (imported from
+// @/admin/contentLint, which itself derives from ActionProcessor.ts — the single
+// source of truth). Anything outside this set is "orphaned" — legacy data the
+// engine no longer reads.
+const isEffectConnected = (effectKey: string) => (CANONICAL_EFFECT_KEYS as readonly string[]).includes(effectKey);
 
 export default function ActionsViewer() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -113,13 +152,41 @@ export default function ActionsViewer() {
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [deleteConfirmActionId, setDeleteConfirmActionId] = useState<string | null>(null);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+  const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);
   const { toast} = useToast();
+  const queryClient = useQueryClient();
+
+  // Data source: fetch via the admin GET endpoint (no static bundle import — the
+  // viewer must reflect the live file, including after a save, not build-time data).
+  const {
+    data: fetchedConfig,
+    isLoading: isConfigLoading,
+    isError: isConfigError,
+    error: configError,
+  } = useQuery<ActionsData>({
+    queryKey: ACTIONS_CONFIG_QUERY_KEY,
+    queryFn: async () => {
+      const response = await apiRequest('GET', '/api/admin/actions-config');
+      return response.json();
+    },
+  });
+
+  // Fallback empty shape while loading/erroring so hooks below can run
+  // unconditionally (rules-of-hooks) — the JSX gates on isConfigLoading/isConfigError
+  // before rendering the actions list.
+  const data: ActionsData = fetchedConfig ?? {
+    version: '',
+    generated: '',
+    description: '',
+    weekly_actions: [],
+    action_categories: [],
+  };
 
   // Get unique roles from actions
   const uniqueRoles = useMemo(() => {
     const roles = new Set(data.weekly_actions.map(action => action.role_id));
     return Array.from(roles).sort();
-  }, []);
+  }, [data.weekly_actions]);
 
   // Role display names
   const getRoleDisplayName = (roleId: string) => {
@@ -185,6 +252,18 @@ export default function ActionsViewer() {
       value: iconClass,
       label: formatIconLabel(iconClass),
       iconClass: iconClass
+    }));
+  };
+
+  // Canonical effect-name options for the effect picker (2.2a): the canonical
+  // whitelist only, each carrying its EFFECT_CHANNEL_DESCRIPTIONS blurb for
+  // help text/title. Replaces the old data-derived getAllEffectNames dropdown.
+  const getCanonicalEffectOptions = () => {
+    return CANONICAL_EFFECT_KEYS.map(key => ({
+      value: key,
+      label: key.replace(/_/g, ' '),
+      description: EFFECT_CHANNEL_DESCRIPTIONS[key]?.text,
+      title: EFFECT_CHANNEL_DESCRIPTIONS[key]?.title ?? key,
     }));
   };
 
@@ -318,17 +397,11 @@ export default function ActionsViewer() {
     }
   };
 
-  // Get all unique effect names from all actions
-  const getAllEffectNames = useMemo(() => {
-    const effectNames = new Set<string>();
-    data.weekly_actions.forEach(action => {
-      action.choices.forEach(choice => {
-        Object.keys(choice.effects_immediate).forEach(key => effectNames.add(key));
-        Object.keys(choice.effects_delayed).forEach(key => effectNames.add(key));
-      });
-    });
-    return Array.from(effectNames).sort();
-  }, []);
+  // Canonical effect names for the effect-name picker (2.2a): the effect-name
+  // Select in edit mode offers ONLY canonical keys — no data-derived union, no
+  // 'new_effect' fallback. Kept as `getAllEffectNames` name for call-site
+  // continuity; sourced from CANONICAL_EFFECT_KEYS.
+  const getAllEffectNames = CANONICAL_EFFECT_KEYS;
 
   // Toggle expanded state for a choice
   const toggleChoiceExpanded = (actionId: string, choiceId: string) => {
@@ -491,10 +564,12 @@ export default function ActionsViewer() {
     const effectsKey = effectType === 'immediate' ? 'effects_immediate' : 'effects_delayed';
     const existingKeys = Object.keys(choice[effectsKey]);
 
-    // Find first unused effect name
+    // Find first unused effect name — ALWAYS from the canonical set, never a
+    // non-canonical fallback like the old 'new_effect' placeholder.
     let newEffectKey = 'money';
     if (existingKeys.includes(newEffectKey)) {
-      newEffectKey = getAllEffectNames.find(name => !existingKeys.includes(name)) || 'new_effect';
+      newEffectKey =
+        getAllEffectNames.find(name => !existingKeys.includes(name)) ?? CANONICAL_EFFECT_KEYS[0];
     }
 
     updateEffect(actionId, choiceId, effectType, newEffectKey, 0);
@@ -502,6 +577,9 @@ export default function ActionsViewer() {
 
   // Add new action
   const addAction = () => {
+    // requires/reactive_trigger deliberately OMITTED here (not set to empty/none):
+    // absent means always-eligible and never-reactive (spec §2.2d) — the editors
+    // below handle their absence directly.
     const newAction: Action = {
       id: `action_${Date.now()}`,
       name: 'New Action',
@@ -555,6 +633,7 @@ export default function ActionsViewer() {
     setModifiedActions(new Map());
     setNewActions([]);
     setDeletedActionIds(new Set());
+    setLintIssues([]);
     toast({
       title: "Changes Discarded",
       description: "All unsaved changes have been discarded.",
@@ -577,6 +656,7 @@ export default function ActionsViewer() {
     setModifiedActions(new Map());
     setNewActions([]);
     setDeletedActionIds(new Set());
+    setLintIssues([]);
   };
 
   // Save all changes to the backend
@@ -592,6 +672,7 @@ export default function ActionsViewer() {
     }
 
     setIsSaving(true);
+    setLintIssues([]);
 
     try {
       // Create a new copy of the data with all changes applied
@@ -607,13 +688,28 @@ export default function ActionsViewer() {
         ...newActions
       ];
 
+      // Lint gate FIRST (spec §2.2f): hard-block issues (bad effect key, bad
+      // requires tag, bad reactive_trigger, empty choices, dup ids, weakly-
+      // dominant choices) must all clear before we even attempt the Zod parse.
+      const issues = lintMeetings(updatedActions);
+      if (issues.length > 0) {
+        setLintIssues(issues);
+        toast({
+          title: "Lint Failed",
+          description: `Found ${issues.length} issue${issues.length !== 1 ? 's' : ''} that must be fixed before saving. See the panel below.`,
+          variant: "destructive",
+        });
+        setIsSaving(false);
+        return;
+      }
+
       const updatedConfig = {
         ...data,
         weekly_actions: updatedActions,
         generated: new Date().toISOString()
       };
 
-      // Validate using shared schema BEFORE sending to backend
+      // Validate using shared schema BEFORE sending to backend (second gate)
       try {
         ActionsConfigSchema.parse(updatedConfig);
       } catch (validationError: any) {
@@ -647,15 +743,13 @@ export default function ActionsViewer() {
         variant: "default",
       });
 
-      // Clear all changes and reload the page to reflect changes
+      // Clear all local edit state and refetch the config instead of a full
+      // page reload (spec §2.2e).
       setModifiedActions(new Map());
       setNewActions([]);
       setDeletedActionIds(new Set());
-
-      // Reload the page after a short delay to let user see the success message
-      setTimeout(() => {
-        window.location.reload();
-      }, 1500);
+      setLintIssues([]);
+      await queryClient.invalidateQueries({ queryKey: ACTIONS_CONFIG_QUERY_KEY });
 
     } catch (error) {
       console.error('Failed to save actions config:', error);
@@ -669,6 +763,35 @@ export default function ActionsViewer() {
     }
   };
 
+  if (isConfigLoading) {
+    return (
+      <GameLayout>
+        <div className="container mx-auto p-6">
+          <Card className="bg-gray-900/50 border-white/10">
+            <CardContent className="p-8 text-center text-white/60">
+              Loading actions configuration...
+            </CardContent>
+          </Card>
+        </div>
+      </GameLayout>
+    );
+  }
+
+  if (isConfigError) {
+    return (
+      <GameLayout>
+        <div className="container mx-auto p-6">
+          <Card className="bg-red-900/20 border-red-500/30">
+            <CardContent className="p-8 text-center text-red-300">
+              Failed to load actions configuration
+              {configError instanceof Error ? `: ${configError.message}` : '.'}
+            </CardContent>
+          </Card>
+        </div>
+      </GameLayout>
+    );
+  }
+
   return (
     <GameLayout>
       <div className="container mx-auto p-6 space-y-6">
@@ -681,6 +804,33 @@ export default function ActionsViewer() {
             </p>
             <p className="text-sm text-white/50">{data.description}</p>
           </div>
+
+          {/* Lint Error Panel (spec §2.2f): grouped by action, scope + message. */}
+          {lintIssues.length > 0 && (
+            <Card className="bg-red-900/20 border-red-500/30">
+              <CardHeader>
+                <CardTitle className="text-lg text-red-300 flex items-center gap-2">
+                  <AlertCircle className="h-5 w-5" />
+                  Save blocked — {lintIssues.length} lint issue{lintIssues.length !== 1 ? 's' : ''}
+                </CardTitle>
+                <CardDescription className="text-red-200/70">
+                  Fix the issues below before saving. These mirror hard rules the test suite enforces.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-2">
+                  {lintIssues.map((issue, idx) => (
+                    <li key={`${issue.scope}-${idx}`} className="text-sm text-red-200">
+                      <Badge variant="outline" className="text-xs bg-red-500/20 text-red-300 border-red-500/30 mr-2">
+                        {issue.scope}
+                      </Badge>
+                      {issue.message}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
 
           {/* Production Warning Banner */}
           {import.meta.env.PROD && (
@@ -1337,7 +1487,87 @@ export default function ActionsViewer() {
                               placeholder="meeting_id"
                             />
                           </div>
+
+                          {/* requires (relevance tags) editor (spec §2.2a) */}
+                          <div className="col-span-2">
+                            <label className="text-xs text-white/60 mb-1 block">
+                              Eligibility Requirements (requires)
+                            </label>
+                            <div className="space-y-1.5 p-2 bg-black/20 rounded border border-white/10">
+                              {RELEVANCE_TAGS.map(tag => {
+                                const currentRequires = (action.requires ?? []) as string[];
+                                const checked = currentRequires.includes(tag);
+                                return (
+                                  <label key={tag} className="flex items-center gap-2 text-xs text-white/80 cursor-pointer">
+                                    <Checkbox
+                                      checked={checked}
+                                      onCheckedChange={(value) => {
+                                        const current = new Set<RelevanceTag>(currentRequires as RelevanceTag[]);
+                                        if (value) {
+                                          current.add(tag);
+                                        } else {
+                                          current.delete(tag);
+                                        }
+                                        const nextRequires = computeRequiresFromChecked(current);
+                                        updateAction(action.id, {
+                                          requires: nextRequires as Action['requires'],
+                                        });
+                                      }}
+                                    />
+                                    {RELEVANCE_TAG_LABELS[tag]}
+                                  </label>
+                                );
+                              })}
+                            </div>
+                            <div className="text-xs text-white/40 mt-1">
+                              Meeting is only offered when ALL checked conditions are true. Nothing checked = always available.
+                            </div>
+                          </div>
+
+                          {/* reactive_trigger selector (spec §2.2c) */}
+                          <div className="col-span-2">
+                            <label className="text-xs text-white/60 mb-1 block">Reactive Trigger</label>
+                            <Select
+                              value={action.reactive_trigger ?? 'none'}
+                              onValueChange={(value) => {
+                                updateAction(action.id, {
+                                  reactive_trigger: value === 'none' ? undefined : (value as HappeningType),
+                                });
+                              }}
+                            >
+                              <SelectTrigger className="h-8 text-xs bg-black/30 border-white/10">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="none">None (not reactive)</SelectItem>
+                                {HAPPENING_TYPES.map(trigger => (
+                                  <SelectItem key={trigger} value={trigger} title={HAPPENING_TYPE_LABELS[trigger]}>
+                                    {HAPPENING_TYPE_LABELS[trigger]}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <div className="text-xs text-white/40 mt-1">
+                              A reactive meeting jumps ahead of the normal draw when its trigger happened this week.
+                            </div>
+                          </div>
                         </div>
+                      </div>
+                    )}
+
+                    {/* requires / reactive_trigger badges (view mode) */}
+                    {!editMode && ((action.requires && action.requires.length > 0) || action.reactive_trigger) && (
+                      <div className="flex flex-wrap gap-2">
+                        {(action.requires ?? []).map(tag => (
+                          <Badge key={tag} variant="outline" className="text-xs bg-purple-500/10 text-purple-300 border-purple-500/30">
+                            {RELEVANCE_TAG_LABELS[tag as RelevanceTag] ?? tag}
+                          </Badge>
+                        ))}
+                        {action.reactive_trigger && (
+                          <Badge variant="outline" className="text-xs bg-amber-500/10 text-amber-300 border-amber-500/30">
+                            Reactive: {HAPPENING_TYPE_LABELS[action.reactive_trigger as HappeningType] ?? action.reactive_trigger}
+                          </Badge>
+                        )}
                       </div>
                     )}
 
@@ -1467,11 +1697,9 @@ export default function ActionsViewer() {
                                                     <SelectValue />
                                                   </SelectTrigger>
                                                   <SelectContent>
-                                                    {getAllEffectNames.map(effectName => (
-                                                      <SelectItem key={effectName} value={effectName}>
-                                                        <span className={!isEffectConnected(effectName) ? 'text-gray-500' : undefined}>
-                                                          {effectName.replace(/_/g, ' ')} {!isEffectConnected(effectName) && '○'}
-                                                        </span>
+                                                    {getCanonicalEffectOptions().map(opt => (
+                                                      <SelectItem key={opt.value} value={opt.value} title={opt.description}>
+                                                        {opt.label}
                                                       </SelectItem>
                                                     ))}
                                                   </SelectContent>
@@ -1553,11 +1781,9 @@ export default function ActionsViewer() {
                                                     <SelectValue />
                                                   </SelectTrigger>
                                                   <SelectContent>
-                                                    {getAllEffectNames.map(effectName => (
-                                                      <SelectItem key={effectName} value={effectName}>
-                                                        <span className={!isEffectConnected(effectName) ? 'text-gray-500' : undefined}>
-                                                          {effectName.replace(/_/g, ' ')} {!isEffectConnected(effectName) && '○'}
-                                                        </span>
+                                                    {getCanonicalEffectOptions().map(opt => (
+                                                      <SelectItem key={opt.value} value={opt.value} title={opt.description}>
+                                                        {opt.label}
                                                       </SelectItem>
                                                     ))}
                                                   </SelectContent>

--- a/client/src/admin/ActionsViewer.tsx
+++ b/client/src/admin/ActionsViewer.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import GameLayout from '@/layouts/GameLayout';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -765,40 +764,36 @@ export default function ActionsViewer() {
 
   if (isConfigLoading) {
     return (
-      <GameLayout>
-        <div className="container mx-auto p-6">
-          <Card className="bg-gray-900/50 border-white/10">
-            <CardContent className="p-8 text-center text-white/60">
-              Loading actions configuration...
-            </CardContent>
-          </Card>
-        </div>
-      </GameLayout>
+      <div className="container mx-auto p-6">
+        <Card className="bg-gray-900/50 border-white/10">
+          <CardContent className="p-8 text-center text-white/60">
+            Loading actions configuration...
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 
   if (isConfigError) {
     return (
-      <GameLayout>
-        <div className="container mx-auto p-6">
-          <Card className="bg-red-900/20 border-red-500/30">
-            <CardContent className="p-8 text-center text-red-300">
-              Failed to load actions configuration
-              {configError instanceof Error ? `: ${configError.message}` : '.'}
-            </CardContent>
-          </Card>
-        </div>
-      </GameLayout>
+      <div className="container mx-auto p-6">
+        <Card className="bg-red-900/20 border-red-500/30">
+          <CardContent className="p-8 text-center text-red-300">
+            Failed to load actions configuration
+            {configError instanceof Error ? `: ${configError.message}` : '.'}
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 
   return (
-    <GameLayout>
-      <div className="container mx-auto p-6 space-y-6">
+    <>
+    <div className="container mx-auto p-6 space-y-6">
         {/* Header */}
         <div className="space-y-4">
           <div>
-            <h1 className="text-3xl font-bold text-white">Actions JSON Viewer</h1>
+            <h2 className="text-2xl font-bold text-white">Meetings</h2>
             <p className="text-white/70">
               Version {data.version} • Generated {data.generated} • {data.weekly_actions.length} actions
             </p>
@@ -1959,6 +1954,6 @@ export default function ActionsViewer() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </GameLayout>
+    </>
   );
 }

--- a/client/src/admin/ActionsViewer.tsx
+++ b/client/src/admin/ActionsViewer.tsx
@@ -25,6 +25,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import { Zap, Clock, Edit, Save, X, AlertCircle, Pencil, Trash2, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
@@ -38,6 +47,7 @@ import {
 import { EFFECT_CHANNEL_DESCRIPTIONS } from '@shared/engine/processors/ActionProcessor';
 import { RELEVANCE_TAGS, HAPPENING_TYPES, type RelevanceTag, type HappeningType } from '@shared/types/gameTypes';
 import { CANONICAL_EFFECT_KEYS, lintMeetings, type LintIssue } from '@/admin/contentLint';
+import { slugifyId, isIdAvailable, orderWithNewestFirst } from '@/admin/utils';
 
 // Use shared types from contracts
 type Effect = Record<string, number>;
@@ -155,6 +165,18 @@ export default function ActionsViewer() {
   const { toast} = useToast();
   const queryClient = useQueryClient();
 
+  // Creation dialog state (slice 4, playtest feedback: new actions must appear at
+  // the top of the list via a pop-up, not silently appended off-screen at the bottom).
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [createName, setCreateName] = useState('');
+  const [createDescription, setCreateDescription] = useState('');
+  const [createRole, setCreateRole] = useState('ceo');
+  const [createCategory, setCreateCategory] = useState('');
+  const [createScope, setCreateScope] = useState<'global' | 'predetermined' | 'user_selected'>('global');
+  const [createIcon, setCreateIcon] = useState('fas fa-circle');
+  const [createId, setCreateId] = useState('');
+  const [createIdEdited, setCreateIdEdited] = useState(false);
+
   // Data source: fetch via the admin GET endpoint (no static bundle import — the
   // viewer must reflect the live file, including after a save, not build-time data).
   const {
@@ -268,11 +290,13 @@ export default function ActionsViewer() {
 
   // Filter actions based on search and filters
   const filteredActions = useMemo(() => {
-    // Combine original actions (excluding deleted) and new actions
-    const allActions = [
-      ...data.weekly_actions.filter(a => !deletedActionIds.has(a.id)),
-      ...newActions
-    ];
+    // Display order: newest-first new actions on top, then originals — a pure
+    // display-order change (slice 4). The save handler below composes its own
+    // array independently and is unchanged in content/order.
+    const allActions = orderWithNewestFirst(
+      newActions,
+      data.weekly_actions.filter(a => !deletedActionIds.has(a.id)),
+    );
 
     return allActions.filter(action => {
       const matchesSearch = searchTerm === '' ||
@@ -574,21 +598,67 @@ export default function ActionsViewer() {
     updateEffect(actionId, choiceId, effectType, newEffectKey, 0);
   };
 
-  // Add new action
-  const addAction = () => {
+  // All action ids currently in play (originals not deleted + new + modified) —
+  // used by the creation dialog to validate id uniqueness (spec: unique against
+  // ALL current action ids).
+  const allCurrentActionIds = useMemo(() => {
+    const ids = new Set<string>();
+    data.weekly_actions.forEach(a => {
+      if (!deletedActionIds.has(a.id)) ids.add(a.id);
+    });
+    newActions.forEach(a => ids.add(a.id));
+    modifiedActions.forEach((_, id) => ids.add(id));
+    return ids;
+  }, [data.weekly_actions, deletedActionIds, newActions, modifiedActions]);
+
+  const createIdTaken = createId.length > 0 && !isIdAvailable(createId, allCurrentActionIds);
+  const createNameValid = createName.trim().length > 0;
+  const canCreateAction = createNameValid && createId.length > 0 && !createIdTaken;
+
+  const openCreateDialog = () => {
+    setCreateName('');
+    setCreateDescription('');
+    setCreateRole('ceo');
+    setCreateCategory(data.action_categories[0]?.id ?? 'business');
+    setCreateScope('global');
+    setCreateIcon('fas fa-circle');
+    setCreateId('');
+    setCreateIdEdited(false);
+    setShowCreateDialog(true);
+  };
+
+  // Keep the id in sync with the name until the user edits it directly.
+  const handleCreateNameChange = (value: string) => {
+    setCreateName(value);
+    if (!createIdEdited) {
+      setCreateId(slugifyId(value));
+    }
+  };
+
+  const handleCreateIdChange = (value: string) => {
+    setCreateIdEdited(true);
+    setCreateId(value);
+  };
+
+  // Add new action — invoked by the creation dialog's Create button. Replaces the
+  // old instant-append-a-blank-template pattern (playtest feedback: new actions
+  // must appear via a pop-up, at the top of the list, not silently at the bottom).
+  const createAction = () => {
+    if (!canCreateAction) return;
+
     // requires/reactive_trigger deliberately OMITTED here (not set to empty/none):
     // absent means always-eligible and never-reactive (spec §2.2d) — the editors
     // below handle their absence directly.
     const newAction: Action = {
-      id: `action_${Date.now()}`,
-      name: 'New Action',
+      id: createId,
+      name: createName.trim(),
       type: 'role_meeting',
-      icon: 'fas fa-circle',
-      description: '',
-      role_id: 'ceo',
-      meeting_id: `meeting_${Date.now()}`,
-      category: 'business',
-      target_scope: 'global',
+      icon: createIcon,
+      description: createDescription,
+      role_id: createRole,
+      meeting_id: createId,
+      category: createCategory,
+      target_scope: createScope,
       prompt: '',
       choices: [{
         id: 'choice_1',
@@ -597,9 +667,15 @@ export default function ActionsViewer() {
         effects_delayed: {}
       }]
     };
+
+    if (createScope === 'user_selected') {
+      newAction.prompt_before_selection = 'Which artist should be affected by this decision?';
+    }
+
     setNewActions(prev => [...prev, newAction]);
     // Auto-expand the new action
     setExpandedActions(prev => new Set([...Array.from(prev), newAction.id]));
+    setShowCreateDialog(false);
   };
 
   // Delete action
@@ -878,7 +954,7 @@ export default function ActionsViewer() {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={addAction}
+                      onClick={openCreateDialog}
                       className="bg-green-600/10 hover:bg-green-600/20 border-green-500/30 text-green-300"
                     >
                       <Plus className="h-4 w-4 mr-2" />
@@ -1954,6 +2030,156 @@ export default function ActionsViewer() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Create New Action Dialog (slice 4, playtest feedback): replaces the old
+          instant-append pattern. Create adds the action at the TOP of the display
+          list (see filteredActions ordering above); Cancel creates nothing. */}
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Add New Action</DialogTitle>
+            <DialogDescription>
+              Fill in the basics below. You can edit choices, effects, and other metadata after creating.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div>
+              <Label htmlFor="create-action-name">Name *</Label>
+              <Input
+                id="create-action-name"
+                value={createName}
+                onChange={(e) => handleCreateNameChange(e.target.value)}
+                className="bg-black/30 border-white/10 mt-1"
+                placeholder="e.g. CMO: Viral Push"
+                autoFocus
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="create-action-description">Description</Label>
+              <Textarea
+                id="create-action-description"
+                value={createDescription}
+                onChange={(e) => setCreateDescription(e.target.value)}
+                className="bg-black/30 border-white/10 mt-1"
+                rows={2}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>Role</Label>
+                <Select value={createRole} onValueChange={setCreateRole}>
+                  <SelectTrigger className="bg-black/30 border-white/10 mt-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {getRoleOptions().map(opt => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div>
+                <Label>Category</Label>
+                <Select value={createCategory} onValueChange={setCreateCategory}>
+                  <SelectTrigger className="bg-black/30 border-white/10 mt-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {getCategoryOptions().map(opt => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        <span className="flex items-center gap-2">
+                          <FontAwesomeIcon icon={parseIconClass(opt.icon)} />
+                          {opt.label}
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div>
+              <Label>Target Scope</Label>
+              <Select value={createScope} onValueChange={(value) => setCreateScope(value as 'global' | 'predetermined' | 'user_selected')}>
+                <SelectTrigger className="bg-black/30 border-white/10 mt-1">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {getTargetScopeOptions().map(opt => (
+                    <SelectItem key={opt.value} value={opt.value} title={opt.description}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <div className="text-xs text-white/40 mt-1">
+                {getTargetScopeOptions().find(opt => opt.value === createScope)?.description}
+              </div>
+            </div>
+
+            <div>
+              <Label>Icon</Label>
+              <div className="flex gap-3 items-start mt-1">
+                <div className="w-12 h-12 flex items-center justify-center bg-gradient-to-br from-brand-gold/20 to-brand-burgundy/20 rounded-lg border-2 border-brand-gold/40">
+                  <FontAwesomeIcon icon={parseIconClass(createIcon)} className="text-brand-gold text-2xl" />
+                </div>
+                <div className="flex-1">
+                  <Select value={createIcon} onValueChange={setCreateIcon}>
+                    <SelectTrigger className="bg-black/30 border-white/10">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {getIconOptions().map(opt => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          <span className="flex items-center gap-2">
+                            <FontAwesomeIcon icon={parseIconClass(opt.iconClass)} className="text-brand-gold w-4" />
+                            <span className="capitalize">{opt.label}</span>
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <Label htmlFor="create-action-id">ID</Label>
+              <Input
+                id="create-action-id"
+                value={createId}
+                onChange={(e) => handleCreateIdChange(e.target.value)}
+                className="bg-black/30 border-white/10 mt-1 font-mono text-sm"
+              />
+              {createIdTaken && (
+                <div className="text-xs text-red-400 mt-1">This id is already taken.</div>
+              )}
+              {createId.length === 0 && (
+                <div className="text-xs text-white/40 mt-1">Auto-generated from the name; you can edit it.</div>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCreateDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-green-600 hover:bg-green-700"
+              onClick={createAction}
+              disabled={!canCreateAction}
+            >
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/client/src/admin/AdminLayout.tsx
+++ b/client/src/admin/AdminLayout.tsx
@@ -10,7 +10,7 @@ function AdminHome() {
         <p className="text-white/80 mb-6">Developer-only utilities. These may modify game state.</p>
         <div className="grid gap-3 max-w-lg">
           <Link href="/prototypes" className="text-brand-gold hover:underline font-semibold">🎨 UI/UX Prototypes</Link>
-          <Link href="/admin/actions-viewer" className="text-brand-rose hover:underline">📋 Actions JSON Viewer</Link>
+          <Link href="/admin/actions-viewer" className="text-brand-rose hover:underline">📝 Content Editor (Meetings & Side Events)</Link>
           <Link href="/admin/quality-tester" className="text-brand-rose hover:underline">Quality Tester</Link>
           <Link href="/admin/tour-variance-tester" className="text-brand-rose hover:underline">Tour Variance Tester</Link>
           <Link href="/admin/popularity-tester" className="text-brand-rose hover:underline">Popularity Tester</Link>

--- a/client/src/admin/ContentEditorPage.tsx
+++ b/client/src/admin/ContentEditorPage.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import GameLayout from '@/layouts/GameLayout';
+import { Button } from '@/components/ui/button';
+import ActionsViewer from '@/admin/ActionsViewer';
+import SideEventsEditor from '@/admin/SideEventsEditor';
+
+// Tab shell for the Content Editor (content-editor-side-events-and-meetings plan,
+// slice 3). No shadcn Tabs primitive exists in this repo yet (checked:
+// client/src/components/ui/ has no tabs.tsx) — rather than add a new dependency for
+// a two-tab admin page, this is a simple state + button shell matching admin styling.
+// GameLayout wraps the page exactly once, here — ActionsViewer and SideEventsEditor
+// are content-only components (no GameLayout of their own).
+type ContentEditorTab = 'meetings' | 'side-events';
+
+export default function ContentEditorPage() {
+  const [tab, setTab] = useState<ContentEditorTab>('meetings');
+
+  return (
+    <GameLayout>
+      <div className="container mx-auto px-6 pt-6">
+        <h1 className="text-3xl font-bold text-white mb-4">Content Editor</h1>
+        <div className="flex gap-2 border-b border-white/10 pb-2" role="tablist" aria-label="Content Editor tabs">
+          <Button
+            role="tab"
+            aria-selected={tab === 'meetings'}
+            variant={tab === 'meetings' ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => setTab('meetings')}
+          >
+            Meetings
+          </Button>
+          <Button
+            role="tab"
+            aria-selected={tab === 'side-events'}
+            variant={tab === 'side-events' ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => setTab('side-events')}
+          >
+            Side Events
+          </Button>
+        </div>
+      </div>
+      {tab === 'meetings' ? <ActionsViewer /> : <SideEventsEditor />}
+    </GameLayout>
+  );
+}

--- a/client/src/admin/SideEventsEditor.tsx
+++ b/client/src/admin/SideEventsEditor.tsx
@@ -22,6 +22,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import { Zap, Clock, Edit, Save, X, AlertCircle, Trash2, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
@@ -33,6 +42,7 @@ import {
 import { EFFECT_CHANNEL_DESCRIPTIONS } from '@shared/engine/processors/ActionProcessor';
 import { SIDE_EVENT_CATEGORIES, type SideEventCategory } from '@shared/types/gameTypes';
 import { CANONICAL_EFFECT_KEYS, lintSideEvents, type LintIssue } from '@/admin/contentLint';
+import { slugifyId, isIdAvailable, orderWithNewestFirst } from '@/admin/utils';
 
 // Read-only balance-knob display context (spec §2.3/fork B): a static import of the
 // authored knob file. This is DISPLAY ONLY — knob edits happen in git, not this tool.
@@ -96,6 +106,16 @@ export function getCategoryOptions(): Array<{ value: SideEventCategory; label: s
   }));
 }
 
+/**
+ * Pure helper: derives a slug seed from the first ~4 words of a prompt, e.g.
+ * "A rival label tries to poach your artist" -> "a_rival_label_tries". Exported
+ * for unit testing without mounting the component.
+ */
+export function slugifyIdFromPromptWords(prompt: string, wordCount: number = 4): string {
+  const words = prompt.trim().split(/\s+/).filter(Boolean).slice(0, wordCount);
+  return slugifyId(words.join(' '));
+}
+
 const getCanonicalEffectOptions = () => {
   return CANONICAL_EFFECT_KEYS.map((key) => ({
     value: key,
@@ -122,6 +142,15 @@ export default function SideEventsEditor() {
   const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);
   const { toast } = useToast();
   const queryClient = useQueryClient();
+
+  // Creation dialog state (slice 4, playtest feedback): new events must appear at
+  // the top of the list via a pop-up, not silently appended off-screen at the bottom.
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [createPrompt, setCreatePrompt] = useState('');
+  const [createRoleHint, setCreateRoleHint] = useState('');
+  const [createCategory, setCreateCategory] = useState<SideEventCategory>('industry_drama');
+  const [createId, setCreateId] = useState('');
+  const [createIdEdited, setCreateIdEdited] = useState(false);
 
   const {
     data: fetchedConfig,
@@ -159,10 +188,13 @@ export default function SideEventsEditor() {
   }, [data.events, newEvents, deletedEventIds]);
 
   const filteredEvents = useMemo(() => {
-    const allEvents = [
-      ...data.events.filter((e) => !deletedEventIds.has(e.id)),
-      ...newEvents,
-    ];
+    // Display order: newest-first new events on top, then originals — a pure
+    // display-order change (slice 4). The save handler composes its own array
+    // independently and is unchanged in content/order.
+    const allEvents = orderWithNewestFirst(
+      newEvents,
+      data.events.filter((e) => !deletedEventIds.has(e.id)),
+    );
     return allEvents.filter((event) => {
       const matchesSearch =
         searchTerm === '' ||
@@ -317,10 +349,65 @@ export default function SideEventsEditor() {
     updateEffect(eventId, choiceId, effectType, newEffectKey, 0);
   };
 
-  const addEvent = () => {
+  // All event ids currently in play (originals not deleted + new + modified) —
+  // used by the creation dialog to validate id uniqueness.
+  const allCurrentEventIds = useMemo(() => {
+    const ids = new Set<string>();
+    data.events.forEach((e) => {
+      if (!deletedEventIds.has(e.id)) ids.add(e.id);
+    });
+    newEvents.forEach((e) => ids.add(e.id));
+    modifiedEvents.forEach((_, id) => ids.add(id));
+    return ids;
+  }, [data.events, deletedEventIds, newEvents, modifiedEvents]);
+
+  const createIdTaken = createId.length > 0 && !isIdAvailable(createId, allCurrentEventIds);
+  const createPromptValid = createPrompt.trim().length > 0;
+  const canCreateEvent = createPromptValid && createId.length > 0 && !createIdTaken;
+
+  /**
+   * Pure helper: slug seed derived from the first ~4 words of the prompt.
+   * Exported for unit testing.
+   */
+  const openCreateDialog = () => {
+    setCreatePrompt('');
+    setCreateRoleHint('');
+    setCreateCategory('industry_drama');
+    setCreateId('');
+    setCreateIdEdited(false);
+    setShowCreateDialog(true);
+  };
+
+  const handleCreatePromptChange = (value: string) => {
+    setCreatePrompt(value);
+    if (!createIdEdited) {
+      setCreateId(slugifyIdFromPromptWords(value));
+    }
+  };
+
+  const handleCreateIdChange = (value: string) => {
+    setCreateIdEdited(true);
+    setCreateId(value);
+  };
+
+  // Create new event — invoked by the creation dialog's Create button. Replaces
+  // the old instant-append-a-blank-template pattern (playtest feedback: new events
+  // must appear via a pop-up, at the top of the list, not silently at the bottom).
+  const createEvent = () => {
+    if (!canCreateEvent) return;
+
     const template = newEventTemplate();
-    setNewEvents((prev) => [...prev, template]);
-    setExpandedEvents((prev) => new Set([...Array.from(prev), template.id]));
+    const newEvent: Event = {
+      ...template,
+      id: createId,
+      role_hint: createRoleHint,
+      category: createCategory,
+      prompt: createPrompt.trim(),
+    };
+
+    setNewEvents((prev) => [...prev, newEvent]);
+    setExpandedEvents((prev) => new Set([...Array.from(prev), newEvent.id]));
+    setShowCreateDialog(false);
   };
 
   const deleteEvent = (eventId: string) => {
@@ -585,7 +672,7 @@ export default function SideEventsEditor() {
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={addEvent}
+                    onClick={openCreateDialog}
                     className="bg-green-600/10 hover:bg-green-600/20 border-green-500/30 text-green-300"
                   >
                     <Plus className="h-4 w-4 mr-2" />
@@ -1133,6 +1220,91 @@ export default function SideEventsEditor() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Create New Event Dialog (slice 4, playtest feedback): replaces the old
+          instant-append pattern. Create adds the event at the TOP of the display
+          list (see filteredEvents ordering above); Cancel creates nothing. */}
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Add New Side Event</DialogTitle>
+            <DialogDescription>
+              Fill in the basics below. You can edit choices, effects, and other metadata after creating.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div>
+              <Label htmlFor="create-event-prompt">Prompt *</Label>
+              <Textarea
+                id="create-event-prompt"
+                value={createPrompt}
+                onChange={(e) => handleCreatePromptChange(e.target.value)}
+                className="bg-black/30 border-white/10 mt-1"
+                rows={3}
+                placeholder="e.g. A rival label tries to poach your artist..."
+                autoFocus
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="create-event-role-hint">Role Hint</Label>
+              <Input
+                id="create-event-role-hint"
+                value={createRoleHint}
+                onChange={(e) => setCreateRoleHint(e.target.value)}
+                className="bg-black/30 border-white/10 mt-1"
+                placeholder="e.g. Sync Licensing"
+              />
+            </div>
+
+            <div>
+              <Label>Category</Label>
+              <Select value={createCategory} onValueChange={(value) => setCreateCategory(value as SideEventCategory)}>
+                <SelectTrigger className="bg-black/30 border-white/10 mt-1">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {getCategoryOptions().map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label} — weight {opt.weight}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label htmlFor="create-event-id">ID</Label>
+              <Input
+                id="create-event-id"
+                value={createId}
+                onChange={(e) => handleCreateIdChange(e.target.value)}
+                className="bg-black/30 border-white/10 mt-1 font-mono text-sm"
+              />
+              {createIdTaken && (
+                <div className="text-xs text-red-400 mt-1">This id is already taken.</div>
+              )}
+              {createId.length === 0 && (
+                <div className="text-xs text-white/40 mt-1">Auto-generated from the prompt; you can edit it.</div>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCreateDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-green-600 hover:bg-green-700"
+              onClick={createEvent}
+              disabled={!canCreateEvent}
+            >
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/admin/SideEventsEditor.tsx
+++ b/client/src/admin/SideEventsEditor.tsx
@@ -1,0 +1,1138 @@
+import { useState, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Zap, Clock, Edit, Save, X, AlertCircle, Trash2, Plus, ChevronDown, ChevronRight } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { apiRequest } from '@/lib/queryClient';
+import {
+  EventsConfigSchema,
+  type SideEventContract,
+  type EventsConfig,
+} from '@shared/api/contracts';
+import { EFFECT_CHANNEL_DESCRIPTIONS } from '@shared/engine/processors/ActionProcessor';
+import { SIDE_EVENT_CATEGORIES, type SideEventCategory } from '@shared/types/gameTypes';
+import { CANONICAL_EFFECT_KEYS, lintSideEvents, type LintIssue } from '@/admin/contentLint';
+
+// Read-only balance-knob display context (spec §2.3/fork B): a static import of the
+// authored knob file. This is DISPLAY ONLY — knob edits happen in git, not this tool.
+// eslint-disable-next-line import/no-relative-packages
+import balanceEvents from '../../../data/balance/events.json';
+
+type Choice = SideEventContract['choices'][number];
+type Event = SideEventContract;
+
+export const EVENTS_CONFIG_QUERY_KEY = ['admin:events-config'] as const;
+
+const sideEventsBalance = (balanceEvents as any).side_events as {
+  weekly_chance: number;
+  max_events_per_week: number;
+  event_cooldown: number;
+  event_weights: Record<string, number>;
+};
+
+// Plain-language category labels for the picker.
+const CATEGORY_LABELS: Record<SideEventCategory, string> = {
+  sync_licensing: 'Sync Licensing',
+  copyright_issues: 'Copyright Issues',
+  platform_opportunities: 'Platform Opportunities',
+  industry_drama: 'Industry Drama',
+  technical_problems: 'Technical Problems',
+  business_opportunities: 'Business Opportunities',
+  artist_personal: 'Artist Personal',
+};
+
+/**
+ * Pure helper: template for a newly-added side event (fork D, full CRUD).
+ * Exported for unit testing without mounting the component.
+ */
+export function newEventTemplate(now: number = Date.now()): Event {
+  return {
+    id: `event_${now}`,
+    role_hint: '',
+    category: 'industry_drama',
+    prompt: '',
+    choices: [
+      {
+        id: 'choice_1',
+        label: 'Choice 1',
+        effects_immediate: {},
+        effects_delayed: {},
+      },
+    ],
+  };
+}
+
+/**
+ * Pure helper: category Select options, each carrying its current weight (or a
+ * "no events yet" marker context is computed by the caller, since that needs the
+ * live event list). Exported for testing.
+ */
+export function getCategoryOptions(): Array<{ value: SideEventCategory; label: string; weight: number | undefined }> {
+  return SIDE_EVENT_CATEGORIES.map((cat) => ({
+    value: cat,
+    label: CATEGORY_LABELS[cat],
+    weight: sideEventsBalance?.event_weights?.[cat],
+  }));
+}
+
+const getCanonicalEffectOptions = () => {
+  return CANONICAL_EFFECT_KEYS.map((key) => ({
+    value: key,
+    label: key.replace(/_/g, ' '),
+    description: EFFECT_CHANNEL_DESCRIPTIONS[key]?.text,
+    title: EFFECT_CHANNEL_DESCRIPTIONS[key]?.title ?? key,
+  }));
+};
+
+export default function SideEventsEditor() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState<SideEventCategory | null>(null);
+  const [expandedEvents, setExpandedEvents] = useState<Set<string>>(new Set());
+  const [expandedChoices, setExpandedChoices] = useState<Map<string, Set<string>>>(new Map());
+
+  const [editMode, setEditMode] = useState(false);
+  const [modifiedEvents, setModifiedEvents] = useState<Map<string, Event>>(new Map());
+  const [newEvents, setNewEvents] = useState<Event[]>([]);
+  const [deletedEventIds, setDeletedEventIds] = useState<Set<string>>(new Set());
+  const [isSaving, setIsSaving] = useState(false);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [deleteConfirmEventId, setDeleteConfirmEventId] = useState<string | null>(null);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+  const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const {
+    data: fetchedConfig,
+    isLoading: isConfigLoading,
+    isError: isConfigError,
+    error: configError,
+  } = useQuery<EventsConfig>({
+    queryKey: EVENTS_CONFIG_QUERY_KEY,
+    queryFn: async () => {
+      const response = await apiRequest('GET', '/api/admin/events-config');
+      return response.json();
+    },
+  });
+
+  const data: EventsConfig = fetchedConfig ?? {
+    version: '',
+    generated: '',
+    events: [],
+  };
+
+  const totalChanges = modifiedEvents.size + newEvents.length + deletedEventIds.size;
+
+  // Count authored events per category, for the "(no events yet)" note.
+  const eventCountByCategory = useMemo(() => {
+    const counts: Partial<Record<SideEventCategory, number>> = {};
+    const allEvents = [
+      ...data.events.filter((e) => !deletedEventIds.has(e.id)),
+      ...newEvents,
+    ];
+    for (const ev of allEvents) {
+      const cat = ev.category as SideEventCategory;
+      counts[cat] = (counts[cat] ?? 0) + 1;
+    }
+    return counts;
+  }, [data.events, newEvents, deletedEventIds]);
+
+  const filteredEvents = useMemo(() => {
+    const allEvents = [
+      ...data.events.filter((e) => !deletedEventIds.has(e.id)),
+      ...newEvents,
+    ];
+    return allEvents.filter((event) => {
+      const matchesSearch =
+        searchTerm === '' ||
+        event.id.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        event.prompt.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        event.role_hint.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchesCategory = !selectedCategory || event.category === selectedCategory;
+      return matchesSearch && matchesCategory;
+    });
+  }, [searchTerm, selectedCategory, data.events, newEvents, deletedEventIds]);
+
+  const getCurrentEvent = (eventId: string): Event => {
+    if (modifiedEvents.has(eventId)) return modifiedEvents.get(eventId)!;
+    const newEvent = newEvents.find((e) => e.id === eventId);
+    if (newEvent) return newEvent;
+    return data.events.find((e) => e.id === eventId)!;
+  };
+
+  const updateEvent = (eventId: string, updates: Partial<Event>) => {
+    const current = getCurrentEvent(eventId);
+    const updated = { ...current, ...updates };
+    const isNew = newEvents.some((e) => e.id === eventId);
+    if (isNew) {
+      setNewEvents((prev) => prev.map((e) => (e.id === eventId ? updated : e)));
+    } else {
+      setModifiedEvents(new Map(modifiedEvents).set(eventId, updated));
+    }
+  };
+
+  const toggleEventExpanded = (eventId: string) => {
+    setExpandedEvents((prev) => {
+      const next = new Set(prev);
+      if (next.has(eventId)) next.delete(eventId);
+      else next.add(eventId);
+      return next;
+    });
+  };
+
+  const toggleChoiceExpanded = (eventId: string, choiceId: string) => {
+    setExpandedChoices((prev) => {
+      const newMap = new Map(prev);
+      const eventChoices = newMap.get(eventId) || new Set();
+      const nextChoices = new Set(eventChoices);
+      if (nextChoices.has(choiceId)) nextChoices.delete(choiceId);
+      else nextChoices.add(choiceId);
+      newMap.set(eventId, nextChoices);
+      return newMap;
+    });
+  };
+
+  const isChoiceExpanded = (eventId: string, choiceId: string): boolean => {
+    return expandedChoices.get(eventId)?.has(choiceId) || false;
+  };
+
+  const updateChoice = (eventId: string, choiceId: string, updates: Partial<Choice>) => {
+    const current = getCurrentEvent(eventId);
+    const updatedChoices = current.choices.map((c) => (c.id === choiceId ? { ...c, ...updates } : c));
+    updateEvent(eventId, { choices: updatedChoices });
+  };
+
+  const addChoice = (eventId: string) => {
+    const current = getCurrentEvent(eventId);
+    const newChoice: Choice = {
+      id: `choice_${Date.now()}`,
+      label: 'New Choice',
+      effects_immediate: {},
+      effects_delayed: {},
+    };
+    updateEvent(eventId, { choices: [...current.choices, newChoice] });
+    toggleChoiceExpanded(eventId, newChoice.id);
+  };
+
+  const deleteChoice = (eventId: string, choiceId: string) => {
+    const current = getCurrentEvent(eventId);
+    if (current.choices.length <= 1) {
+      toast({
+        title: 'Cannot Delete',
+        description: 'Events must have at least one choice.',
+        variant: 'destructive',
+      });
+      return;
+    }
+    updateEvent(eventId, { choices: current.choices.filter((c) => c.id !== choiceId) });
+  };
+
+  const updateEffect = (
+    eventId: string,
+    choiceId: string,
+    effectType: 'immediate' | 'delayed',
+    effectKey: string,
+    value: number,
+  ) => {
+    const current = getCurrentEvent(eventId);
+    const updatedChoices = current.choices.map((choice) => {
+      if (choice.id !== choiceId) return choice;
+      const effectsKey = effectType === 'immediate' ? 'effects_immediate' : 'effects_delayed';
+      return {
+        ...choice,
+        [effectsKey]: {
+          ...choice[effectsKey],
+          [effectKey]: value,
+        },
+      };
+    });
+    updateEvent(eventId, { choices: updatedChoices });
+  };
+
+  const renameEffect = (
+    eventId: string,
+    choiceId: string,
+    effectType: 'immediate' | 'delayed',
+    oldKey: string,
+    newKey: string,
+  ) => {
+    if (oldKey === newKey) return;
+    const current = getCurrentEvent(eventId);
+    const updatedChoices = current.choices.map((choice) => {
+      if (choice.id !== choiceId) return choice;
+      const effectsKey = effectType === 'immediate' ? 'effects_immediate' : 'effects_delayed';
+      const effectValue = choice[effectsKey][oldKey];
+      if (effectValue === undefined) return choice;
+      const { [oldKey]: _, ...remaining } = choice[effectsKey];
+      return {
+        ...choice,
+        [effectsKey]: { ...remaining, [newKey]: Number(effectValue) },
+      };
+    });
+    updateEvent(eventId, { choices: updatedChoices });
+  };
+
+  const deleteEffect = (eventId: string, choiceId: string, effectType: 'immediate' | 'delayed', effectKey: string) => {
+    const current = getCurrentEvent(eventId);
+    const updatedChoices = current.choices.map((choice) => {
+      if (choice.id !== choiceId) return choice;
+      const effectsKey = effectType === 'immediate' ? 'effects_immediate' : 'effects_delayed';
+      const { [effectKey]: _, ...remaining } = choice[effectsKey];
+      return { ...choice, [effectsKey]: remaining };
+    });
+    updateEvent(eventId, { choices: updatedChoices });
+  };
+
+  const addEffect = (eventId: string, choiceId: string, effectType: 'immediate' | 'delayed') => {
+    const current = getCurrentEvent(eventId);
+    const choice = current.choices.find((c) => c.id === choiceId);
+    if (!choice) return;
+    const effectsKey = effectType === 'immediate' ? 'effects_immediate' : 'effects_delayed';
+    const existingKeys = Object.keys(choice[effectsKey]);
+    let newEffectKey = 'money';
+    if (existingKeys.includes(newEffectKey)) {
+      newEffectKey = CANONICAL_EFFECT_KEYS.find((name) => !existingKeys.includes(name)) ?? CANONICAL_EFFECT_KEYS[0];
+    }
+    updateEffect(eventId, choiceId, effectType, newEffectKey, 0);
+  };
+
+  const addEvent = () => {
+    const template = newEventTemplate();
+    setNewEvents((prev) => [...prev, template]);
+    setExpandedEvents((prev) => new Set([...Array.from(prev), template.id]));
+  };
+
+  const deleteEvent = (eventId: string) => {
+    const isNew = newEvents.some((e) => e.id === eventId);
+    if (isNew) {
+      setNewEvents((prev) => prev.filter((e) => e.id !== eventId));
+    } else {
+      setDeletedEventIds((prev) => new Set([...Array.from(prev), eventId]));
+    }
+    setModifiedEvents((prev) => {
+      const newMap = new Map(prev);
+      newMap.delete(eventId);
+      return newMap;
+    });
+    setExpandedEvents((prev) => {
+      const next = new Set(prev);
+      next.delete(eventId);
+      return next;
+    });
+  };
+
+  const handleDiscardChanges = () => {
+    setModifiedEvents(new Map());
+    setNewEvents([]);
+    setDeletedEventIds(new Set());
+    setLintIssues([]);
+    toast({ title: 'Changes Discarded', description: 'All unsaved changes have been discarded.' });
+  };
+
+  const toggleEditMode = () => {
+    if (editMode && totalChanges > 0) {
+      setShowDiscardConfirm(true);
+    } else {
+      setEditMode(!editMode);
+    }
+  };
+
+  const confirmDiscardAndExitEditMode = () => {
+    setEditMode(false);
+    setModifiedEvents(new Map());
+    setNewEvents([]);
+    setDeletedEventIds(new Set());
+    setLintIssues([]);
+  };
+
+  const handleSaveChanges = async () => {
+    if (totalChanges === 0) {
+      toast({ title: 'No Changes', description: 'There are no modifications to save.', variant: 'default' });
+      return;
+    }
+
+    setIsSaving(true);
+    setLintIssues([]);
+
+    try {
+      const updatedEvents = [
+        ...data.events.filter((e) => !deletedEventIds.has(e.id)).map((e) => modifiedEvents.get(e.id) || e),
+        ...newEvents,
+      ];
+
+      // Lint gate FIRST (spec §2.3): hard-block issues must clear before the Zod parse.
+      const issues = lintSideEvents(updatedEvents, sideEventsBalance?.event_weights ?? {});
+      if (issues.length > 0) {
+        setLintIssues(issues);
+        toast({
+          title: 'Lint Failed',
+          description: `Found ${issues.length} issue${issues.length !== 1 ? 's' : ''} that must be fixed before saving. See the panel below.`,
+          variant: 'destructive',
+        });
+        setIsSaving(false);
+        return;
+      }
+
+      const updatedConfig = {
+        ...data,
+        events: updatedEvents,
+        generated: new Date().toISOString(),
+      };
+
+      try {
+        EventsConfigSchema.parse(updatedConfig);
+      } catch (validationError: any) {
+        const errorMessage = validationError.errors
+          ? validationError.errors.map((err: any) => `${err.path.join('.')}: ${err.message}`).join(', ')
+          : 'Invalid configuration structure';
+        toast({
+          title: 'Validation Failed',
+          description: `Please fix the following errors before saving: ${errorMessage}`,
+          variant: 'destructive',
+        });
+        setIsSaving(false);
+        return;
+      }
+
+      const response = await apiRequest('POST', '/api/admin/events-config', { config: updatedConfig });
+      const result = await response.json();
+
+      const changesSummary = [
+        modifiedEvents.size > 0 ? `${modifiedEvents.size} modified` : '',
+        newEvents.length > 0 ? `${newEvents.length} added` : '',
+        deletedEventIds.size > 0 ? `${deletedEventIds.size} deleted` : '',
+      ]
+        .filter(Boolean)
+        .join(', ');
+
+      toast({
+        title: '✓ Changes Saved',
+        description: `Successfully saved changes (${changesSummary}) to events.json. ${result.backupCreated ? 'Backup created.' : ''}`,
+        variant: 'default',
+      });
+
+      setModifiedEvents(new Map());
+      setNewEvents([]);
+      setDeletedEventIds(new Set());
+      setLintIssues([]);
+      await queryClient.invalidateQueries({ queryKey: EVENTS_CONFIG_QUERY_KEY });
+    } catch (error) {
+      console.error('Failed to save events config:', error);
+      toast({
+        title: '✗ Save Failed',
+        description: error instanceof Error ? error.message : 'Failed to save changes. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isConfigLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Card className="bg-gray-900/50 border-white/10">
+          <CardContent className="p-8 text-center text-white/60">Loading events configuration...</CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (isConfigError) {
+    return (
+      <div className="container mx-auto p-6">
+        <Card className="bg-red-900/20 border-red-500/30">
+          <CardContent className="p-8 text-center text-red-300">
+            Failed to load events configuration
+            {configError instanceof Error ? `: ${configError.message}` : '.'}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-2xl font-bold text-white">Side Events</h2>
+          <p className="text-white/70">
+            Version {data.version} • Generated {data.generated} • {data.events.length} events
+          </p>
+        </div>
+
+        {/* Lint Error Panel */}
+        {lintIssues.length > 0 && (
+          <Card className="bg-red-900/20 border-red-500/30">
+            <CardHeader>
+              <CardTitle className="text-lg text-red-300 flex items-center gap-2">
+                <AlertCircle className="h-5 w-5" />
+                Save blocked — {lintIssues.length} lint issue{lintIssues.length !== 1 ? 's' : ''}
+              </CardTitle>
+              <CardDescription className="text-red-200/70">
+                Fix the issues below before saving. These mirror hard rules the test suite enforces.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2">
+                {lintIssues.map((issue, idx) => (
+                  <li key={`${issue.scope}-${idx}`} className="text-sm text-red-200">
+                    <Badge variant="outline" className="text-xs bg-red-500/20 text-red-300 border-red-500/30 mr-2">
+                      {issue.scope}
+                    </Badge>
+                    {issue.message}
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Production Warning Banner (slice-2 pattern, kept here too) */}
+        {import.meta.env.PROD && (
+          <Card className="bg-yellow-900/20 border-yellow-500/30">
+            <CardContent className="p-4">
+              <div className="flex items-start gap-3">
+                <AlertCircle className="h-5 w-5 text-yellow-400 shrink-0 mt-0.5" />
+                <div>
+                  <div className="font-semibold text-yellow-300 mb-1">Production Environment Warning</div>
+                  <p className="text-sm text-yellow-200/80">
+                    You are editing the events.json file in production. Any changes saved here will be{' '}
+                    <strong>lost on next deployment</strong>. All permanent edits should be made in your local
+                    development environment, committed to git, and deployed.
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Read-only knobs strip (fork B) */}
+        <Card className="bg-gray-900/50 border-white/10">
+          <CardHeader>
+            <CardTitle className="text-base text-white/80">Balance Knobs (read-only)</CardTitle>
+            <CardDescription className="text-white/50">
+              Display context from data/balance/events.json — knob edits happen in git, not in this tool.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2 mb-3">
+              <Badge variant="outline" className="text-xs">
+                weekly_chance: {sideEventsBalance?.weekly_chance}
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                max_events_per_week: {sideEventsBalance?.max_events_per_week}
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                event_cooldown: {sideEventsBalance?.event_cooldown}
+              </Badge>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {getCategoryOptions().map((opt) => (
+                <Badge key={opt.value} variant="outline" className="text-xs bg-blue-500/10 text-blue-300 border-blue-500/30">
+                  {opt.label}: {opt.weight}
+                  {!eventCountByCategory[opt.value] && (
+                    <span className="text-white/40 ml-1">(no events yet)</span>
+                  )}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Edit Mode Controls */}
+        <Card className="bg-gray-900/50 border-white/10">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <Button variant={editMode ? 'default' : 'outline'} size="sm" onClick={toggleEditMode}>
+                  {editMode ? (
+                    <>
+                      <X className="h-4 w-4 mr-2" />
+                      Exit Edit Mode
+                    </>
+                  ) : (
+                    <>
+                      <Edit className="h-4 w-4 mr-2" />
+                      Enable Edit Mode
+                    </>
+                  )}
+                </Button>
+
+                {editMode && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={addEvent}
+                    className="bg-green-600/10 hover:bg-green-600/20 border-green-500/30 text-green-300"
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add New Event
+                  </Button>
+                )}
+
+                {editMode && totalChanges > 0 && (
+                  <div className="flex items-center gap-2 text-orange-400">
+                    <AlertCircle className="h-4 w-4" />
+                    <span className="text-sm font-medium">
+                      {modifiedEvents.size > 0 && `${modifiedEvents.size} modified`}
+                      {modifiedEvents.size > 0 && (newEvents.length > 0 || deletedEventIds.size > 0) && ', '}
+                      {newEvents.length > 0 && `${newEvents.length} new`}
+                      {newEvents.length > 0 && deletedEventIds.size > 0 && ', '}
+                      {deletedEventIds.size > 0 && `${deletedEventIds.size} deleted`}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              {editMode && totalChanges > 0 && (
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" size="sm" onClick={handleDiscardChanges}>
+                    <X className="h-4 w-4 mr-2" />
+                    Discard Changes
+                  </Button>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    className="bg-green-600 hover:bg-green-700"
+                    onClick={() => setShowConfirmDialog(true)}
+                    disabled={isSaving}
+                  >
+                    <Save className="h-4 w-4 mr-2" />
+                    {isSaving ? 'Saving...' : 'Save All Changes'}
+                  </Button>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters and Search */}
+      <Card className="bg-gray-900/50 border-white/10">
+        <CardHeader>
+          <CardTitle className="text-lg">Filters</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            placeholder="Search events by id, prompt, or role hint..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="bg-black/30 border-white/10"
+          />
+          <div>
+            <div className="text-sm font-medium text-white/80 mb-2">Category:</div>
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" variant={selectedCategory === null ? 'default' : 'outline'} onClick={() => setSelectedCategory(null)}>
+                All
+              </Button>
+              {SIDE_EVENT_CATEGORIES.map((cat) => (
+                <Button
+                  key={cat}
+                  size="sm"
+                  variant={selectedCategory === cat ? 'default' : 'outline'}
+                  onClick={() => setSelectedCategory(cat)}
+                >
+                  {CATEGORY_LABELS[cat]}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <div className="text-sm text-white/60">
+            Showing {filteredEvents.length} of {data.events.length} events
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Events List */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {filteredEvents.map((originalEvent) => {
+          const event = getCurrentEvent(originalEvent.id);
+          const isExpanded = expandedEvents.has(event.id);
+          const isModified = modifiedEvents.has(event.id);
+
+          return (
+            <Card
+              key={event.id}
+              className={`bg-gray-900/50 border-white/10 hover:border-white/20 transition-colors ${
+                isModified ? 'ring-2 ring-orange-500/50' : ''
+              }`}
+            >
+              <CardHeader className="cursor-pointer" onClick={() => toggleEventExpanded(event.id)}>
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 space-y-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant="outline" className="text-xs">
+                        {event.id}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-300 border-blue-500/30">
+                        {CATEGORY_LABELS[event.category as SideEventCategory] ?? event.category}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs">
+                        {event.choices.length} choice{event.choices.length !== 1 ? 's' : ''}
+                      </Badge>
+                      {isModified && (
+                        <Badge variant="outline" className="text-xs bg-orange-500/20 text-orange-300 border-orange-500/30">
+                          Modified
+                        </Badge>
+                      )}
+                      {newEvents.some((e) => e.id === event.id) && (
+                        <Badge variant="outline" className="text-xs bg-green-500/20 text-green-300 border-green-500/30">
+                          New
+                        </Badge>
+                      )}
+                    </div>
+                    <CardTitle className="text-base text-white/90 font-medium">{event.prompt || '(no prompt yet)'}</CardTitle>
+                    <CardDescription className="text-white/50 text-xs">{event.role_hint}</CardDescription>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {editMode && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setDeleteConfirmEventId(event.id);
+                        }}
+                        title="Delete event"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                    <Button size="sm" variant="ghost">
+                      {isExpanded ? '▼' : '▶'}
+                    </Button>
+                  </div>
+                </div>
+              </CardHeader>
+
+              {isExpanded && (
+                <CardContent className="space-y-4 border-t border-white/10 pt-4">
+                  {editMode ? (
+                    <div className="space-y-3">
+                      <div>
+                        <label className="text-xs text-white/60 mb-1 block">Event ID</label>
+                        <Input
+                          value={event.id}
+                          onChange={(e) => updateEvent(event.id, { id: e.target.value })}
+                          className="h-8 text-xs bg-black/30 border-white/10"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-white/60 mb-1 block">Role Hint</label>
+                        <Input
+                          value={event.role_hint}
+                          onChange={(e) => updateEvent(event.id, { role_hint: e.target.value })}
+                          className="h-8 text-xs bg-black/30 border-white/10"
+                          placeholder="e.g. Sync Licensing"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-white/60 mb-1 block">Category</label>
+                        <Select
+                          value={event.category}
+                          onValueChange={(value) => updateEvent(event.id, { category: value as SideEventCategory })}
+                        >
+                          <SelectTrigger className="h-8 text-xs bg-black/30 border-white/10">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {getCategoryOptions().map((opt) => (
+                              <SelectItem key={opt.value} value={opt.value}>
+                                {opt.label} — weight {opt.weight}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div>
+                        <label className="text-xs text-white/60 mb-1 block">Prompt</label>
+                        <Textarea
+                          value={event.prompt}
+                          onChange={(e) => updateEvent(event.id, { prompt: e.target.value })}
+                          className="text-sm bg-black/30 border-white/10"
+                          rows={3}
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="p-3 bg-brand-gold/10 rounded-lg border border-brand-gold/20">
+                      <div className="text-xs font-semibold text-brand-gold mb-1">Prompt:</div>
+                      <div className="text-sm text-white/90">{event.prompt}</div>
+                    </div>
+                  )}
+
+                  {/* Choices */}
+                  <div>
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="text-sm font-semibold text-white/80">Choices ({event.choices.length}):</div>
+                      {editMode && (
+                        <Button size="sm" variant="outline" className="h-7 text-xs" onClick={() => addChoice(event.id)}>
+                          <Plus className="h-3 w-3 mr-1" />
+                          Add Choice
+                        </Button>
+                      )}
+                    </div>
+                    <div className="space-y-3">
+                      {event.choices.map((choice, idx) => {
+                        const expanded = isChoiceExpanded(event.id, choice.id);
+                        return (
+                          <div key={choice.id} className="bg-black/30 rounded-lg border border-white/10">
+                            <div className="p-3 flex items-center gap-2">
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-6 w-6 p-0"
+                                onClick={() => toggleChoiceExpanded(event.id, choice.id)}
+                              >
+                                {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                              </Button>
+                              <Badge variant="outline" className="text-xs shrink-0">
+                                #{idx + 1}
+                              </Badge>
+                              <div className="flex-1">
+                                {editMode && expanded ? (
+                                  <Input
+                                    value={choice.label}
+                                    onChange={(e) => updateChoice(event.id, choice.id, { label: e.target.value })}
+                                    className="h-7 text-sm bg-black/30 border-white/10"
+                                    placeholder="Choice label"
+                                  />
+                                ) : (
+                                  <div className="font-medium text-white text-sm">{choice.label}</div>
+                                )}
+                              </div>
+                              {editMode && (
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  className="h-6 w-6 p-0 text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                                  onClick={() => deleteChoice(event.id, choice.id)}
+                                >
+                                  <Trash2 className="h-3 w-3" />
+                                </Button>
+                              )}
+                            </div>
+
+                            {expanded && (
+                              <div className="px-3 pb-3 space-y-3 border-t border-white/5 pt-3">
+                                <div>
+                                  <label className="text-xs text-white/60 mb-1 block">Choice ID:</label>
+                                  {editMode ? (
+                                    <Input
+                                      value={choice.id}
+                                      onChange={(e) => updateChoice(event.id, choice.id, { id: e.target.value })}
+                                      className="h-7 text-xs bg-black/30 border-white/10"
+                                    />
+                                  ) : (
+                                    <div className="text-xs text-white/50">{choice.id}</div>
+                                  )}
+                                </div>
+
+                                {/* Immediate Effects */}
+                                <div>
+                                  <div className="flex items-center justify-between mb-2">
+                                    <div className="flex items-center gap-1.5">
+                                      <Zap className="h-3 w-3 text-orange-300" />
+                                      <span className="text-xs font-semibold text-white/60">Immediate Effects:</span>
+                                    </div>
+                                    {editMode && (
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="h-6 text-xs"
+                                        onClick={() => addEffect(event.id, choice.id, 'immediate')}
+                                      >
+                                        <Plus className="h-3 w-3 mr-1" />
+                                        Add
+                                      </Button>
+                                    )}
+                                  </div>
+                                  {Object.entries(choice.effects_immediate).length > 0 ? (
+                                    <div className="space-y-2">
+                                      {Object.entries(choice.effects_immediate).map(([key, value]) => (
+                                        <div key={key} className="flex items-center gap-2">
+                                          {editMode ? (
+                                            <>
+                                              <Select
+                                                value={key}
+                                                onValueChange={(newKey) => renameEffect(event.id, choice.id, 'immediate', key, newKey)}
+                                              >
+                                                <SelectTrigger className="h-7 text-xs bg-black/30 border-white/10 flex-1">
+                                                  <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                  {getCanonicalEffectOptions().map((opt) => (
+                                                    <SelectItem key={opt.value} value={opt.value} title={opt.description}>
+                                                      {opt.label}
+                                                    </SelectItem>
+                                                  ))}
+                                                </SelectContent>
+                                              </Select>
+                                              <Input
+                                                type="number"
+                                                value={value as number}
+                                                onChange={(e) =>
+                                                  updateEffect(event.id, choice.id, 'immediate', key, Number(e.target.value))
+                                                }
+                                                className="h-7 text-xs bg-black/30 border-white/10 w-24"
+                                              />
+                                              <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="h-6 w-6 p-0 text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                                                onClick={() => deleteEffect(event.id, choice.id, 'immediate', key)}
+                                              >
+                                                <Trash2 className="h-3 w-3" />
+                                              </Button>
+                                            </>
+                                          ) : (
+                                            <Badge
+                                              variant="outline"
+                                              className={`text-xs ${
+                                                typeof value === 'number' && value > 0
+                                                  ? 'bg-green-500/10 text-green-400 border-green-500/30'
+                                                  : typeof value === 'number' && value < 0
+                                                  ? 'bg-red-500/10 text-red-400 border-red-500/30'
+                                                  : 'bg-blue-500/10 text-blue-400 border-blue-500/30'
+                                              }`}
+                                            >
+                                              {key}: {value}
+                                            </Badge>
+                                          )}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : (
+                                    <div className="text-xs text-white/30">No immediate effects</div>
+                                  )}
+                                </div>
+
+                                {/* Delayed Effects */}
+                                <div>
+                                  <div className="flex items-center justify-between mb-2">
+                                    <div className="flex items-center gap-1.5">
+                                      <Clock className="h-3 w-3 text-blue-300" />
+                                      <span className="text-xs font-semibold text-white/60">Delayed Effects:</span>
+                                    </div>
+                                    {editMode && (
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        className="h-6 text-xs"
+                                        onClick={() => addEffect(event.id, choice.id, 'delayed')}
+                                      >
+                                        <Plus className="h-3 w-3 mr-1" />
+                                        Add
+                                      </Button>
+                                    )}
+                                  </div>
+                                  {Object.entries(choice.effects_delayed).length > 0 ? (
+                                    <div className="space-y-2">
+                                      {Object.entries(choice.effects_delayed).map(([key, value]) => (
+                                        <div key={key} className="flex items-center gap-2">
+                                          {editMode ? (
+                                            <>
+                                              <Select
+                                                value={key}
+                                                onValueChange={(newKey) => renameEffect(event.id, choice.id, 'delayed', key, newKey)}
+                                              >
+                                                <SelectTrigger className="h-7 text-xs bg-black/30 border-white/10 flex-1">
+                                                  <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                  {getCanonicalEffectOptions().map((opt) => (
+                                                    <SelectItem key={opt.value} value={opt.value} title={opt.description}>
+                                                      {opt.label}
+                                                    </SelectItem>
+                                                  ))}
+                                                </SelectContent>
+                                              </Select>
+                                              <Input
+                                                type="number"
+                                                value={value as number}
+                                                onChange={(e) =>
+                                                  updateEffect(event.id, choice.id, 'delayed', key, Number(e.target.value))
+                                                }
+                                                className="h-7 text-xs bg-black/30 border-white/10 w-24"
+                                              />
+                                              <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                className="h-6 w-6 p-0 text-red-400 hover:text-red-300 hover:bg-red-500/10"
+                                                onClick={() => deleteEffect(event.id, choice.id, 'delayed', key)}
+                                              >
+                                                <Trash2 className="h-3 w-3" />
+                                              </Button>
+                                            </>
+                                          ) : (
+                                            <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-300 border-blue-500/30">
+                                              {key}: {value}
+                                            </Badge>
+                                          )}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : (
+                                    <div className="text-xs text-white/30">No delayed effects</div>
+                                  )}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Raw JSON */}
+                  <details className="mt-4">
+                    <summary className="cursor-pointer text-sm text-white/60 hover:text-white/80">View Raw JSON</summary>
+                    <pre className="mt-2 p-3 bg-black/50 rounded text-xs overflow-auto">{JSON.stringify(event, null, 2)}</pre>
+                  </details>
+                </CardContent>
+              )}
+            </Card>
+          );
+        })}
+      </div>
+
+      {filteredEvents.length === 0 && (
+        <Card className="bg-gray-900/50 border-white/10">
+          <CardContent className="p-8 text-center text-white/50">
+            No events match your filters. Try adjusting your search or filter criteria.
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Save Confirmation Dialog */}
+      <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Save Changes to events.json?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You are about to save {totalChanges} change{totalChanges !== 1 ? 's' : ''} to the events.json file. A
+              backup will be created automatically before saving.
+              <br />
+              <br />
+              <span className="text-orange-400 font-medium">
+                This will modify the game's data files. Please ensure changes are intentional.
+              </span>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setShowConfirmDialog(false);
+                handleSaveChanges();
+              }}
+              className="bg-green-600 hover:bg-green-700"
+            >
+              Confirm & Save
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Discard Unsaved Changes Confirmation Dialog */}
+      <AlertDialog open={showDiscardConfirm} onOpenChange={setShowDiscardConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have {totalChanges} unsaved change{totalChanges !== 1 ? 's' : ''}. Exiting edit mode will discard
+              them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Editing</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setShowDiscardConfirm(false);
+                confirmDiscardAndExitEditMode();
+              }}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              Discard Changes
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete Event Confirmation Dialog */}
+      <AlertDialog open={deleteConfirmEventId !== null} onOpenChange={(open) => !open && setDeleteConfirmEventId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Event?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteConfirmEventId &&
+                (() => {
+                  const eventToDelete = getCurrentEvent(deleteConfirmEventId);
+                  const isNew = newEvents.some((e) => e.id === deleteConfirmEventId);
+                  return (
+                    <>
+                      Are you sure you want to delete <strong className="text-white">{eventToDelete?.id}</strong>?
+                      <br />
+                      <br />
+                      {isNew ? (
+                        <span className="text-yellow-400">
+                          This event will be removed from the new events list (not yet saved to file).
+                        </span>
+                      ) : (
+                        <span className="text-red-400 font-medium">
+                          This event will be marked for deletion and removed when you save changes.
+                        </span>
+                      )}
+                    </>
+                  );
+                })()}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deleteConfirmEventId) {
+                  deleteEvent(deleteConfirmEventId);
+                  setDeleteConfirmEventId(null);
+                  toast({
+                    title: 'Event Deleted',
+                    description: 'The event has been marked for deletion. Save changes to apply.',
+                    variant: 'default',
+                  });
+                }
+              }}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              Delete Event
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/client/src/admin/contentLint.ts
+++ b/client/src/admin/contentLint.ts
@@ -1,0 +1,192 @@
+/**
+ * Client-side lint mirror for the Content Editor (content-editor-side-events-and-meetings
+ * plan, §2.1 shared infrastructure). Pure, framework-free module — no React — so it is
+ * unit-testable in isolation and reusable by both the Meetings tab (slice 2, this file's
+ * first consumer) and the Side Events tab (slice 3, which will add `lintSideEvents` here
+ * following the same LintIssue shape).
+ *
+ * All issues are hard-block errors (fork C decided: dominance is a hard block too — see
+ * plan §6 fork C). The tool's output must never be able to turn the suite red, so every
+ * rule mirrored here is a MIRROR of an actual test/schema constraint:
+ *   - effect keys: shared/engine/processors/ActionProcessor.ts LIVE_EFFECT_KEYS (+ executive_mood)
+ *   - requires tags: shared/types/gameTypes.ts RELEVANCE_TAGS
+ *   - reactive_trigger: shared/types/gameTypes.ts HAPPENING_TYPES
+ *   - dominance: tests/engine/meeting-dominance.test.ts's EXACT value model (mirrored
+ *     byte-for-byte below: same PAYOFF_KEYS, same EXCLUDED_KEYS, same weaklyDominates rule).
+ */
+import { LIVE_EFFECT_KEYS } from '@shared/engine/processors/ActionProcessor';
+import { RELEVANCE_TAGS, HAPPENING_TYPES } from '@shared/types/gameTypes';
+import type { WeeklyAction, DialogueChoiceContract } from '@shared/api/contracts';
+
+export interface LintIssue {
+  severity: 'error';
+  /** e.g. an action id or a choice id — identifies where the issue lives. */
+  scope: string;
+  message: string;
+}
+
+/**
+ * Canonical effect-key set for pickers/lint: LIVE_EFFECT_KEYS plus 'executive_mood'
+ * (which is legitimately read outside applyEffects's per-key switch — see
+ * ActionProcessor.ts's comment on LIVE_EFFECT_KEYS). Exported so ActionsViewer.tsx and
+ * its tests share exactly one canonical list (drift guard).
+ */
+export const CANONICAL_EFFECT_KEYS: readonly string[] = Array.from(
+  new Set<string>([...Array.from(LIVE_EFFECT_KEYS), 'executive_mood']),
+).sort();
+
+const RELEVANCE_TAG_SET: ReadonlySet<string> = new Set(RELEVANCE_TAGS);
+const HAPPENING_TYPE_SET: ReadonlySet<string> = new Set(HAPPENING_TYPES);
+const CANONICAL_EFFECT_KEY_SET: ReadonlySet<string> = new Set(CANONICAL_EFFECT_KEYS);
+
+// ---------------------------------------------------------------------------
+// Dominance model — mirrored EXACTLY from tests/engine/meeting-dominance.test.ts.
+// Do not change these without also updating that test's model in lockstep.
+// ---------------------------------------------------------------------------
+
+const PAYOFF_KEYS = [
+  'money',
+  'reputation',
+  'creative_capital',
+  'artist_mood',
+  'artist_energy',
+  'artist_popularity',
+  'press_story_flag',
+  'press_momentum',
+  'quality_bonus',
+  'awareness_boost',
+  'award_chances',
+  'executive_mood',
+] as const;
+
+const EXCLUDED_KEYS = ['variance_up', 'rep_swing'] as const;
+
+type Vec = Record<string, number>;
+
+function choiceVector(choice: Pick<DialogueChoiceContract, 'effects_immediate' | 'effects_delayed'>): Vec {
+  const v: Vec = {};
+  for (const block of ['effects_immediate', 'effects_delayed'] as const) {
+    const eff = choice[block] || {};
+    for (const [k, val] of Object.entries(eff)) {
+      if (typeof val === 'number') v[k] = (v[k] || 0) + val;
+    }
+  }
+  return v;
+}
+
+/** Does A weakly-dominate B under the meeting-dominance.test.ts model? */
+function weaklyDominates(a: Vec, b: Vec): boolean {
+  for (const k of EXCLUDED_KEYS) {
+    if ((a[k] || 0) !== (b[k] || 0)) return false;
+  }
+  let strictlyBetterSomewhere = false;
+  for (const k of PAYOFF_KEYS) {
+    const av = a[k] || 0;
+    const bv = b[k] || 0;
+    if (av < bv) return false;
+    if (av > bv) strictlyBetterSomewhere = true;
+  }
+  return strictlyBetterSomewhere;
+}
+
+/**
+ * Lint a would-be-saved array of weekly actions (meetings). Returns a list of hard-block
+ * issues; an empty array means the array is safe to save (pending the Zod parse, which
+ * remains the second gate in ActionsViewer.tsx).
+ */
+export function lintMeetings(actions: WeeklyAction[]): LintIssue[] {
+  const issues: LintIssue[] = [];
+
+  const seenActionIds = new Set<string>();
+
+  for (const action of actions) {
+    // Duplicate action ids.
+    if (seenActionIds.has(action.id)) {
+      issues.push({
+        severity: 'error',
+        scope: action.id,
+        message: `Duplicate action id '${action.id}' — action ids must be unique.`,
+      });
+    }
+    seenActionIds.add(action.id);
+
+    // Empty choices array.
+    if (!action.choices || action.choices.length === 0) {
+      issues.push({
+        severity: 'error',
+        scope: action.id,
+        message: `Action '${action.id}' has no choices — every meeting needs at least one.`,
+      });
+    }
+
+    // requires: must be a subset of RELEVANCE_TAGS.
+    if (action.requires) {
+      for (const tag of action.requires) {
+        if (!RELEVANCE_TAG_SET.has(tag)) {
+          issues.push({
+            severity: 'error',
+            scope: action.id,
+            message: `Action '${action.id}' has an unknown requires tag '${tag}' — must be one of: ${RELEVANCE_TAGS.join(', ')}.`,
+          });
+        }
+      }
+    }
+
+    // reactive_trigger: must be one of HAPPENING_TYPES.
+    if (action.reactive_trigger && !HAPPENING_TYPE_SET.has(action.reactive_trigger)) {
+      issues.push({
+        severity: 'error',
+        scope: action.id,
+        message: `Action '${action.id}' has an unknown reactive_trigger '${action.reactive_trigger}' — must be one of: ${HAPPENING_TYPES.join(', ')}.`,
+      });
+    }
+
+    // Duplicate choice ids within this action.
+    const seenChoiceIds = new Set<string>();
+    for (const choice of action.choices ?? []) {
+      const scope = `${action.id}:${choice.id}`;
+      if (seenChoiceIds.has(choice.id)) {
+        issues.push({
+          severity: 'error',
+          scope,
+          message: `Duplicate choice id '${choice.id}' within action '${action.id}' — choice ids must be unique per action.`,
+        });
+      }
+      seenChoiceIds.add(choice.id);
+
+      // Effect keys must be canonical.
+      for (const block of ['effects_immediate', 'effects_delayed'] as const) {
+        const effects = choice[block] || {};
+        for (const key of Object.keys(effects)) {
+          if (!CANONICAL_EFFECT_KEY_SET.has(key)) {
+            issues.push({
+              severity: 'error',
+              scope,
+              message: `Choice '${choice.id}' in action '${action.id}' uses unknown effect key '${key}' — must be one of the canonical effect channels.`,
+            });
+          }
+        }
+      }
+    }
+
+    // Weakly-dominant choice within a meeting.
+    const choices = (action.choices ?? []).map((c) => ({ id: c.id, label: c.label, vec: choiceVector(c) }));
+    for (const a of choices) {
+      for (const b of choices) {
+        if (a.id === b.id) continue;
+        if (weaklyDominates(a.vec, b.vec)) {
+          issues.push({
+            severity: 'error',
+            scope: `${action.id}:${a.id}`,
+            message: `'${a.label}' makes '${b.label}' never worth picking (in ${action.id}).`,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// MISSING (slice 3): lintSideEvents(events: SideEvent[]): LintIssue[] — will share
+// CANONICAL_EFFECT_KEYS and the LintIssue shape defined above.

--- a/client/src/admin/contentLint.ts
+++ b/client/src/admin/contentLint.ts
@@ -15,8 +15,8 @@
  *     byte-for-byte below: same PAYOFF_KEYS, same EXCLUDED_KEYS, same weaklyDominates rule).
  */
 import { LIVE_EFFECT_KEYS } from '@shared/engine/processors/ActionProcessor';
-import { RELEVANCE_TAGS, HAPPENING_TYPES } from '@shared/types/gameTypes';
-import type { WeeklyAction, DialogueChoiceContract } from '@shared/api/contracts';
+import { RELEVANCE_TAGS, HAPPENING_TYPES, SIDE_EVENT_CATEGORIES } from '@shared/types/gameTypes';
+import type { WeeklyAction, DialogueChoiceContract, SideEventContract } from '@shared/api/contracts';
 
 export interface LintIssue {
   severity: 'error';
@@ -38,6 +38,7 @@ export const CANONICAL_EFFECT_KEYS: readonly string[] = Array.from(
 const RELEVANCE_TAG_SET: ReadonlySet<string> = new Set(RELEVANCE_TAGS);
 const HAPPENING_TYPE_SET: ReadonlySet<string> = new Set(HAPPENING_TYPES);
 const CANONICAL_EFFECT_KEY_SET: ReadonlySet<string> = new Set(CANONICAL_EFFECT_KEYS);
+const SIDE_EVENT_CATEGORY_SET: ReadonlySet<string> = new Set(SIDE_EVENT_CATEGORIES);
 
 // ---------------------------------------------------------------------------
 // Dominance model — mirrored EXACTLY from tests/engine/meeting-dominance.test.ts.
@@ -188,5 +189,103 @@ export function lintMeetings(actions: WeeklyAction[]): LintIssue[] {
   return issues;
 }
 
-// MISSING (slice 3): lintSideEvents(events: SideEvent[]): LintIssue[] — will share
-// CANONICAL_EFFECT_KEYS and the LintIssue shape defined above.
+/**
+ * Lint a would-be-saved array of side events (content-editor slice 3, spec §2.3).
+ * Returns a list of hard-block issues; an empty array means the array is safe to
+ * save (pending the Zod parse, which remains the second gate in
+ * SideEventsEditor.tsx).
+ *
+ * `eventWeights` is the `event_weights` table from data/balance/events.json,
+ * keyed by SIDE_EVENT_CATEGORIES entry — passed in by the caller (read-only
+ * display context in the UI; not editable here) so this function stays pure
+ * and framework-free, with no static-import coupling to a specific JSON file.
+ *
+ * DELIBERATELY NO DOMINANCE CHECK. The meeting-dominance suite
+ * (tests/engine/meeting-dominance.test.ts) only covers weekly meetings — side
+ * events are exempt by design. Applying that hard-block here would make the
+ * REAL, currently-shipping data/events.json unsaveable: `royalty_discrepancy`
+ * has a weakly-dominant pair under the same value model — `negotiate` nets
+ * +2000 money with no cost, strictly better than `audit`'s -1000 immediate /
+ * +500 delayed (net -500) on every tracked payoff axis. That's authored,
+ * accepted content, not a bug the tool should block. Do not add a dominance
+ * check to this function without first resolving that data conflict.
+ */
+export function lintSideEvents(
+  events: SideEventContract[],
+  eventWeights: Record<string, number>,
+): LintIssue[] {
+  const issues: LintIssue[] = [];
+
+  const seenEventIds = new Set<string>();
+
+  for (const event of events) {
+    // Duplicate event ids.
+    if (seenEventIds.has(event.id)) {
+      issues.push({
+        severity: 'error',
+        scope: event.id,
+        message: `Duplicate event id '${event.id}' — event ids must be unique.`,
+      });
+    }
+    seenEventIds.add(event.id);
+
+    // Empty choices array.
+    if (!event.choices || event.choices.length === 0) {
+      issues.push({
+        severity: 'error',
+        scope: event.id,
+        message: `Event '${event.id}' has no choices — every side event needs at least one.`,
+      });
+    }
+
+    // category must be one of SIDE_EVENT_CATEGORIES.
+    if (!SIDE_EVENT_CATEGORY_SET.has(event.category)) {
+      issues.push({
+        severity: 'error',
+        scope: event.id,
+        message: `Event '${event.id}' has an unknown category '${event.category}' — must be one of: ${SIDE_EVENT_CATEGORIES.join(', ')}.`,
+      });
+    } else if (!(event.category in eventWeights)) {
+      // Mirrors the HARD assertion in tests/engine/data-lint-side-event-categories.test.ts:
+      // an authored category absent from event_weights is not allowed (a category with
+      // zero authored events is fine — that's the opposite direction).
+      issues.push({
+        severity: 'error',
+        scope: event.id,
+        message: `Event '${event.id}' has category '${event.category}' which has no entry in event_weights (data/balance/events.json) — every authored category must have a weight.`,
+      });
+    }
+
+    // Duplicate choice ids within this event.
+    const seenChoiceIds = new Set<string>();
+    for (const choice of event.choices ?? []) {
+      const scope = `${event.id}:${choice.id}`;
+      if (seenChoiceIds.has(choice.id)) {
+        issues.push({
+          severity: 'error',
+          scope,
+          message: `Duplicate choice id '${choice.id}' within event '${event.id}' — choice ids must be unique per event.`,
+        });
+      }
+      seenChoiceIds.add(choice.id);
+
+      // Effect keys must be canonical.
+      for (const block of ['effects_immediate', 'effects_delayed'] as const) {
+        const effects = choice[block] || {};
+        for (const key of Object.keys(effects)) {
+          if (!CANONICAL_EFFECT_KEY_SET.has(key)) {
+            issues.push({
+              severity: 'error',
+              scope,
+              message: `Choice '${choice.id}' in event '${event.id}' uses unknown effect key '${key}' — must be one of the canonical effect channels.`,
+            });
+          }
+        }
+      }
+    }
+
+    // NO dominance check here — see the function-level comment above.
+  }
+
+  return issues;
+}

--- a/client/src/admin/utils.ts
+++ b/client/src/admin/utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared pure helpers for the admin content editors (ActionsViewer, SideEventsEditor).
+ * Content-editor slice 4 (playtest feedback): creation dialogs need a slug generator
+ * and a uniqueness check independent of any component state, so both editors — and
+ * their tests — can share one implementation.
+ */
+
+/**
+ * Converts free-text input into a lowercase, underscore-separated slug suitable for
+ * use as an action/event id: non-alphanumeric runs become a single underscore,
+ * and leading/trailing underscores are trimmed.
+ *
+ * Examples:
+ *   "CMO: Viral Push" -> "cmo_viral_push"
+ *   "  Multiple   Spaces  " -> "multiple_spaces"
+ *   "Already_snake-case!" -> "already_snake_case"
+ */
+export function slugifyId(input: string): string {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * True when `id` is non-empty and not already present in `existingIds`.
+ * Used by the creation dialogs to gate the Create button and show an inline
+ * "id already taken" note.
+ */
+export function isIdAvailable(id: string, existingIds: ReadonlySet<string> | readonly string[]): boolean {
+  if (id.length === 0) return false;
+  const set = existingIds instanceof Set ? existingIds : new Set(existingIds);
+  return !set.has(id);
+}
+
+/**
+ * Orders items for display so newly-created items appear at the top of the list,
+ * newest first, followed by the originals in their existing order. Pure display-order
+ * helper (playtest feedback fix, slice 4) — the save handler composes its own array
+ * independently and does not use this ordering.
+ */
+export function orderWithNewestFirst<T>(newItems: readonly T[], originalItems: readonly T[]): T[] {
+  return [...[...newItems].reverse(), ...originalItems];
+}

--- a/data/CLAUDE.md
+++ b/data/CLAUDE.md
@@ -21,3 +21,4 @@ Artists, songs, roles, executives, actions, world definitions
   - Quality/variance → `balance/quality.json`
   - Awards / exec-mood modifiers / chart reputation → `balance/progression.json`
 - When authoring changes affect executive meetings, update `docs/01-planning/implementation-specs/REFERENCES AND ANALYSIS/[REFERENCE] executive-meetings-system-complete-reference.md` to match.
+- `events.json` is editable via the admin Content Editor (`GET`/`POST /api/admin/events-config`, mirroring the actions-config pair). Saves via either admin content endpoint append an id-level diff to `data/content-changelog.json` (`{ timestamp, file, added, modified, deleted }`) for a later docs-sync pass to consume.

--- a/docs/01-planning/implementation-specs/[READY] content-editor-side-events-and-meetings-plan.md
+++ b/docs/01-planning/implementation-specs/[READY] content-editor-side-events-and-meetings-plan.md
@@ -1,0 +1,95 @@
+# [DRAFT] Content Editor — Side Events & Meetings (Actions JSON Viewer v2)
+
+*Drafted July 6, 2026. Status: READY — all four §6 forks decided by Nes on July 6, 2026 (A3 changelog, B1 read-only knobs, C2 dominance hard-block, D1 full event CRUD); decisions folded into §2/§3 below.*
+
+**Goal (Nes):** an updated Actions JSON Viewer that lets a game designer / copywriter edit **side events and meetings without code**.
+
+**Merge authority this session:** all work stays local (PR OK), no merge until finalized + playtested.
+
+---
+
+## 1. As-is findings (code-verified July 6, 2026)
+
+### The existing tool
+`client/src/admin/ActionsViewer.tsx` (route `/admin/actions-viewer`, `withAdmin`-gated) is already a full view+edit surface for `data/actions.json` weekly meetings: name / description / prompts / target_scope / role / icon / category / meeting_id, choice CRUD, per-choice effect CRUD, client-side `ActionsConfigSchema` validation, then `POST /api/admin/actions-config` (`server/routes/admin.ts:31`) which re-validates, writes a `.backup`, and overwrites the file.
+
+### Gaps that block the session goal
+1. **No side-events support at all.** `data/events.json` (12 authored events, `category` per event) has no admin endpoints, no editor, and no contracts-level config schema (only the per-event `SideEventSchema` inside `shared/utils/dataLoader.ts:460`).
+2. **The two newest meeting fields are invisible.** `requires` (Tier 0 relevance tags) and `reactive_trigger` (Tier 2) are preserved on edit (object spread + `.passthrough()`) but cannot be seen or edited, and the "Add New Action" template omits them — a new meeting authored in the tool is always-eligible and never reactive, silently.
+3. **The effect whitelist is stale.** `CONNECTED_EFFECTS` (ActionsViewer.tsx:96) hardcodes 6 keys; the canonical `LIVE_EFFECT_KEYS` (`shared/engine/processors/ActionProcessor.ts:62`) has 13 (+ `executive_mood`). Seven live channels (`press_story_flag`, `press_momentum`, `quality_bonus`, `awareness_boost`, `variance_up`, `rep_swing`, `award_chances`) are wrongly badged "Not implemented ○" — actively misleading for a copywriter.
+4. **The effect-name picker is data-derived, not canonical.** It offers the union of names found in the file (plus a `'new_effect'` fallback in `addEffect`) instead of the canonical whitelist — an author can produce a file that `data-lint-effect-keys` rejects and, for events.json, that the server's Zod load would 500 on.
+5. **Prod/data staleness, two flavors:**
+   - The viewer reads actions.json via **static bundle import** (line 30), not the existing `GET /api/admin/actions-config` — in production the tool shows build-time data even after a successful save.
+   - `dataLoader.loadAllData()` **caches** (`dataCache`/`isLoaded`; `clearCache()` at dataLoader.ts:556). Meetings dodge this (`loadActionsData` re-reads the file per call — gameData.ts:111), but **events go through the cache** (gameData.ts:901): a saved events.json edit is invisible to a running server until restart. Same failure class as the July 5 "17 weeks, zero side events" stale-server mystery.
+6. **Guard-rail drift risk.** Content edits must satisfy: effect keys ∈ `LIVE_EFFECT_KEYS` ∪ `executive_mood` (data-lint-effect-keys, covers actions/events/dialogue); `requires` ⊆ `RELEVANCE_TAGS`; `reactive_trigger` ∈ `HAPPENING_TYPES`; event `category` ∈ `SIDE_EVENT_CATEGORIES` **and** present in `event_weights` (hard lint); no weakly-dominant choice within a meeting (`meeting-dominance.test.ts`, meetings only). The tool currently enforces none of these beyond base Zod shape.
+7. **Process conflict.** `data/CLAUDE.md` + root CLAUDE.md require the `[REFERENCE]` exec-meetings doc to be updated when actions.json content changes — a no-code copywriter can't do that. Needs a process decision (§6 fork A).
+
+---
+
+## 2. Design
+
+One admin page, two tabs: **Meetings** (modernized existing editor) and **Side Events** (new). Working title: **Content Editor** (route stays `/admin/actions-viewer`; AdminLayout label updated). Everything is copywriter-first: canonical pickers with plain-language descriptions (reusing `EFFECT_CHANNEL_DESCRIPTIONS` tooltips), inline lint feedback *before* save, and zero free-text where an enum exists.
+
+### 2.1 Shared editor infrastructure
+- **Data source:** both tabs fetch via admin GET endpoints (no static imports). Save → POST → refetch (no `window.location.reload()`).
+- **Canonical pickers:** effect keys from `LIVE_EFFECT_KEYS` ∪ `executive_mood` with channel descriptions; relevance tags from `RELEVANCE_TAGS`; triggers from `HAPPENING_TYPES`; categories from `SIDE_EVENT_CATEGORIES`. Each with a one-line "what this does" blurb (authored once, in the tool).
+- **Lint mirror, client-side, pre-save:**
+  - **Hard block** (would break the game/suite): non-canonical effect key, non-canonical tag/trigger/category, category with no `event_weights` entry, empty choice list, duplicate ids, Zod shape failure, **and weakly-dominant choices** (fork C decided: hard block — mirrors `meeting-dominance.test.ts`'s exact value model incl. the variance-axis exclusion; the block banner names the dominating/dominated pair so the author can fix it). Tool output can never turn the suite red.
+- **Effects legibility:** replace `CONNECTED_EFFECTS` with the canonical set; "orphaned ○" styling only for keys genuinely outside it.
+
+### 2.2 Meetings tab (delta on the existing editor)
+- `requires` editor: checkbox group over the 6 relevance tags, AND-semantics note ("meeting only offered when ALL are true; none checked = always eligible").
+- `reactive_trigger` selector: none | one of the 4 happening types, with a "why-now" explainer and the note that reactive meetings jump the weighted draw when their trigger fired this week.
+- "Add New Action" template updated accordingly (both fields default absent).
+- Everything else (choice/effect CRUD, scope guide, icon/category pickers) kept as-is.
+
+### 2.3 Side Events tab (new)
+- Card list of all events (search box; category filter chips). Per event: `prompt`, `role_hint`, `category` (canonical picker showing that category's current weight), exactly-3-choices-not-enforced choice CRUD (schema allows any count ≥1; UI mirrors meetings), per-choice `label` + immediate/delayed effects with canonical pickers.
+- Add / delete events (delete is safe: `side_event_history` keys by id; stale keys are ignored by the cooldown filter — verified in `sideEventSelection.ts:58`).
+- **Read-only context strip:** `weekly_chance` 0.20 · `max_events_per_week` 1 · `event_cooldown` 2 · per-category weights — displayed for authoring context, NOT editable (feel knobs are explicitly untouched pending play; §6 fork B).
+- `artist_personal` shows a "0 authored events — reserved for mood-driven content" note; the tab is exactly the authoring surface fork E anticipated.
+
+### 2.4 Server (new endpoints + cache fix)
+- `EventsConfigSchema` in `shared/api/contracts.ts` (version/generated/events, event schema deriving `category` from `SIDE_EVENT_CATEGORIES` — the RELEVANCE_TAGS one-source pattern; `.passthrough()` like ActionsConfig).
+- `GET/POST /api/admin/events-config` in `server/routes/admin.ts`, mirroring the actions-config pattern: Zod validate → `.backup` → write.
+- **Both POST handlers call `gameDataLoader.clearCache()`** after a successful write so a running dev server picks up saved content on the next request — closes the events-cache staleness (finding 5b) and is a no-op-but-future-proof for actions. (`tsx` has no watch, but no *server code* changes here — data re-reads suffice.)
+- **Changelog (fork A decided: option 3).** Both POST handlers, after a successful write, compute a server-side id-level diff (old file was just read for the backup) and append an entry to `data/content-changelog.json`: `{ timestamp, file, added: [ids], modified: [ids], deleted: [ids] }`. Machine-readable, git-tracked; a later dev docs pass consumes it for the `[REFERENCE]`-doc sync and prunes consumed entries. The pairing rule is thereby satisfied at commit time without asking the copywriter to touch docs.
+- Route-manifest snapshot delta expected and root-caused: exactly the two new admin routes.
+
+### 2.5 Explicitly out of scope
+- `dialogue.json` (artist dialogues) — different consumer, not in the session goal.
+- Balance knobs editing (weights/chance/cooldown) — fork B, recommended read-only.
+- Any engine/selection logic change. **Golden-master impact: zero by construction** (admin route + client only; no engine code touched; GM double-run per slice regardless, per house rules).
+
+---
+
+## 3. Slice plan (factory, one subagent per slice)
+
+| # | Slice | Model | Contents |
+|---|-------|-------|----------|
+| 1 | Server + contracts | Sonnet 5 | `EventsConfigSchema`, GET/POST events-config, `clearCache()` on both POSTs, changelog writer (shared by both POSTs), endpoint + schema tests, route-manifest re-bless (root-caused) |
+| 2 | Meetings tab modernization | Sonnet 5 | canonical effect whitelist + descriptions, `requires` + `reactive_trigger` editors, new-action template, client lint mirror (all hard blocks incl. dominance), GET-endpoint data source, tests |
+| 3 | Side Events tab | Sonnet 5 | tab shell + events editor, category picker w/ weights context strip, event CRUD, lint mirror reuse, save flow, tests |
+
+Each slice: tsc clean, full suite green incl. data-lint, GM double-run zero-delta, independently revertable. Suite baseline going in: 1,445.
+
+---
+
+## 4. Test plan
+- Slice 1: events-config endpoint characterization (GET shape, POST happy/invalid/backup, cache-clear observable via a re-read), contracts schema unit tests.
+- Slice 2/3: component tests for the lint mirror (each hard-block class + a dominance warn case), tag/trigger editors round-trip without dropping unknown fields, effect picker offers exactly the canonical set.
+- Existing data-lint suites are the backstop and must stay green untouched.
+
+## 5. Risks / notes
+- The tool writes runtime files; **edits are not commits.** The working tree diff after a copywriter session is reviewed/committed by a dev (this is also where fork A's doc-sync lands).
+- Production banner already exists (edits lost on deploy) — kept.
+- `actions.json.backup` / new `events.json.backup` are single-generation; acceptable (git is the real history).
+
+---
+
+## 6. Product forks — DECIDED (Nes, July 6, 2026)
+
+**A. [REFERENCE]-doc sync rule → option 3 (changelog).** The tool emits a machine-readable changelog (`data/content-changelog.json`, appended server-side on every successful save) that the dev docs pass consumes at commit time. Design in §2.4.
+**B. Balance knobs → read-only** context strip (recommendation accepted); knob-editing rights remain a separate future decision.
+**C. Dominance guard → hard block** at save (recommendation NOT taken — Nes chose the stricter gate): tool output can never turn the meeting-dominance suite red. Block banner names the dominating/dominated pair.
+**D. Side-event add/delete → full CRUD** (recommendation accepted).

--- a/docs/05-backend/backend-architecture.md
+++ b/docs/05-backend/backend-architecture.md
@@ -92,6 +92,10 @@ POST   /api/saves                 // Create new save
 // Admin endpoints (require admin role)
 GET    /api/admin/database-stats         // Database health metrics
 POST   /api/admin/cleanup-orphaned-games // Manual orphaned game cleanup
+GET    /api/admin/actions-config         // Content Editor: read data/actions.json
+POST   /api/admin/actions-config         // Content Editor: save meetings (validate → backup → write → cache-clear → changelog)
+GET    /api/admin/events-config          // Content Editor: read data/events.json
+POST   /api/admin/events-config          // Content Editor: save side events (same pipeline; both POSTs append id-level diffs to data/content-changelog.json)
 
 // Authentication (Clerk-issued JWT verified per request; no local auth endpoints)
 GET    /api/me                    // Current user

--- a/docs/09-troubleshooting/technical-debt-backlog.md
+++ b/docs/09-troubleshooting/technical-debt-backlog.md
@@ -9,7 +9,7 @@
 
 - **Created**: September 2025 (Artist Mood System Implementation - commit `4991ab3`)
 - **Last Updated**: July 5, 2026
-- **Total Items**: 75 (C1–C75, no gaps; header previously said 68 with buckets summing to 67 — pre-existing drift, the Completed count had never absorbed C54 and C69)
+- **Total Items**: 76 (C1–C76, no gaps; header previously said 68 with buckets summing to 67 — pre-existing drift, the Completed count had never absorbed C54 and C69)
 - **Completed**: 59
 - **Deferred by decision**: 3 (C32, C42, C43)
 - **In Progress**: 0
@@ -1216,19 +1216,35 @@ The late-July-5 playtest fix disabled meeting choices whose CC cost exceeds the 
 
 ---
 
+### [ ] Comment 76 (C76): `royalty_discrepancy` side event has a weakly-dominant choice 🔵
+**Priority**: 🔵 Low
+**Impact**: In the side event's three choices, "Negotiate a correction" (delayed `money` +2000, nothing else) weakly dominates "Audit rights and metadata" (immediate `money` −1000 + delayed `money` +500 = net −500, nothing else) under the meeting-dominance value model — a rational player never picks Audit. Content-quality wart only; side events are exempt from the dominance suite by design (meetings-only rule).
+**Effort**: Trivial (copy/effects tuning — Nes's call on the trade shape)
+
+Discovered July 6, 2026 while scoping the Content Editor's side-events lint: applying the meetings dominance hard-block to events would have made the real `data/events.json` unsaveable because of this pair. The editor's `lintSideEvents` deliberately omits the dominance check and documents this event as the reason (`client/src/admin/contentLint.ts`). If the pair is ever fixed, consider whether side events should then adopt the dominance rule (lint + a data-lint-style test) — until then the omission is load-bearing.
+
+**Relevant Files**:
+- [data/events.json](data/events.json)
+- [client/src/admin/contentLint.ts](client/src/admin/contentLint.ts)
+- [tests/engine/meeting-dominance.test.ts](tests/engine/meeting-dominance.test.ts)
+
+*Identified July 6, 2026 during the Content Editor (side events & meetings) session.*
+
+---
+
 ## 📊 **Summary Statistics**
 
 ### By Priority
 - 🔴 Critical: 0 items (all completed! 🎉)
 - 🟡 High: 0 items (all completed! 🎉) — note: C40's header lacks the `~~strikethrough~~` convention despite being fixed (PR #66/#68); cosmetic only
 - 🟢 Medium: 2 deferred (C42, C43 — product decisions, July 3, 2026; see stale-entry corrections in Document Information), 1 pending (C62 — remaining scope: zeroed `artistsSuccessful`/`projectsCompleted` score components only, needs design decision + plumbing) — C67 + C68 + C69 resolved July 4, 2026 (PR #119); C58 (stale-week guard) + C60 (delayed-effect targeting) + C62's other sub-items resolved July 4, 2026 (PR #120); C74 (header AUTO review-gate bypass + AR-busy AUTO fix) resolved July 5, 2026
-- 🔵 Low: 1 deferred (C32 — cap unreachable; surfacing fixed), 12 pending (C50 — client tests' incidental DB dependency; C52–C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5/D6 session findings, July 3, 2026; C61, C63, C65 — interactivity-gap analysis findings, July 3, 2026; C66 — exec-meetings revival Phase A finds; C75 — CC gate ignores queued choices, July 5, 2026) — C51 ("On Tour" badge lag) resolved July 4, 2026 (PR #120); C71 (reference-doc staleness log) resolved July 5, 2026 (post-merge docs pass); C70 (12-week copy rot, PR #128) + C72–C73 (content-honesty warts, PRs #129–#130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection) resolved July 5, 2026 (PR #138, Tier 2 MVP-2)
+- 🔵 Low: 1 deferred (C32 — cap unreachable; surfacing fixed), 13 pending (C50 — client tests' incidental DB dependency; C52–C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5/D6 session findings, July 3, 2026; C61, C63, C65 — interactivity-gap analysis findings, July 3, 2026; C66 — exec-meetings revival Phase A finds; C75 — CC gate ignores queued choices, July 5, 2026; C76 — royalty_discrepancy dominant choice, July 6, 2026) — C51 ("On Tour" badge lag) resolved July 4, 2026 (PR #120); C71 (reference-doc staleness log) resolved July 5, 2026 (post-merge docs pass); C70 (12-week copy rot, PR #128) + C72–C73 (content-honesty warts, PRs #129–#130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection) resolved July 5, 2026 (PR #138, Tier 2 MVP-2)
 
 ### By Status
-- ✅ Completed: 59 items (78.7% of 75; 59 + 3 deferred + 13 pending = 75 ✓)
+- ✅ Completed: 59 items (77.6% of 76; 59 + 3 deferred + 14 pending = 76 ✓)
 - 🚧 In Progress: 0 items
 - ⏸️ Deferred by decision: 3 items (C32, C42, C43)
-- 📋 Pending: 13 items (C50 — logged July 3, 2026; C52, C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5 + D6 session findings; C61, C62 (remaining scope: zeroed score components only), C63, C65 — interactivity-gap analysis, July 3, 2026; C66 — exec-meetings revival Phase A finds; C75 — CC gate ignores queued choices, July 5, 2026; all low except C62 medium, not scheduled). C70 (PR #128) + C72 (PR #129) + C73 (PR #130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection, PR #138) resolved July 5, 2026 (Tier 2 MVP-2); C67 (`071c6df`) + C68 (`5b44d9e`) + C69 (`1db5c39`) resolved July 4, 2026 on PR #119; C51 (`6e945e3`) + C58 (`3d8066a`) + C60 (`7898de6`) + C62-partial (`f1b1315`) resolved July 4, 2026 on PR #120; C71 (reference-doc sync) resolved July 5, 2026 in the post-merge docs pass; C74 (header AUTO review-gate + AR-busy AUTO fix) resolved July 5, 2026
+- 📋 Pending: 14 items (C50 — logged July 3, 2026; C52, C53 — v2 redesign follow-ups; C55–C57, C59 — Phase 3.5 + D6 session findings; C61, C62 (remaining scope: zeroed score components only), C63, C65 — interactivity-gap analysis, July 3, 2026; C66 — exec-meetings revival Phase A finds; C75 — CC gate ignores queued choices, July 5, 2026; C76 — royalty_discrepancy dominant choice, July 6, 2026; all low except C62 medium, not scheduled). C70 (PR #128) + C72 (PR #129) + C73 (PR #130) resolved July 5, 2026 (evening debt-pile pass); C64 (seeded side-event selection, PR #138) resolved July 5, 2026 (Tier 2 MVP-2); C67 (`071c6df`) + C68 (`5b44d9e`) + C69 (`1db5c39`) resolved July 4, 2026 on PR #119; C51 (`6e945e3`) + C58 (`3d8066a`) + C60 (`7898de6`) + C62-partial (`f1b1315`) resolved July 4, 2026 on PR #120; C71 (reference-doc sync) resolved July 5, 2026 in the post-merge docs pass; C74 (header AUTO review-gate + AR-busy AUTO fix) resolved July 5, 2026
 
 ---
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { z } from 'zod';
-import { ActionsConfigSchema } from '@shared/api/contracts';
+import { ActionsConfigSchema, EventsConfigSchema } from '@shared/api/contracts';
 import { gameStates } from '@shared/schema';
 import { db } from '../db';
 import { sql, inArray } from 'drizzle-orm';
 import { requireClerkUser, requireAdmin } from '../auth';
+import { gameDataLoader } from '@shared/utils/dataLoader';
+import { diffContentById, appendContentChangelogEntry } from '../utils/contentChangelog';
 
 const router = Router();
 
@@ -51,10 +53,13 @@ router.post('/api/admin/actions-config', requireClerkUser, requireAdmin, async (
 
       const actionsPath = path.join(process.cwd(), 'data', 'actions.json');
 
-      // Create backup before overwriting
+      // Create backup before overwriting (also gives us the pre-save data
+      // for the changelog diff below).
       const backupPath = path.join(process.cwd(), 'data', 'actions.json.backup');
+      let previousConfig: any = null;
       try {
         const existingData = await fs.readFile(actionsPath, 'utf8');
+        previousConfig = JSON.parse(existingData);
         await fs.writeFile(backupPath, existingData, 'utf8');
         console.log('Created backup at', backupPath);
       } catch (backupError) {
@@ -65,6 +70,22 @@ router.post('/api/admin/actions-config', requireClerkUser, requireAdmin, async (
       const formattedConfig = JSON.stringify(config, null, 2);
       await fs.writeFile(actionsPath, formattedConfig, 'utf8');
 
+      // Clear the shared data-loader cache so a running dev server picks up
+      // the saved content on the next request instead of serving stale data
+      // until restart (see spec §2.4 / finding 5b — events.json already hits
+      // this cache; actions.json is future-proofed the same way here).
+      gameDataLoader.clearCache();
+
+      // Changelog (fork A3): diff old vs new weekly_actions by id, append to
+      // data/content-changelog.json. Never fails the save.
+      if (previousConfig) {
+        const diff = diffContentById(
+          previousConfig.weekly_actions ?? [],
+          config.weekly_actions ?? []
+        );
+        await appendContentChangelogEntry('actions.json', diff);
+      }
+
       res.json({
         success: true,
         message: 'Actions configuration updated successfully',
@@ -74,6 +95,89 @@ router.post('/api/admin/actions-config', requireClerkUser, requireAdmin, async (
       console.error('Failed to save actions config:', error);
       res.status(500).json({
         error: 'Failed to save actions configuration',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+
+// Events configuration endpoints (Admin only)
+router.get('/api/admin/events-config', requireClerkUser, requireAdmin, async (req, res) => {
+    try {
+      const eventsPath = path.join(process.cwd(), 'data', 'events.json');
+      const configData = await fs.readFile(eventsPath, 'utf8');
+      const config = JSON.parse(configData);
+      res.json(config);
+    } catch (error) {
+      console.error('Failed to load events config:', error);
+      res.status(500).json({ error: 'Failed to load events configuration' });
+    }
+  });
+
+router.post('/api/admin/events-config', requireClerkUser, requireAdmin, async (req, res) => {
+    try {
+      const { config } = req.body;
+
+      if (!config) {
+        return res.status(400).json({ error: 'Configuration data is required' });
+      }
+
+      // Validate using shared schema from contracts
+      try {
+        EventsConfigSchema.parse(config);
+      } catch (validationError) {
+        if (validationError instanceof z.ZodError) {
+          return res.status(400).json({
+            error: 'Invalid events configuration structure',
+            details: validationError.errors
+          });
+        }
+        throw validationError;
+      }
+
+      const eventsPath = path.join(process.cwd(), 'data', 'events.json');
+
+      // Create backup before overwriting (also gives us the pre-save data
+      // for the changelog diff below).
+      const backupPath = path.join(process.cwd(), 'data', 'events.json.backup');
+      let previousConfig: any = null;
+      try {
+        const existingData = await fs.readFile(eventsPath, 'utf8');
+        previousConfig = JSON.parse(existingData);
+        await fs.writeFile(backupPath, existingData, 'utf8');
+        console.log('Created backup at', backupPath);
+      } catch (backupError) {
+        console.warn('Failed to create backup, continuing with save:', backupError);
+      }
+
+      // Write the new configuration
+      const formattedConfig = JSON.stringify(config, null, 2);
+      await fs.writeFile(eventsPath, formattedConfig, 'utf8');
+
+      // Clear the shared data-loader cache so a running dev server picks up
+      // the saved content on the next request instead of serving stale data
+      // until restart (spec §2.4 / finding 5b: events.json goes through
+      // dataLoader's cache, unlike actions.json's per-call re-read).
+      gameDataLoader.clearCache();
+
+      // Changelog (fork A3): diff old vs new events by id, append to
+      // data/content-changelog.json. Never fails the save.
+      if (previousConfig) {
+        const diff = diffContentById(
+          previousConfig.events ?? [],
+          config.events ?? []
+        );
+        await appendContentChangelogEntry('events.json', diff);
+      }
+
+      res.json({
+        success: true,
+        message: 'Events configuration updated successfully',
+        backupCreated: true
+      });
+    } catch (error) {
+      console.error('Failed to save events config:', error);
+      res.status(500).json({
+        error: 'Failed to save events configuration',
         details: error instanceof Error ? error.message : 'Unknown error'
       });
     }

--- a/server/utils/contentChangelog.ts
+++ b/server/utils/contentChangelog.ts
@@ -1,0 +1,103 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Content changelog writer (content-editor slice 1, spec §2.4 fork A3).
+ *
+ * The admin Content Editor lets a non-dev copywriter edit data/actions.json
+ * and data/events.json without touching docs. To satisfy the doc-sync rule
+ * (root CLAUDE.md "Documentation Maintenance" — actions.json content changes
+ * must update the [REFERENCE] exec-meetings doc) without requiring the
+ * copywriter to do that themselves, both admin POST handlers append a
+ * machine-readable diff entry to data/content-changelog.json on every
+ * successful save. A later dev docs pass consumes these entries to sync the
+ * [REFERENCE] doc and prunes consumed entries.
+ */
+
+export interface ContentChangelogEntry {
+  timestamp: string;
+  file: 'actions.json' | 'events.json';
+  added: string[];
+  modified: string[];
+  deleted: string[];
+}
+
+interface ContentChangelogFile {
+  entries: ContentChangelogEntry[];
+}
+
+/**
+ * Pure id-level diff between two lists of content items (e.g. weekly_actions
+ * or events), keyed by `id`. No fs access — unit-testable in isolation.
+ */
+export function diffContentById(
+  oldItems: Array<{ id: string; [key: string]: unknown }>,
+  newItems: Array<{ id: string; [key: string]: unknown }>
+): { added: string[]; modified: string[]; deleted: string[] } {
+  const oldById = new Map(oldItems.map((item) => [item.id, item]));
+  const newById = new Map(newItems.map((item) => [item.id, item]));
+
+  const added: string[] = [];
+  const modified: string[] = [];
+  const deleted: string[] = [];
+
+  for (const [id, newItem] of Array.from(newById)) {
+    const oldItem = oldById.get(id);
+    if (!oldItem) {
+      added.push(id);
+    } else if (JSON.stringify(oldItem) !== JSON.stringify(newItem)) {
+      modified.push(id);
+    }
+  }
+
+  for (const id of Array.from(oldById.keys())) {
+    if (!newById.has(id)) {
+      deleted.push(id);
+    }
+  }
+
+  return { added, modified, deleted };
+}
+
+/**
+ * Appends a changelog entry to data/content-changelog.json (creating the
+ * file with `{ entries: [] }` if missing). Skips appending when the diff is
+ * entirely empty. Failures are swallowed (warn-only), mirroring the backup
+ * write's failure handling in the admin routes — a changelog write must
+ * never fail the underlying content save.
+ */
+export async function appendContentChangelogEntry(
+  file: ContentChangelogEntry['file'],
+  diff: { added: string[]; modified: string[]; deleted: string[] }
+): Promise<void> {
+  if (diff.added.length === 0 && diff.modified.length === 0 && diff.deleted.length === 0) {
+    return;
+  }
+
+  const changelogPath = path.join(process.cwd(), 'data', 'content-changelog.json');
+
+  try {
+    let changelog: ContentChangelogFile;
+    try {
+      const existing = await fs.readFile(changelogPath, 'utf8');
+      changelog = JSON.parse(existing);
+      if (!Array.isArray(changelog.entries)) {
+        changelog = { entries: [] };
+      }
+    } catch {
+      changelog = { entries: [] };
+    }
+
+    changelog.entries.push({
+      timestamp: new Date().toISOString(),
+      file,
+      added: diff.added,
+      modified: diff.modified,
+      deleted: diff.deleted,
+    });
+
+    await fs.writeFile(changelogPath, JSON.stringify(changelog, null, 2), 'utf8');
+  } catch (error) {
+    console.warn('Failed to write content changelog, continuing:', error);
+  }
+}

--- a/shared/api/contracts.ts
+++ b/shared/api/contracts.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { GameState, GameProject } from '../types/gameTypes';
-import { RELEVANCE_TAGS, HAPPENING_TYPES } from '../types/gameTypes';
+import { RELEVANCE_TAGS, HAPPENING_TYPES, SIDE_EVENT_CATEGORIES } from '../types/gameTypes';
 import { ArtistSchema } from '../schemas/artist';
 
 // API Response schemas
@@ -490,3 +490,60 @@ export type ActionsConfig = z.infer<typeof ActionsConfigSchema>;
 export type SaveActionsConfigRequest = z.infer<typeof SaveActionsConfigRequestSchema>;
 export type SaveActionsConfigResponse = z.infer<typeof SaveActionsConfigResponseSchema>;
 export type GetActionsConfigResponse = z.infer<typeof GetActionsConfigResponseSchema>;
+
+// ========================================
+// Admin Events Config Schemas (content-editor slice 1)
+// ========================================
+
+// Side-event category enum, derived from the canonical SIDE_EVENT_CATEGORIES
+// array in shared/types/gameTypes.ts (the RELEVANCE_TAGS/HAPPENING_TYPES
+// one-source pattern — see RelevanceTagSchema/HappeningTypeSchema above).
+export const SideEventCategorySchema = z.enum(SIDE_EVENT_CATEGORIES);
+
+// Side-event contract schema — reuses DialogueChoiceSchema for choices
+// (same shape as meeting choices: id/label/effects_immediate/effects_delayed).
+export const SideEventContractSchema = z.object({
+  id: z.string(),
+  role_hint: z.string(),
+  category: SideEventCategorySchema,
+  prompt: z.string(),
+  choices: z.array(DialogueChoiceSchema).min(1),
+}).passthrough();
+
+// Full events configuration schema. `generated` is optional here (mirroring
+// ActionsConfigSchema's convention) even though data/events.json always has
+// it and the dataLoader's own schema (shared/utils/dataLoader.ts) requires it.
+export const EventsConfigSchema = z.object({
+  version: z.string(),
+  generated: z.string().optional(),
+  events: z.array(SideEventContractSchema),
+}).passthrough();
+
+// Admin endpoints for events config
+export const adminEventsEndpoints = {
+  getConfig: '/api/admin/events-config',
+  saveConfig: '/api/admin/events-config',
+} as const;
+
+// Request schema for saving events config
+export const SaveEventsConfigRequestSchema = z.object({
+  config: EventsConfigSchema,
+});
+
+// Response schema for saving events config
+export const SaveEventsConfigResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string().optional(),
+  backupCreated: z.boolean().optional(),
+});
+
+// Response schema for getting events config
+export const GetEventsConfigResponseSchema = EventsConfigSchema;
+
+// Export TypeScript types
+export type SideEventCategoryContract = z.infer<typeof SideEventCategorySchema>;
+export type SideEventContract = z.infer<typeof SideEventContractSchema>;
+export type EventsConfig = z.infer<typeof EventsConfigSchema>;
+export type SaveEventsConfigRequest = z.infer<typeof SaveEventsConfigRequestSchema>;
+export type SaveEventsConfigResponse = z.infer<typeof SaveEventsConfigResponseSchema>;
+export type GetEventsConfigResponse = z.infer<typeof GetEventsConfigResponseSchema>;

--- a/tests/client/ActionsViewer.requires-helper.test.ts
+++ b/tests/client/ActionsViewer.requires-helper.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Regression test (content-editor slice 2, spec §2.2b): unchecking every relevance
+ * tag must OMIT the `requires` field entirely — never save `requires: []`, since the
+ * schema requires nonempty-or-absent (WeeklyActionSchema: `z.array(...).nonempty().optional()`).
+ */
+import { describe, it, expect } from 'vitest';
+import { computeRequiresFromChecked } from '@/admin/ActionsViewer';
+import { RELEVANCE_TAGS, type RelevanceTag } from '@shared/types/gameTypes';
+
+describe('computeRequiresFromChecked', () => {
+  it('returns undefined when nothing is checked (never an empty array)', () => {
+    const result = computeRequiresFromChecked(new Set<RelevanceTag>());
+    expect(result).toBeUndefined();
+  });
+
+  it('returns the checked tags in canonical RELEVANCE_TAGS order', () => {
+    const checked = new Set<RelevanceTag>(['tour_active', 'artist_signed']);
+    const result = computeRequiresFromChecked(checked);
+    expect(result).toEqual(['artist_signed', 'tour_active']);
+  });
+
+  it('returns all tags when all are checked', () => {
+    const checked = new Set<RelevanceTag>(RELEVANCE_TAGS);
+    const result = computeRequiresFromChecked(checked);
+    expect(result).toEqual([...RELEVANCE_TAGS]);
+  });
+});

--- a/tests/client/SideEventsEditor.helpers.test.ts
+++ b/tests/client/SideEventsEditor.helpers.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { SIDE_EVENT_CATEGORIES } from '@shared/types/gameTypes';
-import { newEventTemplate, getCategoryOptions } from '@/admin/SideEventsEditor';
+import { newEventTemplate, getCategoryOptions, slugifyIdFromPromptWords } from '@/admin/SideEventsEditor';
 
 describe('newEventTemplate', () => {
   it('produces a valid starter event with one choice and an editable id', () => {
@@ -37,5 +37,31 @@ describe('getCategoryOptions', () => {
       expect(opt).toBeTruthy();
       expect(typeof opt!.weight).toBe('number');
     }
+  });
+});
+
+/**
+ * Content-editor slice 4 (playtest feedback): the creation dialog derives its
+ * default event id from the first ~4 words of the prompt, editable thereafter.
+ */
+describe('slugifyIdFromPromptWords', () => {
+  it('slugifies the first 4 words of the prompt by default', () => {
+    expect(slugifyIdFromPromptWords('A rival label tries to poach your artist')).toBe('a_rival_label_tries');
+  });
+
+  it('uses the whole prompt when it has fewer words than the word count', () => {
+    expect(slugifyIdFromPromptWords('Short prompt')).toBe('short_prompt');
+  });
+
+  it('respects a custom word count', () => {
+    expect(slugifyIdFromPromptWords('One two three four five six', 2)).toBe('one_two');
+  });
+
+  it('returns an empty string for an empty prompt', () => {
+    expect(slugifyIdFromPromptWords('')).toBe('');
+  });
+
+  it('collapses extra whitespace between words', () => {
+    expect(slugifyIdFromPromptWords('  Multiple    spaces   here   now  ')).toBe('multiple_spaces_here_now');
   });
 });

--- a/tests/client/SideEventsEditor.helpers.test.ts
+++ b/tests/client/SideEventsEditor.helpers.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for the pure helpers extracted from SideEventsEditor.tsx (content-editor
+ * slice 3). Mirrors slice 2's precedent (tests/client/ActionsViewer.requires-helper.test.ts)
+ * of testing pure logic without mounting the component — GameLayout pulls Clerk/store
+ * deps that aren't worth wiring up here.
+ */
+import { describe, it, expect } from 'vitest';
+import { SIDE_EVENT_CATEGORIES } from '@shared/types/gameTypes';
+import { newEventTemplate, getCategoryOptions } from '@/admin/SideEventsEditor';
+
+describe('newEventTemplate', () => {
+  it('produces a valid starter event with one choice and an editable id', () => {
+    const event = newEventTemplate(1720000000000);
+    expect(event.id).toBe('event_1720000000000');
+    expect(event.role_hint).toBe('');
+    expect(event.category).toBe('industry_drama');
+    expect(event.prompt).toBe('');
+    expect(event.choices).toHaveLength(1);
+    expect(event.choices[0].effects_immediate).toEqual({});
+    expect(event.choices[0].effects_delayed).toEqual({});
+  });
+
+  it('generates a fresh id per call by default (Date.now())', () => {
+    const a = newEventTemplate();
+    const b = newEventTemplate();
+    expect(a.id).toMatch(/^event_\d+$/);
+    expect(b.id).toMatch(/^event_\d+$/);
+  });
+});
+
+describe('getCategoryOptions', () => {
+  it('returns one option per SIDE_EVENT_CATEGORIES entry, each carrying its weight', () => {
+    const options = getCategoryOptions();
+    expect(options).toHaveLength(SIDE_EVENT_CATEGORIES.length);
+    for (const cat of SIDE_EVENT_CATEGORIES) {
+      const opt = options.find((o) => o.value === cat);
+      expect(opt).toBeTruthy();
+      expect(typeof opt!.weight).toBe('number');
+    }
+  });
+});

--- a/tests/client/admin-utils.slugify.test.ts
+++ b/tests/client/admin-utils.slugify.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the shared admin content-editor helpers (content-editor slice 4,
+ * playtest feedback: creation dialogs need a slug generator + uniqueness check).
+ */
+import { describe, it, expect } from 'vitest';
+import { slugifyId, isIdAvailable, orderWithNewestFirst } from '@/admin/utils';
+
+describe('slugifyId', () => {
+  it('lowercases and joins words with underscores', () => {
+    expect(slugifyId('CMO: Viral Push')).toBe('cmo_viral_push');
+  });
+
+  it('collapses repeated non-alphanumeric runs into a single underscore', () => {
+    expect(slugifyId('  Multiple   Spaces  ')).toBe('multiple_spaces');
+    expect(slugifyId('a---b___c')).toBe('a_b_c');
+  });
+
+  it('trims leading and trailing underscores', () => {
+    expect(slugifyId('!!!Leading and trailing!!!')).toBe('leading_and_trailing');
+  });
+
+  it('preserves already-snake-case input modulo punctuation normalization', () => {
+    expect(slugifyId('Already_snake-case!')).toBe('already_snake_case');
+  });
+
+  it('handles numbers and mixed case', () => {
+    expect(slugifyId('Q3 2026 Campaign')).toBe('q3_2026_campaign');
+  });
+
+  it('returns an empty string for input with no alphanumeric content', () => {
+    expect(slugifyId('!!!')).toBe('');
+  });
+});
+
+describe('isIdAvailable', () => {
+  const existing = new Set(['action_a', 'action_b', 'action_c']);
+
+  it('returns false for an empty id', () => {
+    expect(isIdAvailable('', existing)).toBe(false);
+  });
+
+  it('returns false when the id is already present', () => {
+    expect(isIdAvailable('action_b', existing)).toBe(false);
+  });
+
+  it('returns true when the id is not present', () => {
+    expect(isIdAvailable('action_d', existing)).toBe(true);
+  });
+
+  it('accepts a plain readonly array as well as a Set', () => {
+    const arr = ['x', 'y', 'z'] as const;
+    expect(isIdAvailable('y', arr)).toBe(false);
+    expect(isIdAvailable('w', arr)).toBe(true);
+  });
+});
+
+/**
+ * Content-editor slice 4 (playtest feedback): newly created items must render at
+ * the TOP of the list, newest first, with originals following in their existing
+ * order. This is a pure display-order helper — it does not affect what gets
+ * written to disk on save.
+ */
+describe('orderWithNewestFirst', () => {
+  it('returns originals unchanged when there are no new items', () => {
+    expect(orderWithNewestFirst([], ['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('places new items before originals', () => {
+    const result = orderWithNewestFirst(['new1'], ['orig1', 'orig2']);
+    expect(result).toEqual(['new1', 'orig1', 'orig2']);
+  });
+
+  it('orders multiple new items newest-first (most recently added first)', () => {
+    // newActions accumulates oldest->newest via push; the most recent add
+    // (last in the array) should render first.
+    const result = orderWithNewestFirst(['new1', 'new2', 'new3'], ['orig1']);
+    expect(result).toEqual(['new3', 'new2', 'new1', 'orig1']);
+  });
+
+  it('does not mutate the input arrays', () => {
+    const newItems = ['new1', 'new2'];
+    const originals = ['orig1'];
+    orderWithNewestFirst(newItems, originals);
+    expect(newItems).toEqual(['new1', 'new2']);
+    expect(originals).toEqual(['orig1']);
+  });
+});

--- a/tests/client/contentLint.sideEvents.test.ts
+++ b/tests/client/contentLint.sideEvents.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for lintSideEvents (content-editor slice 3, spec §2.3).
+ *
+ * Mirrors tests/client/contentLint.test.ts's style (slice 2) for the meetings lint
+ * mirror. Each hard-block class must fire, the real data/events.json must lint
+ * clean against the real event_weights table, and the weakly-dominant pair that
+ * exists TODAY in real data (royalty_discrepancy: negotiate vs audit) must NOT be
+ * flagged — side events deliberately have no dominance check (see the
+ * function-level comment in contentLint.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { SIDE_EVENT_CATEGORIES } from '@shared/types/gameTypes';
+import { EventsConfigSchema, type SideEventContract } from '@shared/api/contracts';
+import { lintSideEvents } from '@/admin/contentLint';
+
+function baseEvent(overrides: Partial<SideEventContract> = {}): SideEventContract {
+  return {
+    id: 'event_1',
+    role_hint: 'Test Role',
+    category: 'industry_drama',
+    prompt: 'A thing happens.',
+    choices: [
+      {
+        id: 'choice_1',
+        label: 'Choice 1',
+        effects_immediate: { money: 100 },
+        effects_delayed: {},
+      },
+    ],
+    ...overrides,
+  } as SideEventContract;
+}
+
+const REAL_WEIGHTS: Record<string, number> = {
+  sync_licensing: 0.15,
+  copyright_issues: 0.1,
+  platform_opportunities: 0.2,
+  industry_drama: 0.15,
+  technical_problems: 0.1,
+  business_opportunities: 0.15,
+  artist_personal: 0.15,
+};
+
+describe('lintSideEvents — clean fixture', () => {
+  it('returns [] for a valid single event/choice', () => {
+    expect(lintSideEvents([baseEvent()], REAL_WEIGHTS)).toEqual([]);
+  });
+});
+
+describe('lintSideEvents — hard-block classes', () => {
+  it('flags a non-canonical effect key', () => {
+    const event = baseEvent({
+      choices: [
+        {
+          id: 'choice_1',
+          label: 'Choice 1',
+          effects_immediate: { totally_made_up_key: 5 } as any,
+          effects_delayed: {},
+        },
+      ],
+    });
+    const issues = lintSideEvents([event], REAL_WEIGHTS);
+    expect(issues.some((i) => i.message.includes('totally_made_up_key'))).toBe(true);
+  });
+
+  it('flags a category not in SIDE_EVENT_CATEGORIES', () => {
+    const event = baseEvent({ category: 'not_a_real_category' as any });
+    const issues = lintSideEvents([event], REAL_WEIGHTS);
+    expect(issues.some((i) => i.message.includes('not_a_real_category'))).toBe(true);
+  });
+
+  it('flags a category missing from the passed eventWeights table', () => {
+    const event = baseEvent({ category: 'artist_personal' });
+    const weightsWithoutArtistPersonal = { ...REAL_WEIGHTS };
+    delete weightsWithoutArtistPersonal.artist_personal;
+    const issues = lintSideEvents([event], weightsWithoutArtistPersonal);
+    expect(issues.some((i) => i.message.includes('event_weights'))).toBe(true);
+  });
+
+  it('flags an empty choices array', () => {
+    const event = baseEvent({ choices: [] });
+    const issues = lintSideEvents([event], REAL_WEIGHTS);
+    expect(issues.some((i) => i.message.includes('no choices'))).toBe(true);
+  });
+
+  it('flags duplicate event ids', () => {
+    const e1 = baseEvent({ id: 'dup_id' });
+    const e2 = baseEvent({ id: 'dup_id' });
+    const issues = lintSideEvents([e1, e2], REAL_WEIGHTS);
+    expect(issues.some((i) => i.message.includes('Duplicate event id'))).toBe(true);
+  });
+
+  it('flags duplicate choice ids within an event', () => {
+    const event = baseEvent({
+      choices: [
+        { id: 'same', label: 'A', effects_immediate: {}, effects_delayed: {} },
+        { id: 'same', label: 'B', effects_immediate: {}, effects_delayed: {} },
+      ],
+    });
+    const issues = lintSideEvents([event], REAL_WEIGHTS);
+    expect(issues.some((i) => i.message.includes('Duplicate choice id'))).toBe(true);
+  });
+});
+
+describe('lintSideEvents — deliberate absence of a dominance check', () => {
+  it('does NOT flag a weakly-dominant pair (documented in the function comment)', () => {
+    // Mirrors royalty_discrepancy in real data/events.json: 'negotiate' nets
+    // +2000 money for free, which weakly-dominates 'audit' (-1000 immediate,
+    // +500 delayed = net -500) on every tracked payoff axis. If this ever
+    // starts failing, a dominance check was added to lintSideEvents — see the
+    // function-level comment explaining why that would break real content.
+    const event = baseEvent({
+      id: 'royalty_discrepancy',
+      category: 'business_opportunities',
+      choices: [
+        {
+          id: 'audit',
+          label: 'Audit rights and metadata',
+          effects_immediate: { money: -1000 },
+          effects_delayed: { money: 500 },
+        },
+        {
+          id: 'negotiate',
+          label: 'Negotiate a correction',
+          effects_immediate: {},
+          effects_delayed: { money: 2000 },
+        },
+      ],
+    });
+    const issues = lintSideEvents([event], REAL_WEIGHTS);
+    expect(issues.filter((i) => i.message.includes('never worth picking'))).toEqual([]);
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('lintSideEvents — real data/events.json', () => {
+  it('lints clean against the real event_weights table', () => {
+    const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'data', 'events.json'), 'utf-8'));
+    const parsed = EventsConfigSchema.parse(raw);
+    const balance = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'data', 'balance', 'events.json'), 'utf-8'),
+    );
+    const weights = balance.side_events.event_weights as Record<string, number>;
+
+    const issues = lintSideEvents(parsed.events, weights);
+    expect(issues, issues.map((i) => `${i.scope}: ${i.message}`).join('\n')).toEqual([]);
+  });
+});
+
+describe('lintSideEvents — drift guard: SIDE_EVENT_CATEGORIES vs event_weights', () => {
+  it('every SIDE_EVENT_CATEGORIES entry has a weight in data/balance/events.json', () => {
+    const balance = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'data', 'balance', 'events.json'), 'utf-8'),
+    );
+    const weights = balance.side_events.event_weights as Record<string, number>;
+    const missing = SIDE_EVENT_CATEGORIES.filter((cat) => !(cat in weights));
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/client/contentLint.test.ts
+++ b/tests/client/contentLint.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the client-side lint mirror (content-editor slice 2, spec §2.1/§2.2f).
+ *
+ * These are the substance of the slice's test plan: each hard-block class must fire,
+ * a clean fixture must return [], and the canonical effect-key list must be a drift
+ * guard against the old hardcoded-6-key bug.
+ */
+import { describe, it, expect } from 'vitest';
+import { LIVE_EFFECT_KEYS } from '@shared/engine/processors/ActionProcessor';
+import type { WeeklyAction } from '@shared/api/contracts';
+import { CANONICAL_EFFECT_KEYS, lintMeetings } from '@/admin/contentLint';
+
+function baseAction(overrides: Partial<WeeklyAction> = {}): WeeklyAction {
+  return {
+    id: 'action_1',
+    name: 'Test Action',
+    type: 'role_meeting',
+    icon: 'fas fa-circle',
+    description: 'desc',
+    role_id: 'ceo',
+    meeting_id: 'meeting_1',
+    category: 'business',
+    target_scope: 'global',
+    prompt: 'prompt',
+    choices: [
+      {
+        id: 'choice_1',
+        label: 'Choice 1',
+        effects_immediate: { money: 100 },
+        effects_delayed: {},
+      },
+    ],
+    details: {} as any,
+    recommendations: {} as any,
+    ...overrides,
+  } as WeeklyAction;
+}
+
+describe('contentLint — CANONICAL_EFFECT_KEYS', () => {
+  it('equals LIVE_EFFECT_KEYS union executive_mood (drift guard)', () => {
+    const expected = new Set([...Array.from(LIVE_EFFECT_KEYS), 'executive_mood']);
+    expect(new Set(CANONICAL_EFFECT_KEYS)).toEqual(expected);
+  });
+});
+
+describe('lintMeetings — clean fixture', () => {
+  it('returns [] for a valid single action/choice', () => {
+    const issues = lintMeetings([baseAction()]);
+    expect(issues).toEqual([]);
+  });
+
+  it('returns [] for a valid action with requires and reactive_trigger set', () => {
+    const action = baseAction({
+      requires: ['artist_signed', 'music_exists'] as any,
+      reactive_trigger: 'chart_debut' as any,
+    });
+    expect(lintMeetings([action])).toEqual([]);
+  });
+});
+
+describe('lintMeetings — hard-block classes', () => {
+  it('flags a non-canonical effect key', () => {
+    const action = baseAction({
+      choices: [
+        {
+          id: 'choice_1',
+          label: 'Choice 1',
+          effects_immediate: { totally_made_up_key: 5 } as any,
+          effects_delayed: {},
+        },
+      ],
+    });
+    const issues = lintMeetings([action]);
+    expect(issues.some((i) => i.message.includes('totally_made_up_key'))).toBe(true);
+  });
+
+  it('flags a requires entry not in RELEVANCE_TAGS', () => {
+    const action = baseAction({ requires: ['not_a_real_tag'] as any });
+    const issues = lintMeetings([action]);
+    expect(issues.some((i) => i.message.includes('not_a_real_tag'))).toBe(true);
+  });
+
+  it('flags a reactive_trigger not in HAPPENING_TYPES', () => {
+    const action = baseAction({ reactive_trigger: 'not_a_real_trigger' as any });
+    const issues = lintMeetings([action]);
+    expect(issues.some((i) => i.message.includes('not_a_real_trigger'))).toBe(true);
+  });
+
+  it('flags an empty choices array', () => {
+    const action = baseAction({ choices: [] });
+    const issues = lintMeetings([action]);
+    expect(issues.some((i) => i.message.includes('no choices'))).toBe(true);
+  });
+
+  it('flags duplicate action ids', () => {
+    const a1 = baseAction({ id: 'dup_id' });
+    const a2 = baseAction({ id: 'dup_id' });
+    const issues = lintMeetings([a1, a2]);
+    expect(issues.some((i) => i.message.includes('Duplicate action id'))).toBe(true);
+  });
+
+  it('flags duplicate choice ids within an action', () => {
+    const action = baseAction({
+      choices: [
+        { id: 'same', label: 'A', effects_immediate: {}, effects_delayed: {} },
+        { id: 'same', label: 'B', effects_immediate: {}, effects_delayed: {} },
+      ],
+    });
+    const issues = lintMeetings([action]);
+    expect(issues.some((i) => i.message.includes('Duplicate choice id'))).toBe(true);
+  });
+
+  it('flags a weakly-dominant choice (naming both choices)', () => {
+    const action = baseAction({
+      choices: [
+        {
+          id: 'good',
+          label: 'Good Choice',
+          effects_immediate: { money: 100, reputation: 5 },
+          effects_delayed: {},
+        },
+        {
+          id: 'bad',
+          label: 'Bad Choice',
+          effects_immediate: { money: 50, reputation: 5 },
+          effects_delayed: {},
+        },
+      ],
+    });
+    const issues = lintMeetings([action]);
+    const dominanceIssue = issues.find((i) => i.message.includes('never worth picking'));
+    expect(dominanceIssue).toBeTruthy();
+    expect(dominanceIssue!.message).toContain('Good Choice');
+    expect(dominanceIssue!.message).toContain('Bad Choice');
+  });
+
+  it('does NOT flag a pair that differs only on the variance/excluded axes', () => {
+    const action = baseAction({
+      choices: [
+        {
+          id: 'safe',
+          label: 'Safe Choice',
+          effects_immediate: { money: 100, variance_up: 0 },
+          effects_delayed: {},
+        },
+        {
+          id: 'risky',
+          label: 'Risky Choice',
+          effects_immediate: { money: 100, variance_up: 10 },
+          effects_delayed: {},
+        },
+      ],
+    });
+    const issues = lintMeetings([action]);
+    expect(issues.filter((i) => i.message.includes('never worth picking'))).toEqual([]);
+  });
+});

--- a/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
+++ b/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
@@ -47,6 +47,22 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
       "requireClerkUser",
       "requireAdmin",
     ],
+    "path": "/api/admin/events-config",
+  },
+  {
+    "method": "POST",
+    "middleware": [
+      "requireClerkUser",
+      "requireAdmin",
+    ],
+    "path": "/api/admin/events-config",
+  },
+  {
+    "method": "GET",
+    "middleware": [
+      "requireClerkUser",
+      "requireAdmin",
+    ],
     "path": "/api/admin/health",
   },
   {

--- a/tests/server/routes/admin-events-config.test.ts
+++ b/tests/server/routes/admin-events-config.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+/**
+ * Admin events-config endpoint characterization test (content-editor slice 1).
+ *
+ * Mirrors the existing actions-config pair (server/routes/admin.ts): GET
+ * reads data/events.json, POST validates via EventsConfigSchema, backs up,
+ * writes, clears the gameDataLoader cache, and appends a changelog entry.
+ * Exercises the real router over supertest with auth + db mocked (db is
+ * imported by admin.ts for unrelated routes; this suite never queries it).
+ *
+ * Uses a temp fixture data/ directory (via process.chdir) so the test never
+ * touches the real data/events.json or data/content-changelog.json.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+
+vi.mock('../../../server/db', () => ({
+  db: {},
+  pool: {},
+  testDatabaseConnection: async () => true,
+}));
+
+vi.mock('../../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = 'test-admin-user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { gameDataLoader } from '@shared/utils/dataLoader';
+
+const VALID_EVENTS_CONFIG = {
+  version: '0.1.0',
+  generated: '2025-08-14',
+  events: [
+    {
+      id: 'sync_offer',
+      role_hint: 'Sync Licensing',
+      category: 'sync_licensing',
+      prompt: 'A blockbuster film wants your upcoming single for a key scene.',
+      choices: [
+        {
+          id: 'take_deal',
+          label: 'Take the deal (exclusive)',
+          effects_immediate: { money: 20000 },
+          effects_delayed: { reputation: 1 },
+        },
+      ],
+    },
+  ],
+};
+
+let app: Express;
+let originalCwd: string;
+let tmpDir: string;
+
+describe('admin events-config endpoints', () => {
+  beforeAll(async () => {
+    const adminRouter = (await import('../../../server/routes/admin')).default;
+    app = express();
+    app.use(express.json());
+    app.use(adminRouter);
+  });
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'admin-events-config-test-'));
+    await fs.mkdir(path.join(tmpDir, 'data'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, 'data', 'events.json'),
+      JSON.stringify(VALID_EVENTS_CONFIG, null, 2),
+      'utf8'
+    );
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('GET returns the current events config', async () => {
+    const res = await request(app).get('/api/admin/events-config');
+    expect(res.status).toBe(200);
+    expect(res.body.events).toHaveLength(1);
+    expect(res.body.events[0].id).toBe('sync_offer');
+  });
+
+  it('POST with a valid config writes the file, backs it up, and reports success', async () => {
+    const updated = {
+      ...VALID_EVENTS_CONFIG,
+      events: [
+        ...VALID_EVENTS_CONFIG.events,
+        {
+          id: 'new_event',
+          role_hint: 'Test',
+          category: 'industry_drama',
+          prompt: 'Something happened.',
+          choices: [
+            {
+              id: 'react',
+              label: 'React',
+              effects_immediate: {},
+              effects_delayed: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await request(app)
+      .post('/api/admin/events-config')
+      .send({ config: updated });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.backupCreated).toBe(true);
+
+    const writtenRaw = await fs.readFile(path.join(tmpDir, 'data', 'events.json'), 'utf8');
+    const written = JSON.parse(writtenRaw);
+    expect(written.events).toHaveLength(2);
+
+    const backupRaw = await fs.readFile(path.join(tmpDir, 'data', 'events.json.backup'), 'utf8');
+    const backup = JSON.parse(backupRaw);
+    expect(backup.events).toHaveLength(1);
+  });
+
+  it('POST with an invalid config (non-canonical category) returns 400 and does not write', async () => {
+    const invalid = {
+      ...VALID_EVENTS_CONFIG,
+      events: [
+        {
+          ...VALID_EVENTS_CONFIG.events[0],
+          category: 'not_a_real_category',
+        },
+      ],
+    };
+
+    const res = await request(app)
+      .post('/api/admin/events-config')
+      .send({ config: invalid });
+
+    expect(res.status).toBe(400);
+
+    const writtenRaw = await fs.readFile(path.join(tmpDir, 'data', 'events.json'), 'utf8');
+    const written = JSON.parse(writtenRaw);
+    expect(written.events[0].category).toBe('sync_licensing');
+  });
+
+  it('POST appends an id-level diff to data/content-changelog.json', async () => {
+    const updated = {
+      ...VALID_EVENTS_CONFIG,
+      events: [
+        {
+          id: 'new_event',
+          role_hint: 'Test',
+          category: 'industry_drama',
+          prompt: 'Something happened.',
+          choices: [
+            { id: 'react', label: 'React', effects_immediate: {}, effects_delayed: {} },
+          ],
+        },
+      ],
+    };
+
+    await request(app).post('/api/admin/events-config').send({ config: updated });
+
+    const changelogRaw = await fs.readFile(path.join(tmpDir, 'data', 'content-changelog.json'), 'utf8');
+    const changelog = JSON.parse(changelogRaw);
+    expect(changelog.entries).toHaveLength(1);
+    expect(changelog.entries[0].file).toBe('events.json');
+    expect(changelog.entries[0].added).toEqual(['new_event']);
+    expect(changelog.entries[0].deleted).toEqual(['sync_offer']);
+  });
+
+  it('POST clears the gameDataLoader cache so a re-read picks up the save', async () => {
+    const clearCacheSpy = vi.spyOn(gameDataLoader, 'clearCache');
+
+    await request(app).post('/api/admin/events-config').send({ config: VALID_EVENTS_CONFIG });
+
+    expect(clearCacheSpy).toHaveBeenCalled();
+    clearCacheSpy.mockRestore();
+  });
+});

--- a/tests/server/utils/contentChangelog.test.ts
+++ b/tests/server/utils/contentChangelog.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Content changelog helper tests (content-editor slice 1, spec §2.4 fork A3).
+ *
+ * diffContentById is a pure function (no fs) — tested directly for the
+ * added/modified/deleted/empty-skip cases. appendContentChangelogEntry does
+ * real fs work; exercised separately against a scratch file.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { diffContentById, appendContentChangelogEntry } from '../../../server/utils/contentChangelog';
+
+describe('diffContentById', () => {
+  it('detects added ids', () => {
+    const result = diffContentById(
+      [{ id: 'a', value: 1 }],
+      [{ id: 'a', value: 1 }, { id: 'b', value: 2 }]
+    );
+    expect(result.added).toEqual(['b']);
+    expect(result.modified).toEqual([]);
+    expect(result.deleted).toEqual([]);
+  });
+
+  it('detects modified ids via deep JSON diff', () => {
+    const result = diffContentById(
+      [{ id: 'a', value: 1, nested: { x: 1 } }],
+      [{ id: 'a', value: 1, nested: { x: 2 } }]
+    );
+    expect(result.added).toEqual([]);
+    expect(result.modified).toEqual(['a']);
+    expect(result.deleted).toEqual([]);
+  });
+
+  it('detects deleted ids', () => {
+    const result = diffContentById(
+      [{ id: 'a', value: 1 }, { id: 'b', value: 2 }],
+      [{ id: 'a', value: 1 }]
+    );
+    expect(result.added).toEqual([]);
+    expect(result.modified).toEqual([]);
+    expect(result.deleted).toEqual(['b']);
+  });
+
+  it('returns all-empty arrays when nothing changed', () => {
+    const items = [{ id: 'a', value: 1 }];
+    const result = diffContentById(items, [{ id: 'a', value: 1 }]);
+    expect(result.added).toEqual([]);
+    expect(result.modified).toEqual([]);
+    expect(result.deleted).toEqual([]);
+  });
+
+  it('handles a combination of added, modified, and deleted in one diff', () => {
+    const result = diffContentById(
+      [{ id: 'a', value: 1 }, { id: 'b', value: 2 }],
+      [{ id: 'a', value: 999 }, { id: 'c', value: 3 }]
+    );
+    expect(result.added).toEqual(['c']);
+    expect(result.modified).toEqual(['a']);
+    expect(result.deleted).toEqual(['b']);
+  });
+});
+
+describe('appendContentChangelogEntry', () => {
+  let originalCwd: string;
+  let tmpDir: string;
+
+  afterEach(async () => {
+    if (originalCwd) {
+      process.chdir(originalCwd);
+    }
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  async function withTempCwd() {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'content-changelog-test-'));
+    await fs.mkdir(path.join(tmpDir, 'data'), { recursive: true });
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  }
+
+  it('creates the changelog file with entries array when missing, and appends an entry', async () => {
+    await withTempCwd();
+    await appendContentChangelogEntry('events.json', { added: ['x'], modified: [], deleted: [] });
+
+    const changelogPath = path.join(tmpDir, 'data', 'content-changelog.json');
+    const raw = await fs.readFile(changelogPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0]).toMatchObject({
+      file: 'events.json',
+      added: ['x'],
+      modified: [],
+      deleted: [],
+    });
+    expect(typeof parsed.entries[0].timestamp).toBe('string');
+  });
+
+  it('appends to existing entries without clobbering them', async () => {
+    await withTempCwd();
+    const changelogPath = path.join(tmpDir, 'data', 'content-changelog.json');
+    await fs.writeFile(
+      changelogPath,
+      JSON.stringify({ entries: [{ timestamp: 't0', file: 'actions.json', added: [], modified: ['old'], deleted: [] }] }),
+      'utf8'
+    );
+
+    await appendContentChangelogEntry('events.json', { added: [], modified: [], deleted: ['y'] });
+
+    const parsed = JSON.parse(await fs.readFile(changelogPath, 'utf8'));
+    expect(parsed.entries).toHaveLength(2);
+    expect(parsed.entries[0].file).toBe('actions.json');
+    expect(parsed.entries[1].file).toBe('events.json');
+  });
+
+  it('skips appending when the diff is entirely empty', async () => {
+    await withTempCwd();
+    await appendContentChangelogEntry('actions.json', { added: [], modified: [], deleted: [] });
+
+    const changelogPath = path.join(tmpDir, 'data', 'content-changelog.json');
+    await expect(fs.access(changelogPath)).rejects.toThrow();
+  });
+});

--- a/tests/shared/api/events-config-contract.test.ts
+++ b/tests/shared/api/events-config-contract.test.ts
@@ -1,0 +1,63 @@
+/**
+ * EventsConfigSchema contract tests (content-editor slice 1).
+ *
+ * Guards the one-source pattern: data/events.json must parse unchanged
+ * against the admin-facing contract schema (mirrors the dataLoader's own
+ * SideEventSchema), and the schema must reject non-canonical categories and
+ * zero-choice events the same way the engine-side lint suites do.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { EventsConfigSchema } from '@shared/api/contracts';
+
+describe('EventsConfigSchema', () => {
+  it('parses data/events.json unchanged', () => {
+    const raw = fs.readFileSync(path.join(process.cwd(), 'data', 'events.json'), 'utf8');
+    const data = JSON.parse(raw);
+    const result = EventsConfigSchema.parse(data);
+    expect(result.events.length).toBe(data.events.length);
+    expect(result.version).toBe(data.version);
+  });
+
+  it('rejects a non-canonical category', () => {
+    const bad = {
+      version: '0.1.0',
+      generated: '2025-08-14',
+      events: [
+        {
+          id: 'bad_event',
+          role_hint: 'Test',
+          category: 'not_a_real_category',
+          prompt: 'A test event.',
+          choices: [
+            {
+              id: 'choice_a',
+              label: 'Do a thing',
+              effects_immediate: {},
+              effects_delayed: {},
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => EventsConfigSchema.parse(bad)).toThrow();
+  });
+
+  it('rejects an event with zero choices', () => {
+    const bad = {
+      version: '0.1.0',
+      generated: '2025-08-14',
+      events: [
+        {
+          id: 'no_choices_event',
+          role_hint: 'Test',
+          category: 'sync_licensing',
+          prompt: 'A test event.',
+          choices: [],
+        },
+      ],
+    };
+    expect(() => EventsConfigSchema.parse(bad)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Upgrades the Actions JSON Viewer into a two-tab **Content Editor** (`/admin/actions-viewer`) so a game designer/copywriter can edit **meetings AND side events without code**. Spec: `docs/01-planning/implementation-specs/[READY] content-editor-side-events-and-meetings-plan.md` — all four product forks decided by Nes (A3 changelog / B1 read-only knobs / C2 dominance hard-block / D1 full event CRUD).

**⛔ DO NOT MERGE yet — per session merge authority, this waits for Nes's live playtest of the editor.**

## Slices
1. **`5a3c4ef` server/contracts** — `GET/POST /api/admin/events-config` (validate → backup → write); `EventsConfigSchema` deriving `category` from canonical `SIDE_EVENT_CATEGORIES`; both content POSTs now `gameDataLoader.clearCache()` (closes events-cache staleness — same failure class as the July 5 stale-server mystery) and append id-level diffs to `data/content-changelog.json` (fork A3, consumed by later docs passes for the [REFERENCE]-doc pairing rule).
2. **`c7dec05` meetings tab** — canonical effect picker (`LIVE_EFFECT_KEYS` ∪ `executive_mood`, with channel-description blurbs; replaces a stale 6-key hardcode that mislabeled 7 live channels), `requires` checkbox editor (omit-when-empty; can never emit `[]`), `reactive_trigger` selector with plain-language why-now copy, live GET data source (no more static bundle import / full-page reload), and a client lint mirror (`contentLint.ts`) that hard-blocks saves on anything the data-lint suite or the meeting-dominance rule would reject — dominance model mirrored line-for-line from `meeting-dominance.test.ts`.
3. **`2284fcd` side events tab** — full event CRUD, category picker with live weights, read-only balance-knobs strip (fork B), "(no events yet)" note on zero-event categories (`artist_personal` — fork E's authoring surface is now real), `lintSideEvents` (canonical keys/categories + category-must-have-weight). **Deliberately no dominance block for events**: real `data/events.json` contains a weakly-dominant pair today (`royalty_discrepancy` — logged as C76).

Plus `77b5cdd` doc-sync (C76 ledger entry, backend-architecture admin-endpoint list) and `f08d095` (the spec).

## Verification
Fresh-context adversarial verifier (Opus): **all 13 checklist items CONFIRMED, none refuted, no High/Medium findings** — gates independently reproduced: tsc clean, **1,488/1,488 tests green** (baseline 1,445 → +43), GM double-run green with zero snapshot rewrite, engine-adjacent diff confirmed empty (only `admin.ts` + `contentChangelog.ts` under `server/`, nothing under `shared/engine/`).

## Playtest notes for Nes
- Check out this branch and **restart the dev server** (slice 1 changed server code; `tsx` has no watch).
- After that, content saves need NO restart — both tabs fetch live files and saves clear the server data cache.
- Try: edit a meeting prompt · toggle `requires` tags · set a reactive trigger · create a save-blocked dominant choice (the lint panel should name the pair) · edit a side event · author a first `artist_personal` event · check `data/content-changelog.json` after saving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)