### PR TITLE
feat(client): Exec Console — reskin the Executive Suite as "The Board" mixing console

### DIFF
--- a/client/src/components/executive-meetings/AutoSelectReviewPanel.tsx
+++ b/client/src/components/executive-meetings/AutoSelectReviewPanel.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
 import { Button } from '../ui/button';
-import { Badge } from '../ui/badge';
-import { Card, CardContent } from '../ui/card';
-import { Check, X, Pencil, Zap, Sparkles } from 'lucide-react';
+import { Check, X, Zap, Sparkles, Wand2 } from 'lucide-react';
 import type { RoleMeeting, DialogueChoice, Executive } from '../../../../shared/types/gameTypes';
 import { ChoiceEffects } from './DialogueInterface';
+import { roleConfig } from './ExecutiveCard';
 import { getChoiceCreativeCapitalCost } from '../../services/executiveAutoSelect';
 import { formatWhyNow } from '../../utils/reactiveContextCopy';
 
 /**
- * Meeting-relevance PR-3 — AUTO Option A (propose-then-confirm).
+ * Meeting-relevance PR-3 — AUTO Option A (propose-then-confirm), restyled as the
+ * Exec Console's "proposed patch list" modal overlay (2026-07-11 redesign).
  *
  * AUTO no longer commits its picks straight away. It computes them and hands the
- * proposal to this compact review panel: one row per exec that AUTO chose (execs
+ * proposal to this review overlay: one row per exec that AUTO chose (execs
  * sitting out on an empty pool never appear — they never make it into
  * `autoOptions`). Each row shows the picked meeting, AUTO's chosen choice, the
  * choice's effect badges (reused verbatim from `ChoiceEffects`, so the same
  * LIVE_EFFECT_KEYS whitelist + `EffectBadgeTooltip` wrapping the manual dialogue
- * uses), and the pick's Creative Capital / money cost (surfaced from what AUTO
- * already computes — no new economy math).
+ * uses), the Tier 2 "why now" line when the pick is reactive, and the pick's
+ * Creative Capital / money cost (surfaced from what AUTO already computes — no
+ * new economy math).
  *
  * The player can (a) confirm all — commits exactly these picks — or (b) override
  * a single row, which drops the whole proposal and enters the normal manual
@@ -34,16 +35,21 @@ interface AutoOptionLike {
   choice: DialogueChoice;
 }
 
-const ROLE_LABELS: Record<string, string> = {
-  ceo: 'CEO — You',
-  head_ar: 'A&R — Marcus Rodriguez',
-  cco: 'CCO — Dante Washington',
-  cmo: 'CMO — Samara Chen',
-  head_distribution: 'Distro — Patricia Williams',
-};
+function execConfig(role: string) {
+  return (
+    roleConfig[role as keyof typeof roleConfig] ?? {
+      shortTitle: role.replace(/_/g, ' ').toUpperCase(),
+      name: role.replace(/_/g, ' '),
+      title: role.replace(/_/g, ' '),
+      avatar: undefined,
+      roleText: 'text-text-muted',
+    }
+  );
+}
 
 function roleLabel(role: string): string {
-  return ROLE_LABELS[role] ?? role.replace(/_/g, ' ').toUpperCase();
+  const config = execConfig(role);
+  return `${config.shortTitle} — ${config.name}`;
 }
 
 function meetingLabel(meeting: RoleMeeting): string {
@@ -79,107 +85,129 @@ export function AutoSelectReviewPanel({
   if (options.length === 0) return null;
 
   return (
-    <div className="w-full max-w-xl mx-auto" data-testid="auto-select-review-panel">
-      <div className="flex items-center gap-2 mb-4">
-        <Zap className="h-4 w-4 text-neon-cyan" />
-        <span className="font-display text-sm text-text-primary">
-          AUTO picked {options.length} meeting{options.length === 1 ? '' : 's'} — review before committing
-        </span>
-      </div>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-surface-app/70 p-4 backdrop-blur-lg"
+      data-testid="auto-select-review-panel"
+    >
+      <div className="chromatic-hairline relative max-h-[86vh] w-[860px] max-w-full overflow-auto rounded-card border border-white/10 bg-gradient-to-b from-surface-panel to-surface-inner p-7 shadow-panel md:p-9">
+        <div className="mb-2 flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-action-pink to-action-purple shadow-action">
+              <Wand2 className="h-4 w-4 text-white" />
+            </div>
+            <h2 className="m-0 font-display text-[21px] font-semibold text-text-primary">
+              AUTO — proposed patch list
+            </h2>
+          </div>
+          <span className="font-mono text-[11px] text-text-muted">
+            {options.length} pick{options.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        <p className="mb-6 mt-0 text-[13px] text-text-muted">
+          Safe picks for your remaining focus slots. Nothing commits until you confirm.
+        </p>
 
-      <div className="space-y-3">
-        {options.map((option) => {
-          const ccCost = getChoiceCreativeCapitalCost(option.choice);
-          const moneyDelta = getChoiceMoneyDelta(option.choice);
-          return (
-            <Card
-              key={option.executive.role}
-              data-testid={`auto-review-row-${option.executive.role}`}
-              className="glass-panel chromatic-hairline border-0"
-            >
-              <CardContent className="p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <Badge
-                      variant="secondary"
-                      className="text-[10px] px-2 py-0.5 font-mono uppercase tracking-wide bg-neon-lilac/10 text-neon-lilac border border-neon-lilac/40 rounded-pill"
-                    >
-                      {roleLabel(option.executive.role)}
-                    </Badge>
+        <div className="flex flex-col gap-3.5">
+          {options.map((option) => {
+            const ccCost = getChoiceCreativeCapitalCost(option.choice);
+            const moneyDelta = getChoiceMoneyDelta(option.choice);
+            const config = execConfig(option.executive.role);
+            return (
+              <div
+                key={option.executive.role}
+                data-testid={`auto-review-row-${option.executive.role}`}
+                className="chromatic-hairline relative overflow-hidden rounded-card border border-white/[0.08] bg-surface-inner/50 px-5 py-4"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded-full shadow-panel">
+                    {config.avatar ? (
+                      <img
+                        src={config.avatar}
+                        alt={`${config.title} avatar`}
+                        className="h-full w-full object-cover object-top"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-money to-action-pink font-display text-sm text-white">
+                        {config.shortTitle}
+                      </div>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-baseline gap-2.5">
+                      <span className="text-[14.5px] font-semibold text-text-primary">{roleLabel(option.executive.role)}</span>
+                    </div>
+                    <div className="mt-0.5 text-[12.5px] text-text-body">
+                      {meetingLabel(option.meeting)} →{' '}
+                      <span className="font-medium text-text-primary">{option.choice.label}</span>
+                    </div>
                     {option.meeting.reactiveContext && (
                       <div
                         data-testid="why-now-line"
-                        className="mt-2 flex items-center gap-1.5 text-xs font-mono text-neon-cyan"
+                        className="mt-2 inline-flex items-center gap-1.5 rounded-pill border border-neon-cyan/30 bg-neon-cyan/10 px-2.5 py-0.5 text-[11px] text-neon-cyan"
                       >
                         <Sparkles className="h-3 w-3 shrink-0" />
-                        <span>{formatWhyNow(option.meeting.reactiveContext)}</span>
+                        <span className="font-mono">{formatWhyNow(option.meeting.reactiveContext)}</span>
                       </div>
                     )}
-                    <div className="mt-2 text-sm text-text-primary italic leading-snug">
-                      "{meetingLabel(option.meeting)}"
+                    <div className="mt-2.5">
+                      <ChoiceEffects choice={option.choice} targetScope={option.meeting.target_scope} />
                     </div>
-                    <div className="mt-1 text-sm font-medium text-text-body">
-                      {option.choice.label}
-                    </div>
+                    {(ccCost > 0 || moneyDelta !== 0) && (
+                      <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px]">
+                        {ccCost > 0 && (
+                          <span className="font-mono text-neon-lilac">Cost: {ccCost} Creative</span>
+                        )}
+                        {moneyDelta !== 0 && (
+                          <span className="font-mono text-money">
+                            {moneyDelta > 0 ? '+' : '-'}${Math.abs(moneyDelta).toLocaleString()}
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </div>
-
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onOverrideRow(option.executive)}
-                    aria-label={`Override ${roleLabel(option.executive.role)}`}
-                    data-testid={`auto-review-override-${option.executive.role}`}
-                    className="shrink-0 gap-1 text-text-muted hover:text-neon-cyan"
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                    Override
-                  </Button>
-                </div>
-
-                <div className="mt-3">
-                  <ChoiceEffects choice={option.choice} targetScope={option.meeting.target_scope} />
-                </div>
-
-                {(ccCost > 0 || moneyDelta !== 0) && (
-                  <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px]">
+                  <div className="flex flex-shrink-0 flex-col items-end gap-2">
                     {ccCost > 0 && (
-                      <span className="font-mono text-neon-lilac">
-                        Cost: {ccCost} Creative
+                      <span className="flex items-center gap-1.5 rounded-pill border border-neon-lilac/30 bg-neon-lilac/10 px-2.5 py-1 font-mono text-[11px] text-neon-lilac">
+                        <Zap className="h-2.5 w-2.5" />
+                        {ccCost} CC
                       </span>
                     )}
-                    {moneyDelta !== 0 && (
-                      <span className="font-mono text-money">
-                        {moneyDelta > 0 ? '+' : '-'}${Math.abs(moneyDelta).toLocaleString()}
-                      </span>
-                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onOverrideRow(option.executive)}
+                      aria-label={`Override ${roleLabel(option.executive.role)}`}
+                      data-testid={`auto-review-override-${option.executive.role}`}
+                      className="rounded-button border border-neon-cyan/40 bg-neon-cyan/[0.07] text-xs text-neon-cyan hover:bg-neon-cyan/15 hover:text-neon-cyan"
+                    >
+                      Override
+                    </Button>
                   </div>
-                )}
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
 
-      <div className="mt-5 flex items-center justify-end gap-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onCancel}
-          data-testid="auto-review-cancel"
-          className="gap-1 text-text-muted hover:text-text-primary"
-        >
-          <X className="h-4 w-4" />
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          onClick={onConfirmAll}
-          data-testid="auto-review-confirm"
-          className="gap-1 rounded-button border border-neon-cyan/35 bg-neon-cyan/[0.06] text-neon-cyan hover:bg-neon-cyan/10 hover:text-neon-cyan"
-        >
-          <Check className="h-4 w-4" />
-          Confirm All
-        </Button>
+        <div className="mt-6 flex gap-3.5">
+          <Button
+            onClick={onConfirmAll}
+            data-testid="auto-review-confirm"
+            className="flex-1 gap-2 rounded-button bg-gradient-to-br from-action-pink to-action-purple py-6 text-[14.5px] font-semibold text-white shadow-action hover:opacity-90"
+          >
+            <Check className="h-4 w-4" />
+            Confirm All
+          </Button>
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            data-testid="auto-review-cancel"
+            className="flex-none basis-[180px] gap-2 rounded-button border border-white/10 bg-white/[0.03] py-6 text-sm text-text-body hover:bg-white/[0.07]"
+          >
+            <X className="h-4 w-4" />
+            Cancel
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/executive-meetings/DialogueInterface.tsx
+++ b/client/src/components/executive-meetings/DialogueInterface.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
-import { Card, CardContent } from '../ui/card';
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '../ui/carousel';
-import { BorderTrail } from '../motion-primitives/border-trail';
-import { GlowEffect } from '../motion-primitives/glow-effect';
-import { TrendingUp, TrendingDown, Clock, Zap, ArrowLeft, Shuffle } from 'lucide-react';
+import { TrendingUp, TrendingDown, Clock, Zap, Shuffle } from 'lucide-react';
 import type { DialogueChoice } from '../../../../shared/types/gameTypes';
 import { LIVE_EFFECT_KEYS } from '@shared/engine/processors/ActionProcessor';
 import { EffectBadgeTooltip } from './EffectBadgeTooltip';
@@ -219,6 +215,12 @@ export function ChoiceEffects({
   );
 }
 
+/**
+ * Exec Console redesign (2026-07-11): the dialogue step renders all takes SIDE
+ * BY SIDE ("your three takes" in the console design) instead of a carousel —
+ * the player compares responses at a glance. Behavior is unchanged: same
+ * ChoiceEffects badge honesty, same CC affordability gate + testids.
+ */
 export function DialogueInterface({
   dialogue,
   onSelectChoice,
@@ -234,87 +236,77 @@ export function DialogueInterface({
 
   return (
     <div className="space-y-6">
-      <Card className="glass-panel chromatic-hairline relative overflow-hidden w-full max-w-md mx-auto border-0">
-        <GlowEffect
-          mode="static"
-          colors={['#a05af0', '#4a6bff', '#c8a6ff', '#ff4d8d']}
-          blur="medium"
-        />
-        <CardContent className="p-4 relative z-10">
-          <p className="text-base italic leading-relaxed text-text-primary">
-            "{displayPrompt}"
-          </p>
-        </CardContent>
-      </Card>
+      {/* prompt quote panel */}
+      <div className="chromatic-hairline relative rounded-card border border-neon-pink/20 bg-gradient-to-br from-action-pink/15 to-action-purple/15 px-6 py-5">
+        <p className="text-[15.5px] italic leading-relaxed text-text-primary">
+          "{displayPrompt}"
+        </p>
+        {selectedArtistName && (
+          <div className="mt-2.5 inline-flex items-center gap-2 rounded-pill border border-neon-lilac/30 bg-neon-lilac/10 px-3 py-1 text-[11px] text-neon-lilac">
+            Re: {selectedArtistName}
+          </div>
+        )}
+      </div>
 
-      <div className="space-y-4">
+      <div>
+        <div className="mb-3.5 font-mono text-[10px] uppercase tracking-[0.24em] text-text-muted">
+          your takes
+        </div>
+        <div className="grid grid-cols-1 items-stretch gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {dialogue.choices.map((choice) => {
+            // CC affordability gate: disable a choice the player can't pay
+            // for (same cost math AUTO budgets with). undefined prop = no gate.
+            const ccCost = getChoiceCreativeCapitalCost(choice);
+            const cannotAfford =
+              typeof availableCreativeCapital === 'number' && ccCost > availableCreativeCapital;
+            return (
+              <div
+                key={choice.id}
+                className={`chromatic-hairline relative flex flex-col rounded-card border bg-surface-inner/60 p-5 ${
+                  cannotAfford ? 'border-negative/25 opacity-80' : 'border-white/10'
+                }`}
+              >
+                <div className="mb-3.5 flex items-start justify-between gap-2.5">
+                  <div className="text-sm font-semibold leading-snug text-text-primary">
+                    {choice.label}
+                  </div>
+                  <span className="flex flex-shrink-0 items-center gap-1.5 rounded-pill border border-neon-lilac/30 bg-neon-lilac/10 px-2.5 py-1 font-mono text-[10.5px] text-neon-lilac">
+                    <Zap className="h-2.5 w-2.5" />
+                    {ccCost === 0 ? 'Free' : `${ccCost} CC`}
+                  </span>
+                </div>
 
-        <Carousel
-          className="w-full max-w-md mx-auto"
-          opts={{
-            loop: true,
-          }}
-        >
-          <CarouselContent>
-            {dialogue.choices.map((choice) => {
-              // CC affordability gate: disable a choice the player can't pay
-              // for (same cost math AUTO budgets with). undefined prop = no gate.
-              const ccCost = getChoiceCreativeCapitalCost(choice);
-              const cannotAfford =
-                typeof availableCreativeCapital === 'number' && ccCost > availableCreativeCapital;
-              return (
-              <CarouselItem key={choice.id}>
-                <Card className="glass-panel chromatic-hairline relative border-0 transition-all duration-200 hover:shadow-glow-lilac">
-                  <BorderTrail
-                    size={180}
-                    className="bg-gradient-to-l from-action-pink via-money to-neon-lilac"
-                    transition={{
-                      repeat: Infinity,
-                      duration: 4,
-                      ease: "linear"
-                    }}
-                  />
-                  <CardContent className="p-4">
-                    <div className="space-y-3">
-                      <div className="font-medium text-sm leading-relaxed text-text-primary">
-                        {choice.label}
-                      </div>
+                <ChoiceEffects
+                  choice={choice}
+                  targetScope={targetScope}
+                  selectedArtistName={selectedArtistName}
+                />
 
-                      <ChoiceEffects
-                        choice={choice}
-                        targetScope={targetScope}
-                        selectedArtistName={selectedArtistName}
-                      />
+                <div className="flex-1" />
 
-                      {cannotAfford && (
-                        <div
-                          data-testid={`cc-gate-${choice.id}`}
-                          className="flex items-center gap-1.5 text-xs font-mono text-warning"
-                        >
-                          <Zap className="h-3 w-3 shrink-0" />
-                          <span>
-                            Needs {ccCost} Creative Capital — you have {availableCreativeCapital}
-                          </span>
-                        </div>
-                      )}
-                      <Button
-                        onClick={() => onSelectChoice(choice)}
-                        disabled={cannotAfford}
-                        className="w-full rounded-button bg-gradient-to-br from-action-pink to-action-purple text-white shadow-action hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
-                        size="sm"
-                      >
-                        Choose This Response
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              </CarouselItem>
-              );
-            })}
-          </CarouselContent>
-          <CarouselPrevious className="bg-neon-lilac/10 hover:bg-neon-lilac/20 border-neon-lilac/40 text-neon-lilac" />
-          <CarouselNext className="bg-neon-lilac/10 hover:bg-neon-lilac/20 border-neon-lilac/40 text-neon-lilac" />
-        </Carousel>
+                {cannotAfford && (
+                  <div
+                    data-testid={`cc-gate-${choice.id}`}
+                    className="mt-3.5 flex items-center gap-1.5 rounded-lg border border-negative/30 bg-negative/10 px-3 py-2 text-xs font-mono text-negative"
+                  >
+                    <Zap className="h-3 w-3 shrink-0" />
+                    <span>
+                      Needs {ccCost} Creative Capital — you have {availableCreativeCapital}
+                    </span>
+                  </div>
+                )}
+                <Button
+                  onClick={() => onSelectChoice(choice)}
+                  disabled={cannotAfford}
+                  className="mt-3.5 w-full rounded-button bg-gradient-to-br from-action-pink to-action-purple text-white shadow-action hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+                  size="sm"
+                >
+                  {cannotAfford ? 'Locked' : 'Choose'}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/executive-meetings/ExecutiveCard.tsx
+++ b/client/src/components/executive-meetings/ExecutiveCard.tsx
@@ -1,9 +1,22 @@
 import React from 'react';
 import { Badge } from '../ui/badge';
-import { Users, Brain, DollarSign, Star, Truck } from 'lucide-react';
+import { HoloDisc } from '../ui/holo-disc';
+import { Users, Brain, DollarSign, Star, Check } from 'lucide-react';
 import type { Executive } from '../../../../shared/types/gameTypes';
 import { getMoodModifiers, isNeutral } from '@shared/utils/executiveMoodModifier';
 
+/**
+ * Exec Console redesign (2026-07-11, from the claude.ai/design "Exec Meetings —
+ * Console" direction): each executive renders as a mixing-console CHANNEL STRIP —
+ * channel number, avatar disc, name/role/salary, vertical loyalty & mood faders,
+ * and a status readout at the foot of the strip. The CEO renders as the narrower
+ * MASTER strip (spinning HoloDisc, no faders — the CEO has no exec mood/loyalty row).
+ *
+ * All pre-redesign behavior contracts are preserved:
+ * - `sit-out-${role}` / `urgency-dot-${role}` testids (Tier 0 sit-out, Tier 2 urgency)
+ * - selection blocked while disabled / sitting out / A&R-busy
+ * - mood-band modifier chip via the SAME shared util the engine routes through
+ */
 interface ExecutiveCardProps {
   executive: Executive;
   disabled?: boolean;
@@ -27,62 +40,115 @@ interface ExecutiveCardProps {
     arOfficeSourcingType: string | null;
     arOfficeOperationStart: number | null;
   };
-  flipAvatar?: boolean;
-  badgesOnLeft?: boolean;
-  alignContent?: 'left' | 'right' | 'center';
-  isSelected?: boolean;
-  compactBadges?: boolean;
+  /** This exec already has a meeting queued into a focus slot this week. */
+  queued?: boolean;
+  /** No focus slots remain this week (distinct from queued — drives status copy). */
+  noSlots?: boolean;
+  /** Console channel number shown in the strip head (1-based). */
+  channelNumber?: number;
 }
 
-const roleConfig = {
+export const roleConfig = {
   ceo: {
     icon: Star,
-    color: 'bg-purple-500',
     title: 'Chief Executive Officer',
     shortTitle: 'CEO',
     name: 'You',
     avatar: undefined,
+    roleText: 'text-money',
+    ringShadow: 'shadow-[0_0_0_1.5px_rgba(240,201,138,0.5)]',
+    tint: 'from-money/10',
+    border: 'border-money/30',
   },
   head_ar: {
     icon: Users,
-    color: 'bg-blue-500',
     title: 'Head of A&R',
     shortTitle: 'A&R',
     name: 'Marcus Rodriguez',
     avatar: '/avatars/marcus_rodriguez_exec@0.5x.png',
+    roleText: 'text-neon-cyan',
+    ringShadow: 'shadow-[0_0_0_1.5px_rgba(55,214,255,0.45)]',
+    tint: 'from-neon-cyan/10',
+    border: 'border-white/10',
   },
   cco: {
     icon: Brain,
-    color: 'bg-green-500',
     title: 'Chief Creative Officer',
     shortTitle: 'CCO',
     name: 'Dante Washington',
     avatar: '/avatars/dante_washingtong_exec@0.5x.png',
+    roleText: 'text-neon-lilac',
+    ringShadow: 'shadow-[0_0_0_1.5px_rgba(160,90,240,0.45)]',
+    tint: 'from-neon-purple/10',
+    border: 'border-white/10',
   },
   cmo: {
     icon: DollarSign,
-    color: 'bg-orange-500',
     title: 'Chief Marketing Officer',
     shortTitle: 'CMO',
     name: 'Samara Chen',
     avatar: '/avatars/samara_chen_exec@0.5x.png',
+    roleText: 'text-neon-pink',
+    ringShadow: 'shadow-[0_0_0_1.5px_rgba(255,61,110,0.4)]',
+    tint: 'from-neon-magenta/10',
+    border: 'border-white/10',
   },
   head_distribution: {
     icon: DollarSign,
-    color: 'bg-teal-500',
-    title: 'Head of Distribution & Operations',
+    title: 'Head of Distribution',
     shortTitle: 'Distro',
     name: 'Patricia Williams',
     avatar: '/avatars/patricia_williams_exec@0.5x.png',
+    roleText: 'text-positive',
+    ringShadow: 'shadow-[0_0_0_1.5px_rgba(55,224,176,0.45)]',
+    tint: 'from-positive/10',
+    border: 'border-white/10',
   },
 } as const;
 
-export function ExecutiveCard({ executive, disabled = false, sitOut = false, hasReactiveMeeting = false, onSelect, weeklySalary, arOfficeStatus, flipAvatar = false, badgesOnLeft = false, alignContent = 'center', isSelected = false, compactBadges = false }: ExecutiveCardProps) {
+function VerticalFader({ value, label, fillClass, valueClass }: {
+  value: number;
+  label: string;
+  fillClass: string;
+  valueClass: string;
+}) {
+  const clamped = Math.max(0, Math.min(100, value));
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <div className="relative h-[88px] w-2 overflow-hidden rounded-full bg-white/[0.07]">
+        <div
+          className={`absolute bottom-0 left-0 right-0 rounded-full ${fillClass}`}
+          style={{ height: `${clamped}%` }}
+        />
+      </div>
+      <span className="font-mono text-[9px] uppercase tracking-[0.12em] text-text-muted">{label}</span>
+      <span className={`font-mono text-[11px] ${valueClass}`}>{clamped}</span>
+    </div>
+  );
+}
+
+export function ExecutiveCard({
+  executive,
+  disabled = false,
+  sitOut = false,
+  hasReactiveMeeting = false,
+  onSelect,
+  weeklySalary,
+  arOfficeStatus,
+  queued = false,
+  noSlots = false,
+  channelNumber,
+}: ExecutiveCardProps) {
   const config = roleConfig[executive.role as keyof typeof roleConfig] || {
     icon: Users,
-    color: 'bg-gray-500',
     title: executive.role,
+    shortTitle: executive.role,
+    name: executive.role,
     avatar: undefined,
+    roleText: 'text-text-muted',
+    ringShadow: '',
+    tint: 'from-white/5',
+    border: 'border-white/10',
   };
 
   const IconComponent = config.icon;
@@ -91,55 +157,13 @@ export function ExecutiveCard({ executive, disabled = false, sitOut = false, has
   const isArBusy = !!(isHeadAR && arOfficeStatus?.arOfficeSlotUsed);
   // PR-1 sit-out: an exec with an empty eligible meeting pool cannot be
   // selected into a focus slot this week.
-  const effectiveDisabled = disabled || isArBusy || sitOut;
-  const shouldCompact = compactBadges && !isSelected;
+  const effectiveDisabled = disabled || isArBusy || sitOut || queued;
 
   const loyaltyValue = executive.loyalty ?? 50;
   const moodValue = executive.mood ?? 50;
-  const levelValue = executive.level ?? 1;
-
-  const formatSalaryAbbrev = (value: number) => {
-    const thousands = value / 1000;
-    const rounded = Math.round(thousands * 10) / 10;
-    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}K`;
-  };
-
-  const salaryLabel = (value: number) => {
-    if (shouldCompact) {
-      return `$${formatSalaryAbbrev(value)}`;
-    }
-    return `Salary $${value.toLocaleString()}`;
-  };
-
-  const alignmentClass = alignContent === 'left' ? 'items-start' : alignContent === 'right' ? 'items-end' : 'items-center';
-  const badgeOffsetDefault = badgesOnLeft ? '-left-20' : '-right-20';
-  const badgeOffsetCompact = badgesOnLeft ? '-left-8' : '-right-6';
-  const badgeStackSideClass = shouldCompact ? badgeOffsetCompact : badgeOffsetDefault;
-  const badgeStackAlignment = badgesOnLeft ? 'items-end' : 'items-start';
-  const badgeStackGapClass = shouldCompact ? 'gap-0.5' : 'gap-1';
-  const neutralBadgeClass = 'font-mono bg-neon-lilac/10 text-neon-lilac border border-neon-lilac/40 rounded-pill';
-
-  const loyaltyClass = shouldCompact
-    ? neutralBadgeClass
-    : loyaltyValue >= 70
-      ? 'font-mono bg-positive/10 text-positive border border-positive/40 rounded-pill'
-      : loyaltyValue >= 40
-        ? 'font-mono bg-warning/10 text-warning border border-warning/40 rounded-pill'
-        : 'font-mono bg-negative/10 text-negative border border-negative/40 rounded-pill';
-
-  const moodClass = shouldCompact
-    ? neutralBadgeClass
-    : moodValue >= 70
-      ? 'font-mono bg-positive/10 text-positive border border-positive/40 rounded-pill'
-      : moodValue >= 40
-        ? 'font-mono bg-warning/10 text-warning border border-warning/40 rounded-pill'
-        : 'font-mono bg-negative/10 text-negative border border-negative/40 rounded-pill';
-
-  const levelClass = shouldCompact ? neutralBadgeClass : 'font-mono bg-neon-blue/10 text-neon-blue border border-neon-blue/40 rounded-pill';
-  const salaryClass = shouldCompact ? neutralBadgeClass : 'font-mono bg-money/10 text-money border border-money/40 rounded-pill';
 
   // Exec-meetings-revival PR-9 (C6/D) — active mood-modifier chip. CEO has no exec row
-  // (returns early below), so this only surfaces for real executives. Neutral band
+  // (master strip below), so this only surfaces for real executives. Neutral band
   // (mood 30-80) shows nothing. Uses the SAME shared util the engine + preview route
   // through, so the label can never drift from the mechanic.
   const moodModifiers = getMoodModifiers(moodValue);
@@ -147,49 +171,74 @@ export function ExecutiveCard({ executive, disabled = false, sitOut = false, has
     ? null
     : moodModifiers.band === 'inspired'
       ? {
-          label: shouldCompact
-            ? `+${Math.round((moodModifiers.effectMultiplier - 1) * 100)}%`
-            : `Inspired +${Math.round((moodModifiers.effectMultiplier - 1) * 100)}%`,
+          label: `Inspired +${Math.round((moodModifiers.effectMultiplier - 1) * 100)}%`,
           className: 'font-mono bg-neon-cyan/10 text-neon-cyan border border-neon-cyan/40 rounded-pill',
         }
       : moodModifiers.band === 'content'
         ? {
-            label: shouldCompact
-              ? `-${Math.round((1 - moodModifiers.costMultiplier) * 100)}%`
-              : `Content −${Math.round((1 - moodModifiers.costMultiplier) * 100)}% costs`,
+            label: `Content −${Math.round((1 - moodModifiers.costMultiplier) * 100)}% costs`,
             className: 'font-mono bg-positive/10 text-positive border border-positive/40 rounded-pill',
           }
         : {
-            label: shouldCompact
-              ? `+${Math.round((moodModifiers.costMultiplier - 1) * 100)}%`
-              : `Disgruntled +${Math.round((moodModifiers.costMultiplier - 1) * 100)}% costs`,
+            label: `Disgruntled +${Math.round((moodModifiers.costMultiplier - 1) * 100)}% costs`,
             className: 'font-mono bg-negative/10 text-negative border border-negative/40 rounded-pill',
           };
 
-  // CEO only shows badge, no avatar
+  // Console status readout (foot of the strip) — precedence mirrors the design:
+  // busy > queued > sit-out > no-slots > open for business.
+  const status = isArBusy
+    ? { text: 'Running a scouting op — back next week', className: 'bg-neon-amber/10 border-neon-amber/30 text-neon-amber' }
+    : queued
+      ? { text: 'Meeting queued for this week', className: 'bg-neon-green/10 border-neon-green/30 text-neon-green' }
+      : sitOut
+        ? { text: isCEO ? 'Nothing needs your call this week' : 'Nothing needs their call this week', className: 'bg-white/[0.03] border-white/10 text-text-muted' }
+        : noSlots
+          ? { text: 'No focus slots remaining', className: 'bg-negative/10 border-negative/25 text-negative' }
+          : { text: 'Has something for you', className: 'bg-neon-purple/10 border-neon-purple/35 text-neon-lilac' };
+
+  const queuedChip = (
+    <span className="flex items-center gap-1.5 rounded-pill border border-neon-green/40 bg-neon-green/15 px-2 py-0.5 font-mono text-[9px] font-semibold text-neon-green">
+      <Check className="h-2.5 w-2.5" /> Queued
+    </span>
+  );
+
+  // ── CEO master strip ─────────────────────────────────────────────────────
   if (isCEO) {
     return (
-      <div className="flex flex-col items-center gap-1">
-        <div className="relative inline-block">
-          <Badge
-            variant="secondary"
-            className={`text-xs px-3 py-1 font-mono uppercase tracking-wide bg-neon-lilac/10 text-neon-lilac border border-neon-lilac/40 rounded-pill ${
-              effectiveDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-neon-lilac/20 transition-colors'
-            }`}
-            onClick={effectiveDisabled ? undefined : onSelect}
-          >
-            {config.shortTitle} - {config.name}
-          </Badge>
+      <div
+        data-testid="exec-strip-ceo"
+        onClick={effectiveDisabled ? undefined : onSelect}
+        className={`relative flex w-[150px] flex-shrink-0 flex-col items-center overflow-hidden rounded-card border ${config.border} bg-gradient-to-b ${config.tint} to-surface-inner/90 px-4 py-5 transition-colors ${
+          effectiveDisabled ? 'opacity-60' : 'cursor-pointer hover:border-money/60'
+        }`}
+      >
+        <div className="mb-4 flex w-full items-center justify-between">
+          <span className="font-mono text-[9px] uppercase tracking-[0.26em] text-money">master</span>
           {hasReactiveMeeting && !sitOut && (
             <span
-              data-testid={`urgency-dot-${executive.role}`}
+              data-testid="urgency-dot-ceo"
               aria-label="Something happened this week"
-              className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-neon-cyan shadow-[0_0_6px_2px_rgba(34,211,238,0.6)] animate-pulse"
+              className="h-2.5 w-2.5 rounded-full bg-neon-cyan shadow-[0_0_8px_2px_rgba(34,211,238,0.6)] animate-pulse"
             />
           )}
         </div>
+        <HoloDisc size={56} spinSeconds={12} className="mb-3.5" />
+        <div className="text-center text-[13.5px] font-semibold text-text-primary">
+          {config.shortTitle} - {config.name}
+        </div>
+        <div className="mt-1 text-center font-mono text-[9px] uppercase tracking-[0.16em] text-money/70">
+          {queued ? 'meeting queued' : noSlots ? 'no slots left' : 'quarterly vision'}
+        </div>
+        <div className="flex-1 min-h-4" />
+        {queued ? (
+          queuedChip
+        ) : (
+          <div className="w-full rounded-lg border border-money/25 bg-money/[0.08] px-1 py-1.5 text-center font-mono text-[9px] uppercase tracking-[0.14em] text-money">
+            open channel
+          </div>
+        )}
         {sitOut && (
-          <span data-testid={`sit-out-${executive.role}`} className="text-xs text-text-muted">
+          <span data-testid="sit-out-ceo" className="mt-2 text-center text-xs text-text-muted">
             Nothing needs your call this week
           </span>
         )}
@@ -197,95 +246,91 @@ export function ExecutiveCard({ executive, disabled = false, sitOut = false, has
     );
   }
 
-  // Avatar column content
-  const avatarColumn = (
-    <div className={`flex-shrink-0 flex flex-col ${alignmentClass} justify-center gap-2`}>
-      <div className="relative">
-        {/* Tier 2 (PR-2, urgency indicator): dot/pulse signaling a reactive
-            meeting is queued for this exec — no content, just "something
-            happened". Suppressed when sitting out (no meeting to open). */}
-        {hasReactiveMeeting && !sitOut && (
+  // ── Exec channel strip ───────────────────────────────────────────────────
+  return (
+    <div
+      data-testid={`exec-strip-${executive.role}`}
+      onClick={effectiveDisabled ? undefined : onSelect}
+      className={`relative flex flex-1 flex-col items-center overflow-hidden rounded-card border ${
+        effectiveDisabled ? 'border-white/[0.07]' : 'border-white/[0.14] hover:border-white/25'
+      } bg-gradient-to-b ${config.tint} to-surface-inner/90 px-4 py-5 transition-all duration-200 ${
+        effectiveDisabled ? (queued ? 'opacity-75' : 'opacity-55') : 'cursor-pointer hover:-translate-y-1.5'
+      } ${hasReactiveMeeting && !effectiveDisabled ? 'shadow-[0_0_34px_rgba(55,214,255,0.16)]' : ''}`}
+    >
+      {/* channel head */}
+      <div className="mb-4 flex w-full items-center justify-between">
+        <span className="font-mono text-[9px] uppercase tracking-[0.22em] text-text-muted">
+          ch {channelNumber ?? ''}
+        </span>
+        {queued ? (
+          queuedChip
+        ) : hasReactiveMeeting && !sitOut ? (
           <span
             data-testid={`urgency-dot-${executive.role}`}
             aria-label="Something happened this week"
-            className="absolute -top-1 -right-1 z-10 h-3.5 w-3.5 rounded-full bg-neon-cyan shadow-[0_0_8px_2px_rgba(34,211,238,0.6)] animate-pulse"
+            className="h-2.5 w-2.5 rounded-full bg-neon-cyan shadow-[0_0_8px_2px_rgba(34,211,238,0.6)] animate-pulse"
           />
-        )}
-        {/* Avatar/Icon Box */}
-        <div className="w-36 h-36 bg-gradient-to-br from-neon-purple to-neon-blue border border-white/10 rounded-card overflow-hidden relative shadow-panel">
-          {config.avatar ? (
-            <img
-              src={config.avatar}
-              alt={`${config.title} avatar`}
-              className={`absolute w-full object-cover ${flipAvatar ? 'scale-x-[-1]' : ''}`}
-              style={{
-                height: '244px',
-                top: '-20px',
-                imageRendering: 'auto'
-              }}
-            />
-          ) : (
-            <div className={`w-full h-full flex items-center justify-center`}>
-              <div className="p-3 rounded-card bg-white/10 text-white">
-                <IconComponent className="h-12 w-12" />
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Metrics Badges - Stacked vertically, slightly overlapping avatar */}
-        <div className={`absolute ${badgeStackSideClass} top-1/2 -translate-y-1/2 flex flex-col ${badgeStackGapClass} ${badgeStackAlignment}`}>
-          {/* Loyalty Badge */}
-          <Badge variant="secondary" className={`text-xs px-2 py-1 ${loyaltyClass}`}>
-            {shouldCompact ? `L${loyaltyValue}` : `Loyalty: ${loyaltyValue}`}
-          </Badge>
-
-          {/* Mood Badge */}
-          <Badge variant="secondary" className={`text-xs px-2 py-1 ${moodClass}`}>
-            {shouldCompact ? `M${moodValue}` : `Mood: ${moodValue}`}
-          </Badge>
-
-          {/* Exec-meetings-revival PR-9: mood-modifier chip (non-neutral only) */}
-          {moodBandChip && (
-            <Badge variant="secondary" className={`text-xs px-2 py-1 ${moodBandChip.className}`}>
-              {moodBandChip.label}
-            </Badge>
-          )}
-
-          {/* Level Badge */}
-          <Badge variant="secondary" className={`text-xs px-2 py-1 ${levelClass}`}>
-            {shouldCompact ? `Lvl${levelValue}` : `Level ${levelValue}`}
-          </Badge>
-
-          {/* Salary Badge */}
-          {weeklySalary !== undefined && (
-            <Badge variant="secondary" className={`text-xs px-2 py-1 ${salaryClass}`}>
-              {salaryLabel(weeklySalary)}
-            </Badge>
-          )}
-        </div>
+        ) : null}
       </div>
 
-      {/* Title - Name Badge - Clickable */}
-      <Badge
-        variant="secondary"
-        className={`text-xs px-3 py-1 font-mono uppercase tracking-wide bg-neon-lilac/10 text-neon-lilac border border-neon-lilac/40 rounded-pill ${
-          effectiveDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-neon-lilac/20 transition-colors'
-        }`}
-        onClick={effectiveDisabled ? undefined : onSelect}
-      >
-        {config.shortTitle} - {config.name}
-      </Badge>
+      {/* avatar disc */}
+      <div className={`relative mb-3.5 h-[78px] w-[78px] overflow-hidden rounded-full ${config.ringShadow} shadow-panel`}>
+        {config.avatar ? (
+          <img
+            src={config.avatar}
+            alt={`${config.title} avatar`}
+            className="absolute left-1/2 top-0 h-[130px] w-auto max-w-none -translate-x-1/2 object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-neon-purple to-neon-blue">
+            <IconComponent className="h-8 w-8 text-white" />
+          </div>
+        )}
+      </div>
 
-      {/* Meeting-relevance Tier 0 (PR-1): sit-out notice — empty eligible pool */}
-      {sitOut && (
-        <span data-testid={`sit-out-${executive.role}`} className="text-xs text-text-muted max-w-36 text-center">
-          Nothing needs their call this week
-        </span>
+      <div className="text-center text-[14.5px] font-semibold text-text-primary">{config.name}</div>
+      <div className={`mt-1 font-mono text-[9px] uppercase tracking-[0.18em] ${config.roleText}`}>
+        {config.title}
+      </div>
+      {weeklySalary !== undefined && (
+        <div className="mt-1.5 font-mono text-[10.5px] text-money">
+          ${weeklySalary.toLocaleString()}/wk
+        </div>
       )}
+
+      {/* vertical faders */}
+      <div className="my-4 flex gap-6">
+        <VerticalFader
+          value={loyaltyValue}
+          label="loy"
+          fillClass="bg-gradient-to-b from-neon-lilac to-neon-purple shadow-[0_0_10px_rgba(160,90,240,0.7)]"
+          valueClass="text-neon-lilac"
+        />
+        <VerticalFader
+          value={moodValue}
+          label="mood"
+          fillClass="bg-gradient-to-b from-neon-green to-positive shadow-[0_0_10px_rgba(55,224,176,0.6)]"
+          valueClass="text-positive"
+        />
+      </div>
+
+      {/* Exec-meetings-revival PR-9: mood-modifier chip (non-neutral only) */}
+      {moodBandChip && (
+        <Badge variant="secondary" className={`mb-2 px-2 py-0.5 text-[10px] ${moodBandChip.className}`}>
+          {moodBandChip.label}
+        </Badge>
+      )}
+
+      <div className="flex-1" />
+
+      {/* status readout */}
+      <div className={`flex min-h-[44px] w-full items-center justify-center rounded-lg border px-2.5 py-1.5 text-center text-[11px] leading-snug ${status.className}`}>
+        {status.text}
+      </div>
+
+      {/* Meeting-relevance Tier 0 (PR-1): sit-out testid anchor (copy lives in the
+          status readout above so the strip stays one coherent console element) */}
+      {sitOut && <span data-testid={`sit-out-${executive.role}`} className="sr-only">sitting out</span>}
     </div>
   );
-
-  // A&R Status content
-  return avatarColumn;
 }

--- a/client/src/components/executive-meetings/ExecutiveMeetings.tsx
+++ b/client/src/components/executive-meetings/ExecutiveMeetings.tsx
@@ -3,17 +3,32 @@ import { useMachine } from '@xstate/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { executiveMeetingMachine } from '../../machines/executiveMeetingMachine';
 import { makeCachedFetchExecutives } from '../../hooks/useExecutives';
-import { ExecutiveCard } from './ExecutiveCard';
+import { ExecutiveCard, roleConfig } from './ExecutiveCard';
 import { MeetingSelector } from './MeetingSelector';
 import { DialogueInterface } from './DialogueInterface';
 import { AutoSelectReviewPanel } from './AutoSelectReviewPanel';
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Button } from '../ui/button';
-import { Badge } from '../ui/badge';
-import { ArrowLeft, Loader2, Zap } from 'lucide-react';
+import { ArrowLeft, Loader2, Check, Wand2 } from 'lucide-react';
 import { fetchRoleMeetings, fetchMeetingDialogue, fetchAllRoles } from '../../services/executiveService';
 import { useGameStore } from '../../store/gameStore';
 import { useArtists } from '../../hooks/useArtists';
+import type { Executive } from '../../../../shared/types/gameTypes';
+
+/**
+ * Exec Console redesign (2026-07-11, "Exec Meetings — Console" design direction):
+ * the meeting flow renders as a mixing console. Screen layout:
+ *
+ * - GRID (machine idle): the console deck — CEO master strip + a channel strip
+ *   per executive (loyalty/mood faders, live status readout, queued chips).
+ * - SOLO (selectingMeeting → inDialogue): a mini channel rail on the left keeps
+ *   every exec one click away (SELECT_EXECUTIVE is legal from solo states); the
+ *   solo panel walks brief → (artist) → dialogue takes.
+ * - AUTO review (reviewingAutoSelections): the "proposed patch list" modal
+ *   overlay (AutoSelectReviewPanel) over whatever screen is behind it.
+ *
+ * ALL machine wiring, prefetches, and slot/CC sync are unchanged from the
+ * pre-redesign component — this is a presentation restructure only.
+ */
 
 interface ExecutiveMeetingsProps {
   gameId: string;
@@ -44,6 +59,27 @@ interface ExecutiveMeetingsProps {
       effects_delayed: Record<string, number>;
     }>;
   }) => void;
+}
+
+function execConfig(role: string) {
+  return (
+    roleConfig[role as keyof typeof roleConfig] ?? {
+      shortTitle: role.replace(/_/g, ' ').toUpperCase(),
+      name: role.replace(/_/g, ' '),
+      title: role.replace(/_/g, ' '),
+      avatar: undefined,
+      roleText: 'text-text-muted',
+    }
+  );
+}
+
+function SoloLoader({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center p-12">
+      <Loader2 className="mb-2 h-6 w-6 animate-spin text-neon-lilac" />
+      <span className="text-text-body">{label}</span>
+    </div>
+  );
 }
 
 export function ExecutiveMeetings({
@@ -295,287 +331,287 @@ export function ExecutiveMeetings({
     }
   }, [context.impactPreview, onImpactPreviewUpdate]);
 
-  // Render middle column content based on state
-  const renderMiddleColumn = () => {
-    // Meeting-relevance PR-3 (AUTO Option A): review AUTO's proposed picks before
-    // they commit. Execs that sat out never made it into autoOptions, so they
-    // never appear here.
-    if (state.matches('reviewingAutoSelections')) {
+  // ── screen selection ───────────────────────────────────────────────────────
+  const isSoloScreen =
+    (state.matches('selectingMeeting') ||
+      state.matches('loadingMeetings') ||
+      state.matches('loadingDialogue') ||
+      state.matches('inDialogue') ||
+      state.matches('processingChoice')) &&
+    !!context.selectedExecutive;
+
+  const canOpenExecutive = (executive: Executive) => {
+    const isArBusy = executive.role === 'head_ar' && !!arOfficeStatus?.arOfficeSlotUsed;
+    return (
+      hasAvailableSlots &&
+      !isExecutiveUsed(executive.role) &&
+      !sitOutRoles.has(executive.role) &&
+      !isArBusy
+    );
+  };
+
+  const orderedExecutives = useMemo(() => {
+    const ceo = executives.find(exec => exec.role === 'ceo');
+    const rest = executives.filter(exec => exec.role !== 'ceo');
+    return { ceo, rest, all: ceo ? [ceo, ...rest] : rest };
+  }, [executives]);
+
+  // ── solo view (brief / artist / dialogue) ──────────────────────────────────
+  const renderSoloContent = () => {
+    if (state.matches('loadingMeetings')) return <SoloLoader label="Loading meetings..." />;
+    if (state.matches('loadingDialogue')) return <SoloLoader label="Loading dialogue..." />;
+    if (state.matches('processingChoice')) return <SoloLoader label="Committing your call..." />;
+
+    if (state.matches('selectingMeeting')) {
       return (
+        <MeetingSelector
+          meetings={context.availableMeetings}
+          signedArtists={artists.filter(a => a.signed) as any}
+          onSelectMeeting={(meeting, selectedArtistId) => send({ type: 'SELECT_MEETING', meeting, selectedArtistId })}
+          onBack={() => send({ type: 'BACK_TO_EXECUTIVES' })}
+        />
+      );
+    }
+
+    if (state.matches('inDialogue') && context.currentDialogue) {
+      return (
+        <DialogueInterface
+          dialogue={context.currentDialogue}
+          onSelectChoice={(choice) => send({ type: 'SELECT_CHOICE', choice })}
+          onBack={() => send({ type: 'BACK_TO_MEETINGS' })}
+          availableCreativeCapital={creativeCapital}
+          targetScope={context.selectedMeeting?.target_scope}
+          selectedArtistName={
+            context.selectedArtistId
+              ? artists.find(a => a.id === context.selectedArtistId)?.name
+              : undefined
+          }
+        />
+      );
+    }
+
+    return null;
+  };
+
+  const renderSoloView = () => {
+    const activeExec = context.selectedExecutive!;
+    const config = execConfig(activeExec.role);
+    const stepLabel = state.matches('inDialogue') || state.matches('loadingDialogue')
+      ? 'step 2 · response'
+      : state.matches('processingChoice')
+        ? 'committing'
+        : 'step 1 · brief';
+
+    return (
+      <div className="flex gap-6" data-screen-label="Solo channel">
+        {/* mini channel rail */}
+        <div className="flex w-[86px] flex-shrink-0 flex-col gap-3">
+          {orderedExecutives.all.map((executive) => {
+            const railConfig = execConfig(executive.role);
+            const isActive = activeExec.role === executive.role;
+            const clickable = !isActive && canOpenExecutive(executive);
+            const queued = isExecutiveUsed(executive.role);
+            return (
+              <div
+                key={executive.role}
+                title={`${railConfig.shortTitle} — ${railConfig.name}`}
+                data-testid={`rail-${executive.role}`}
+                onClick={clickable ? () => send({ type: 'SELECT_EXECUTIVE', executive }) : undefined}
+                className={`relative flex h-[86px] flex-col items-center justify-center gap-1.5 rounded-card border bg-gradient-to-b from-surface-panel/85 to-surface-inner/90 transition-colors ${
+                  isActive
+                    ? 'border-neon-lilac/50 opacity-100'
+                    : clickable
+                      ? 'cursor-pointer border-white/10 opacity-80 hover:border-white/25'
+                      : 'border-white/10 opacity-40'
+                }`}
+              >
+                <div className="h-10 w-10 overflow-hidden rounded-full shadow-panel">
+                  {railConfig.avatar ? (
+                    <img src={railConfig.avatar} alt="" className="h-full w-full object-cover object-top" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-money to-action-pink font-display text-[11px] text-white">
+                      {railConfig.shortTitle}
+                    </div>
+                  )}
+                </div>
+                <span className="font-mono text-[8px] uppercase tracking-[0.14em] text-text-muted">
+                  {executive.role === 'ceo' ? 'mstr' : 'ch'}
+                </span>
+                {queued && (
+                  <span className="absolute right-1.5 top-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-neon-green/50 bg-neon-green/20">
+                    <Check className="h-2 w-2 text-neon-green" />
+                  </span>
+                )}
+                {isActive && (
+                  <span className="absolute -left-px bottom-4 top-4 w-[3px] rounded-full bg-gradient-to-b from-neon-pink via-neon-purple to-neon-cyan shadow-[0_0_10px_rgba(160,90,240,0.7)]" />
+                )}
+              </div>
+            );
+          })}
+          <Button
+            variant="outline"
+            aria-label="Back to executives"
+            onClick={() => send({ type: 'BACK_TO_EXECUTIVES' })}
+            className="h-[52px] rounded-card border border-white/10 bg-white/[0.02] text-text-muted hover:border-white/25 hover:text-text-primary"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* solo channel content */}
+        <div className="chromatic-hairline hud-ticks relative flex-1 overflow-hidden rounded-card border border-white/10 bg-gradient-to-b from-surface-panel/85 to-surface-inner/95 p-6 shadow-panel md:p-8">
+          {/* solo header */}
+          <div className="mb-6 flex items-center gap-4">
+            <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-full shadow-panel">
+              {config.avatar ? (
+                <img src={config.avatar} alt={`${config.title} avatar`} className="h-full w-full object-cover object-top" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-money to-action-pink font-display text-base text-white">
+                  {config.shortTitle}
+                </div>
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className="text-lg font-semibold text-text-primary">{config.name}</span>
+                <span className={`rounded-pill border border-white/10 bg-white/5 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.2em] ${config.roleText}`}>
+                  {config.title}
+                </span>
+                <span className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.2em] text-neon-pink">
+                  <span className="h-1.5 w-1.5 rounded-full bg-neon-magenta shadow-[0_0_8px_1px_rgba(255,61,110,0.8)]" />
+                  solo
+                </span>
+              </div>
+            </div>
+            {state.matches('inDialogue') && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => send({ type: 'BACK_TO_MEETINGS' })}
+                aria-label="Back to meeting list"
+                className="text-text-muted hover:text-text-primary"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            )}
+            <div className="text-right font-mono text-[10px] uppercase tracking-[0.2em] text-text-muted">
+              {stepLabel}
+            </div>
+          </div>
+
+          {renderSoloContent()}
+        </div>
+      </div>
+    );
+  };
+
+  // ── grid view (console deck) ───────────────────────────────────────────────
+  const renderGridView = () => (
+    <div data-screen-label="Exec selection console">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div className="font-mono text-[10px] uppercase tracking-[0.28em] text-text-muted">
+          executive channels · patch a meeting into a focus slot
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted/70">
+            <span className="h-1.5 w-1.5 rounded-full bg-neon-green shadow-[0_0_8px_1px_rgba(87,255,143,0.8)]" />
+            console live
+          </div>
+          {hasAvailableSlots && !isAutoFlowActive && (
+            <Button
+              size="sm"
+              onClick={() => send({ type: 'AUTO_SELECT' })}
+              disabled={!hasAvailableSlots || executives.length === 0}
+              className="gap-1.5 rounded-button bg-gradient-to-br from-action-pink to-action-purple font-semibold text-white shadow-action hover:opacity-90"
+            >
+              <Wand2 className="h-3.5 w-3.5" />
+              AUTO
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {executivesLoading && executives.length === 0 ? (
+        <SoloLoader label="Loading executives..." />
+      ) : (
+        <div className="flex flex-col items-stretch gap-4 lg:flex-row">
+          {orderedExecutives.ceo && (
+            <>
+              <ExecutiveCard
+                key="ceo"
+                executive={orderedExecutives.ceo}
+                disabled={!hasAvailableSlots}
+                noSlots={!hasAvailableSlots}
+                queued={isExecutiveUsed('ceo')}
+                sitOut={sitOutRoles.has('ceo')}
+                hasReactiveMeeting={reactiveRoles.has('ceo')}
+                onSelect={() => send({ type: 'SELECT_EXECUTIVE', executive: orderedExecutives.ceo! })}
+                weeklySalary={roleSalaries['ceo']}
+                arOfficeStatus={arOfficeStatus}
+              />
+              <div className="hidden w-px flex-shrink-0 bg-white/[0.07] lg:block" />
+            </>
+          )}
+          {orderedExecutives.rest.map((executive, index) => (
+            <ExecutiveCard
+              key={executive.role}
+              executive={executive}
+              channelNumber={index + 1}
+              disabled={!hasAvailableSlots}
+              noSlots={!hasAvailableSlots}
+              queued={isExecutiveUsed(executive.role)}
+              sitOut={sitOutRoles.has(executive.role)}
+              hasReactiveMeeting={reactiveRoles.has(executive.role)}
+              onSelect={() => send({ type: 'SELECT_EXECUTIVE', executive })}
+              weeklySalary={roleSalaries[executive.role]}
+              arOfficeStatus={arOfficeStatus}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  if (executivesError && executives.length === 0) {
+    return (
+      <div className="text-center p-8">
+        <div className="p-3 bg-negative/10 border border-negative/30 rounded-card mb-4">
+          <p className="text-sm text-negative">Failed to load executives: {executivesError}</p>
+          <p className="text-xs text-text-muted mt-1">Please refresh to try again</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      {isSoloScreen ? renderSoloView() : renderGridView()}
+
+      {/* AUTO computing overlay */}
+      {state.matches('autoSelecting') && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-surface-app/70 backdrop-blur-lg">
+          <Loader2 className="mb-2 h-6 w-6 animate-spin text-neon-cyan" />
+          <span className="text-text-body">AUTO is choosing meetings...</span>
+        </div>
+      )}
+
+      {/* Meeting-relevance PR-3 (AUTO Option A): review AUTO's proposed picks
+          before they commit. Execs that sat out never made it into autoOptions,
+          so they never appear here. Renders as the console's modal overlay. */}
+      {state.matches('reviewingAutoSelections') && (
         <AutoSelectReviewPanel
           options={context.autoOptions}
           onConfirmAll={() => send({ type: 'CONFIRM_AUTO_SELECT' })}
           onCancel={() => send({ type: 'CANCEL_AUTO_SELECT' })}
           onOverrideRow={(executive) => send({ type: 'OVERRIDE_AUTO_ROW', executive })}
         />
-      );
-    }
+      )}
 
-    if (state.matches('autoSelecting')) {
-      return (
-        <div className="flex flex-col items-center justify-center p-8">
-          <Loader2 className="h-6 w-6 animate-spin text-neon-cyan mb-2" />
-          <span className="text-text-body">AUTO is choosing meetings...</span>
+      {context.error && (
+        <div className="mt-4 p-3 bg-negative/10 border border-negative/30 rounded-card">
+          <p className="text-sm text-negative">{context.error}</p>
         </div>
-      );
-    }
-
-    if (state.matches('loadingMeetings')) {
-      return (
-        <div className="flex flex-col items-center justify-center p-8">
-          <Loader2 className="h-6 w-6 animate-spin text-neon-lilac mb-2" />
-          <span className="text-text-body">Loading meetings...</span>
-        </div>
-      );
-    }
-
-    if (state.matches('selectingMeeting')) {
-      const roleConfig = {
-        ceo: { shortTitle: 'CEO', name: 'You' },
-        head_ar: { shortTitle: 'A&R', name: 'Marcus Rodriguez' },
-        cco: { shortTitle: 'CCO', name: 'Dante Washington' },
-        cmo: { shortTitle: 'CMO', name: 'Samara Chen' },
-        head_distribution: { shortTitle: 'Distro', name: 'Patricia Williams' },
-      } as const;
-
-      const config = context.selectedExecutive?.role
-        ? roleConfig[context.selectedExecutive.role as keyof typeof roleConfig]
-        : null;
-
-      return (
-        <div>
-          <div className="flex items-center gap-2 mb-4">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => send({ type: 'BACK_TO_EXECUTIVES' })}
-              aria-label="Back to executive list"
-            >
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-            {config && (
-              <Badge
-                variant="secondary"
-                className="text-xs px-3 py-1 font-mono uppercase tracking-wide bg-neon-lilac/10 text-neon-lilac border border-neon-lilac/40 rounded-pill"
-              >
-                {config.shortTitle} - {config.name}
-              </Badge>
-            )}
-          </div>
-          <MeetingSelector
-            meetings={context.availableMeetings}
-            signedArtists={artists.filter(a => a.signed) as any}
-            onSelectMeeting={(meeting, selectedArtistId) => send({ type: 'SELECT_MEETING', meeting, selectedArtistId })}
-            onBack={() => send({ type: 'BACK_TO_EXECUTIVES' })}
-          />
-        </div>
-      );
-    }
-
-    if (state.matches('loadingDialogue')) {
-      return (
-        <div className="flex flex-col items-center justify-center p-8">
-          <Loader2 className="h-6 w-6 animate-spin text-neon-lilac mb-2" />
-          <span className="text-text-body">Loading dialogue...</span>
-        </div>
-      );
-    }
-
-    if (state.matches('inDialogue')) {
-      const roleConfig = {
-        ceo: { shortTitle: 'CEO', name: 'You' },
-        head_ar: { shortTitle: 'A&R', name: 'Marcus Rodriguez' },
-        cco: { shortTitle: 'CCO', name: 'Dante Washington' },
-        cmo: { shortTitle: 'CMO', name: 'Samara Chen' },
-        head_distribution: { shortTitle: 'Distro', name: 'Patricia Williams' },
-      } as const;
-
-      const config = context.selectedExecutive?.role
-        ? roleConfig[context.selectedExecutive.role as keyof typeof roleConfig]
-        : null;
-
-      return (
-        <div>
-          <div className="flex items-center gap-2 mb-4">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => send({ type: 'BACK_TO_MEETINGS' })}
-              aria-label="Back to meeting list"
-            >
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-            {config && (
-              <Badge
-                variant="secondary"
-                className="text-xs px-3 py-1 font-mono uppercase tracking-wide bg-neon-lilac/10 text-neon-lilac border border-neon-lilac/40 rounded-pill"
-              >
-                {config.shortTitle} - {config.name}
-              </Badge>
-            )}
-          </div>
-          {context.currentDialogue && (
-            <DialogueInterface
-              dialogue={context.currentDialogue}
-              onSelectChoice={(choice) => send({ type: 'SELECT_CHOICE', choice })}
-              onBack={() => send({ type: 'BACK_TO_MEETINGS' })}
-              availableCreativeCapital={creativeCapital}
-              targetScope={context.selectedMeeting?.target_scope}
-              selectedArtistName={
-                context.selectedArtistId
-                  ? artists.find(a => a.id === context.selectedArtistId)?.name
-                  : undefined
-              }
-            />
-          )}
-        </div>
-      );
-    }
-
-    if (state.matches('processingChoice')) {
-      return (
-        <div className="flex flex-col items-center justify-center p-8">
-          <Loader2 className="h-6 w-6 animate-spin text-neon-lilac mb-2" />
-          <span className="text-text-body">Processing your choice...</span>
-        </div>
-      );
-    }
-
-    if (state.matches('complete')) {
-      return (
-        <div className="flex flex-col items-center justify-center p-8">
-          <div className="text-positive font-medium">Meeting completed!</div>
-          <p className="text-sm text-text-muted mt-1">Returning to executives...</p>
-        </div>
-      );
-    }
-
-    // Default idle state - show loading if executives haven't loaded yet
-    if (executivesLoading && executives.length === 0) {
-      return (
-        <div className="flex flex-col items-center justify-center p-8">
-          <Loader2 className="h-6 w-6 animate-spin text-neon-lilac mb-2" />
-          <span className="text-text-body">Loading executives...</span>
-        </div>
-      );
-    }
-
-    return (
-      <div className="flex items-center justify-center text-text-muted">
-        Select an executive
-      </div>
-    );
-  };
-
-  return (
-    <Card className="w-full bg-transparent border-none">
-      <CardHeader>
-        <CardTitle className="flex items-center justify-between text-text-primary font-display text-lg">
-          Executive Meetings
-          <div className="flex items-center gap-3">
-            {hasAvailableSlots && !isAutoFlowActive && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => send({ type: 'AUTO_SELECT' })}
-                disabled={!hasAvailableSlots || executives.length === 0}
-                className="flex items-center gap-1.5 rounded-button border border-neon-cyan/35 bg-neon-cyan/[0.06] text-neon-cyan hover:bg-neon-cyan/10 hover:text-neon-cyan"
-              >
-                <Zap className="w-3.5 h-3.5" />
-                AUTO
-              </Button>
-            )}
-          </div>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="px-0">
-        {executivesError ? (
-          <div className="text-center p-8">
-            <div className="p-3 bg-negative/10 border border-negative/30 rounded-card mb-4">
-              <p className="text-sm text-negative">Failed to load executives: {executivesError}</p>
-              <p className="text-xs text-text-muted mt-1">Please refresh to try again</p>
-            </div>
-          </div>
-        ) : (
-          (() => {
-            const nonCeoExecutives = executives.filter(exec => exec.role !== 'ceo');
-            const ceoExecutive = executives.find(exec => exec.role === 'ceo');
-
-            return (
-              <div className="grid grid-cols-[auto_1fr_auto] gap-12 w-full px-6">
-              {/* Left Column - First 2 Executives */}
-              <div className="space-y-6">
-                {nonCeoExecutives.slice(0, 2).map((executive) => (
-                  <ExecutiveCard
-                    key={executive.role}
-                    executive={executive}
-                    disabled={!hasAvailableSlots || isExecutiveUsed(executive.role)}
-                    sitOut={sitOutRoles.has(executive.role)}
-                    hasReactiveMeeting={reactiveRoles.has(executive.role)}
-                    onSelect={() => send({ type: 'SELECT_EXECUTIVE', executive })}
-                    weeklySalary={roleSalaries[executive.role]}
-                    arOfficeStatus={arOfficeStatus}
-                    flipAvatar={true}
-                    alignContent="left"
-                    isSelected={context.selectedExecutive?.role === executive.role}
-                    compactBadges={!!context.selectedExecutive}
-                  />
-                ))}
-              </div>
-
-              {/* Middle Column - Dynamic content based on state */}
-              <div className="flex items-start justify-center px-8">
-                {renderMiddleColumn()}
-              </div>
-
-              {/* Right Column - Next 2 Executives */}
-              <div className="space-y-6">
-                {nonCeoExecutives.slice(2, 4).map((executive) => (
-                  <ExecutiveCard
-                    key={executive.role}
-                    executive={executive}
-                    disabled={!hasAvailableSlots || isExecutiveUsed(executive.role)}
-                    sitOut={sitOutRoles.has(executive.role)}
-                    hasReactiveMeeting={reactiveRoles.has(executive.role)}
-                    onSelect={() => send({ type: 'SELECT_EXECUTIVE', executive })}
-                    weeklySalary={roleSalaries[executive.role]}
-                    arOfficeStatus={arOfficeStatus}
-                    badgesOnLeft={true}
-                    alignContent="right"
-                    isSelected={context.selectedExecutive?.role === executive.role}
-                    compactBadges={!!context.selectedExecutive}
-                  />
-                ))}
-              </div>
-
-              {/* Bottom Row - CEO Badge Only */}
-              <div className="col-span-3 flex items-center justify-center mt-8">
-                {ceoExecutive && (
-                  <ExecutiveCard
-                    key="ceo"
-                    executive={ceoExecutive}
-                    disabled={!hasAvailableSlots || isExecutiveUsed(ceoExecutive.role)}
-                    sitOut={sitOutRoles.has(ceoExecutive.role)}
-                    hasReactiveMeeting={reactiveRoles.has(ceoExecutive.role)}
-                    onSelect={() => send({ type: 'SELECT_EXECUTIVE', executive: ceoExecutive })}
-                    weeklySalary={roleSalaries['ceo']}
-                    arOfficeStatus={arOfficeStatus}
-                    isSelected={context.selectedExecutive?.role === ceoExecutive.role}
-                    compactBadges={!!context.selectedExecutive}
-                  />
-                )}
-              </div>
-            </div>
-          );
-        })())
-        }
-
-        {context.error && (
-          <div className="mt-4 p-3 bg-negative/10 border border-negative/30 rounded-card">
-            <p className="text-sm text-negative">{context.error}</p>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+      )}
+    </div>
   );
 }

--- a/client/src/components/executive-meetings/MeetingSelector.tsx
+++ b/client/src/components/executive-meetings/MeetingSelector.tsx
@@ -1,68 +1,29 @@
 import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
-import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '../ui/carousel';
-import { Clock, DollarSign, Zap, Globe, Star, User, Sparkles } from 'lucide-react';
+import { Globe, Star, User, Sparkles, ChevronLeft, ChevronRight } from 'lucide-react';
 import type { RoleMeeting, GameArtist } from '../../../../shared/types/gameTypes';
-import { ArtistSelector } from './ArtistSelector';
 import { formatWhyNow } from '../../utils/reactiveContextCopy';
+
+/**
+ * Exec Console redesign (2026-07-11): the meeting step renders as the solo
+ * channel's BRIEF — "this week's meeting" label, meeting title, the exec's
+ * prompt as a quote panel, and a Start Meeting CTA. `user_selected` meetings
+ * route through the console ARTIST PICKER step (cards with mood/energy/
+ * popularity meters — picking an artist starts the meeting immediately).
+ *
+ * Behavior contracts preserved from the pre-redesign selector:
+ * - empty eligible pool → calm sit-out state (`meeting-pool-empty` testid + copy)
+ * - `user_selected` meetings hidden when no artists are signed (FR-12)
+ * - Tier 2 "why now" line renders when the meeting carries `reactiveContext`
+ * - multiple meetings in the pool stay reachable (pager instead of carousel)
+ */
 
 interface MeetingSelectorProps {
   meetings: RoleMeeting[];
   signedArtists: GameArtist[];
   onSelectMeeting: (meeting: RoleMeeting, selectedArtistId?: string) => void;
   onBack: () => void;
-}
-
-function ChoicePreview({ choices }: { choices: RoleMeeting['choices'] }) {
-  const totalChoices = choices.length;
-  const hasImmediateEffects = choices.some(choice =>
-    Object.keys(choice.effects_immediate).length > 0
-  );
-  const hasDelayedEffects = choices.some(choice =>
-    Object.keys(choice.effects_delayed).length > 0
-  );
-
-  return (
-    <div className="flex items-center gap-2 text-sm text-text-muted">
-      <span>{totalChoices} choices</span>
-      {hasImmediateEffects && (
-        <Badge variant="outline" className="text-xs font-mono rounded-pill border-neon-lilac/40 bg-neon-lilac/10 text-neon-lilac">
-          <Zap className="h-3 w-3 mr-1" />
-          Immediate
-        </Badge>
-      )}
-      {hasDelayedEffects && (
-        <Badge variant="outline" className="text-xs font-mono rounded-pill border-neon-lilac/40 bg-neon-lilac/10 text-neon-lilac">
-          <Clock className="h-3 w-3 mr-1" />
-          Delayed
-        </Badge>
-      )}
-    </div>
-  );
-}
-
-function MeetingCostEstimate({ choices }: { choices: RoleMeeting['choices'] }) {
-  const costs = choices
-    .map(choice => choice.effects_immediate.money || 0)
-    .filter(cost => cost < 0);
-
-  if (costs.length === 0) return null;
-
-  const minCost = Math.min(...costs);
-  const maxCost = Math.max(...costs);
-
-  return (
-    <div className="flex items-center gap-1 text-sm text-money font-mono">
-      <DollarSign className="h-3 w-3" />
-      {minCost === maxCost ? (
-        <span>Cost: ${Math.abs(minCost).toLocaleString()}</span>
-      ) : (
-        <span>Cost: ${Math.abs(maxCost).toLocaleString()} - ${Math.abs(minCost).toLocaleString()}</span>
-      )}
-    </div>
-  );
 }
 
 function ScopeBadge({ scope }: { scope: string }) {
@@ -107,17 +68,29 @@ function WhyNowLine({ meeting }: { meeting: RoleMeeting }) {
   return (
     <div
       data-testid="why-now-line"
-      className="flex items-center gap-1.5 text-xs font-mono text-neon-cyan"
+      className="inline-flex items-center gap-2 rounded-pill border border-neon-cyan/30 bg-neon-cyan/10 px-3 py-1.5 text-[11.5px] text-neon-cyan"
     >
-      <Sparkles className="h-3 w-3 shrink-0" />
-      <span>{formatWhyNow(meeting.reactiveContext)}</span>
+      <Sparkles className="h-3 w-3 shrink-0 animate-pulse" />
+      <span className="font-mono">{formatWhyNow(meeting.reactiveContext)}</span>
     </div>
   );
 }
 
+function meetingTitle(meeting: RoleMeeting): string {
+  return meeting.name || meeting.id.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+}
+
+function StatChip({ label, value, className }: { label: string; value: number; className: string }) {
+  return (
+    <span className={`font-mono text-[10.5px] ${className}`}>
+      {label} {Math.max(0, Math.min(100, value))}%
+    </span>
+  );
+}
+
 export function MeetingSelector({ meetings, signedArtists, onSelectMeeting, onBack }: MeetingSelectorProps) {
-  const [selectedMeetingIndex, setSelectedMeetingIndex] = useState<number | null>(null);
-  const [selectedArtistId, setSelectedArtistId] = useState<string | null>(null);
+  const [meetingIndex, setMeetingIndex] = useState(0);
+  const [pickingArtistFor, setPickingArtistFor] = useState<RoleMeeting | null>(null);
 
   // Filter out user_selected meetings if no artists are signed (FR-12)
   const filteredMeetings = signedArtists.length === 0
@@ -141,128 +114,123 @@ export function MeetingSelector({ meetings, signedArtists, onSelectMeeting, onBa
     );
   }
 
-  const handleSelectMeeting = (meeting: RoleMeeting, index: number) => {
-    // If user_selected and no artist selected yet, show artist selector
-    if (meeting.target_scope === 'user_selected' && signedArtists.length > 0) {
-      setSelectedMeetingIndex(index);
-      setSelectedArtistId(null);
-    } else {
-      // For global or predetermined meetings, proceed immediately
-      onSelectMeeting(meeting);
-    }
-  };
-
-  const handleArtistSelected = (artistId: string) => {
-    setSelectedArtistId(artistId);
-  };
-
-  const handleConfirmMeeting = () => {
-    if (selectedMeetingIndex !== null && selectedArtistId) {
-      const meeting = meetings[selectedMeetingIndex];
-      onSelectMeeting(meeting, selectedArtistId);
-    }
-  };
-
-  const handleBackFromArtistSelection = () => {
-    setSelectedMeetingIndex(null);
-    setSelectedArtistId(null);
-  };
-
-  // If showing artist selection
-  if (selectedMeetingIndex !== null) {
-    const meeting = filteredMeetings[selectedMeetingIndex];
-    const selectedArtist = signedArtists.find(a => a.id === selectedArtistId);
-    const displayPrompt = selectedArtist
-      ? meeting.prompt.replace('{artistName}', selectedArtist.name)
-      : meeting.prompt;
-
+  // ── step: artist picker ──────────────────────────────────────────────────
+  if (pickingArtistFor) {
+    const meeting = pickingArtistFor;
     return (
-      <div className="w-full max-w-md mx-auto space-y-4">
-        <Card className="glass-panel chromatic-hairline border-0">
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-lg text-text-primary">{meeting.name || meeting.id.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</CardTitle>
-              <ScopeBadge scope={meeting.target_scope} />
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <WhyNowLine meeting={meeting} />
-            <ArtistSelector
-              artists={signedArtists}
-              selectedArtistId={selectedArtistId}
-              onSelectArtist={handleArtistSelected}
-              prompt={meeting.prompt_before_selection}
-            />
-
-            {selectedArtistId && (
-              <div className="p-3 bg-neon-lilac/10 border border-neon-lilac/30 rounded-card">
-                <p className="text-sm text-text-body italic">
-                  "{displayPrompt}"
-                </p>
+      <div data-screen-label="Artist picker">
+        <h2 className="m-0 mb-1.5 text-[22px] font-semibold text-text-primary">Which artist is this about?</h2>
+        <div className="mb-3 text-[13px] text-text-muted">{meetingTitle(meeting)}</div>
+        <div className="mb-4 empty:hidden">
+          <WhyNowLine meeting={meeting} />
+        </div>
+        {meeting.prompt_before_selection && (
+          <p className="mb-6 text-sm italic text-text-body">"{meeting.prompt_before_selection}"</p>
+        )}
+        <div className="flex flex-wrap gap-4">
+          {signedArtists.map((artist) => (
+            <div
+              key={artist.id}
+              data-testid={`console-artist-pick-${artist.id}`}
+              onClick={() => onSelectMeeting(meeting, artist.id)}
+              className="chromatic-hairline relative w-full max-w-[250px] cursor-pointer rounded-card border border-white/10 bg-surface-inner/50 px-5 py-5 text-center transition-all duration-200 hover:-translate-y-1 hover:border-neon-lilac/50"
+            >
+              <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-card bg-gradient-to-br from-neon-purple to-neon-blue font-display text-xl text-white shadow-panel">
+                {artist.name
+                  .split(/\s+/)
+                  .map(part => part[0])
+                  .filter(Boolean)
+                  .slice(0, 2)
+                  .join('')
+                  .toLowerCase()}
               </div>
-            )}
-
-            <div className="flex gap-2">
-              <Button
-                onClick={handleBackFromArtistSelection}
-                variant="outline"
-                className="flex-1 rounded-button border border-white/10 bg-white/[0.02] text-text-body hover:bg-white/5"
-              >
-                Back
-              </Button>
-              <Button
-                onClick={handleConfirmMeeting}
-                disabled={!selectedArtistId}
-                className="flex-1 rounded-button bg-gradient-to-br from-action-pink to-action-purple text-white shadow-action hover:opacity-90"
-              >
-                Start Meeting
-              </Button>
+              <div className="text-[14.5px] font-semibold text-text-primary">{artist.name}</div>
+              {artist.archetype && (
+                <div className="mt-0.5 text-[11.5px] text-neon-lilac">{artist.archetype}</div>
+              )}
+              <div className="mt-2.5 flex justify-center gap-3">
+                <StatChip label="M" value={artist.mood ?? 50} className="text-warning" />
+                <StatChip label="E" value={artist.energy ?? 50} className="text-positive" />
+                <StatChip label="P" value={artist.popularity ?? 0} className="text-neon-pink" />
+              </div>
             </div>
-          </CardContent>
-        </Card>
+          ))}
+        </div>
+        <Button
+          onClick={() => setPickingArtistFor(null)}
+          variant="outline"
+          className="mt-6 rounded-button border border-white/10 bg-white/[0.02] text-text-body hover:bg-white/5"
+        >
+          Back
+        </Button>
       </div>
     );
   }
 
-  // Default carousel view
+  // ── step: meeting brief ──────────────────────────────────────────────────
+  const safeIndex = Math.min(meetingIndex, filteredMeetings.length - 1);
+  const meeting = filteredMeetings[safeIndex];
+  const isUserSelected = meeting.target_scope === 'user_selected' && signedArtists.length > 0;
+  const briefPrompt = meeting.target_scope === 'user_selected' && meeting.prompt_before_selection
+    ? meeting.prompt_before_selection
+    : meeting.prompt;
+
+  const handleStart = () => {
+    if (isUserSelected) {
+      setPickingArtistFor(meeting);
+    } else {
+      onSelectMeeting(meeting);
+    }
+  };
+
   return (
-    <Carousel
-      className="w-full max-w-md mx-auto"
-      opts={{
-        loop: true,
-      }}
-    >
-      <CarouselContent>
-        {filteredMeetings.map((meeting, index) => (
-          <CarouselItem key={meeting.id}>
-            <Card className="glass-panel chromatic-hairline border-0 transition-all duration-200 hover:shadow-glow-lilac">
-              <CardHeader className="pb-3">
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-lg text-text-primary">{meeting.name || meeting.id.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</CardTitle>
-                  <ScopeBadge scope={meeting.target_scope} />
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                <WhyNowLine meeting={meeting} />
-                <p className="text-sm text-text-body italic">
-                  "{meeting.target_scope === 'user_selected' && meeting.prompt_before_selection
-                    ? meeting.prompt_before_selection
-                    : meeting.prompt}"
-                </p>
-                <Button
-                  onClick={() => handleSelectMeeting(meeting, index)}
-                  size="sm"
-                  className="w-full rounded-button bg-gradient-to-br from-action-pink to-action-purple text-white shadow-action hover:opacity-90"
-                >
-                  {meeting.target_scope === 'user_selected' ? 'Select Artist' : 'Start Meeting'}
-                </Button>
-              </CardContent>
-            </Card>
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-      <CarouselPrevious className="bg-neon-lilac/10 hover:bg-neon-lilac/20 border-neon-lilac/40 text-neon-lilac" />
-      <CarouselNext className="bg-neon-lilac/10 hover:bg-neon-lilac/20 border-neon-lilac/40 text-neon-lilac" />
-    </Carousel>
+    <div data-screen-label="Meeting card">
+      <div className="mb-2.5 flex items-center justify-between">
+        <div className="font-mono text-[10px] uppercase tracking-[0.24em] text-text-muted">
+          this week's meeting
+        </div>
+        <ScopeBadge scope={meeting.target_scope} />
+      </div>
+      <h2 className="m-0 mb-3 text-[25px] font-semibold text-text-primary">{meetingTitle(meeting)}</h2>
+      <div className="mb-5">
+        <WhyNowLine meeting={meeting} />
+      </div>
+      <div className="chromatic-hairline relative mb-7 rounded-card border border-neon-pink/20 bg-gradient-to-br from-action-pink/15 to-action-purple/15 px-7 py-6">
+        <div className="text-[17px] italic leading-relaxed text-text-primary/90">
+          "{briefPrompt}"
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-4">
+        <Button
+          onClick={handleStart}
+          className="w-[340px] max-w-full rounded-button bg-gradient-to-br from-action-pink to-action-purple py-6 text-[15px] font-semibold text-white shadow-action hover:opacity-90"
+        >
+          {isUserSelected ? 'Start Meeting — pick an artist' : 'Start Meeting'}
+        </Button>
+        {filteredMeetings.length > 1 && (
+          <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Previous meeting"
+              onClick={() => setMeetingIndex((safeIndex - 1 + filteredMeetings.length) % filteredMeetings.length)}
+              className="h-7 w-7 p-0 text-text-muted hover:text-text-primary"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span>{safeIndex + 1} / {filteredMeetings.length}</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="Next meeting"
+              onClick={() => setMeetingIndex((safeIndex + 1) % filteredMeetings.length)}
+              className="h-7 w-7 p-0 text-text-muted hover:text-text-primary"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/client/src/components/executive-meetings/__tests__/MeetingSelector.emptyPool.test.tsx
+++ b/client/src/components/executive-meetings/__tests__/MeetingSelector.emptyPool.test.tsx
@@ -48,7 +48,8 @@ describe('ExecutiveCard — sitOut prop', () => {
 
     expect(screen.getByTestId('sit-out-head_distribution')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText(/Distro - Patricia Williams/i));
+    // Console redesign: the whole channel strip is the click target.
+    fireEvent.click(screen.getByTestId('exec-strip-head_distribution'));
     expect(onSelect).not.toHaveBeenCalled();
   });
 
@@ -58,7 +59,7 @@ describe('ExecutiveCard — sitOut prop', () => {
 
     expect(screen.queryByTestId('sit-out-head_distribution')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText(/Distro - Patricia Williams/i));
+    fireEvent.click(screen.getByTestId('exec-strip-head_distribution'));
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/pages/ExecutiveSuitePage.tsx
+++ b/client/src/pages/ExecutiveSuitePage.tsx
@@ -1,8 +1,6 @@
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { useGameStore } from '@/store/gameStore';
 import { useGameState } from '@/hooks/useGameState';
-import { AlertCircle, Loader2, Briefcase } from 'lucide-react';
+import { Zap } from 'lucide-react';
 import { SelectionSummary } from '../components/SelectionSummary';
 import { ExecutiveMeetings } from '../components/executive-meetings/ExecutiveMeetings';
 import { useGameContext } from '@/contexts/GameContext';
@@ -10,6 +8,13 @@ import GameLayout from '@/layouts/GameLayout';
 import { useState } from 'react';
 import { toast } from '@/hooks/use-toast';
 import logger from '@/lib/logger';
+
+/**
+ * Exec Console redesign (2026-07-11, "Exec Meetings — Console" direction): the
+ * Executive Suite renders as "The Board" — a mixing-console deck. The page owns
+ * the slim HUD header (title, week line, focus-slot pips, CC meter) and the
+ * console deck framing; ExecutiveMeetings owns the screens inside it.
+ */
 
 interface SelectedChoice {
   executiveName: string;
@@ -46,9 +51,6 @@ export default function ExecutiveSuitePage({
     selectedChoices: []
   });
 
-  const loading = false;
-  const error: string | null = null;
-
   // Fallback advance week function if not provided
   const handleAdvanceWeek = onAdvanceWeek || (async () => {
     try {
@@ -68,87 +70,97 @@ export default function ExecutiveSuitePage({
 
   if (!gameState || !gameId) return null;
 
+  const totalSlots = gameState.focusSlots || 3;
+  const usedSlots = gameState.usedFocusSlots || 0;
+  const slotsLeft = totalSlots - usedSlots;
+  const creativeCapital = gameState.creativeCapital ?? 0;
+  const gridHint = slotsLeft > 0
+    ? `${slotsLeft} focus slot${slotsLeft === 1 ? '' : 's'} remaining`
+    : 'all slots committed — advance the week';
+
   return (
     <GameLayout>
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <header className="mb-10 flex items-start justify-between">
+      <main className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        {/* ===== slim HUD header ===== */}
+        <header className="mb-8 flex flex-wrap items-center justify-between gap-6">
           <div>
-            <div className="text-label text-[10px] uppercase tracking-[0.24em] text-neon-lilac/60 mb-1 flex items-center gap-2">
-              <Briefcase className="w-3 h-3" />
-              Week {gameState.currentWeek}
+            <div className="flex items-center gap-3">
+              <h1 className="font-display text-2xl md:text-[26px] text-text-primary text-aberration">the board</h1>
+              <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-neon-cyan">executive console</span>
             </div>
-            <h1 className="font-display text-2xl md:text-[28px] text-text-primary text-aberration">Executive Meetings</h1>
-            <div className="shimmer-bar w-40 mt-2" />
-            <p className="mt-3 text-sm md:text-base text-text-body flex items-center gap-2">
-              Allocate {(gameState?.focusSlots || 3) - (gameState?.usedFocusSlots || 0)} of {gameState?.focusSlots || 3} focus slots to strategic actions
-              {gameState?.focusSlots === 4 && (
-                <span className="inline-flex items-center gap-1 rounded-pill bg-positive/10 border border-positive/40 text-positive px-3 py-0.5 font-mono text-[11px]">
-                  4th Slot Unlocked
+            <div className="mt-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted/70">
+              week {gameState.currentWeek} · {gridHint}
+              {totalSlots === 4 && (
+                <span className="ml-3 inline-flex items-center gap-1 rounded-pill bg-positive/10 border border-positive/40 text-positive px-2.5 py-0.5 normal-case tracking-normal text-[10px]">
+                  4th slot unlocked
                 </span>
               )}
-            </p>
+            </div>
+            <div className="shimmer-bar w-40 mt-2" />
           </div>
-          <div className="inline-flex items-center gap-2 rounded-pill border border-white/10 bg-white/5 px-4 py-2 text-label text-[10px] font-semibold uppercase tracking-[0.4em] text-text-muted">
-            Executive Suite
+
+          <div className="flex items-center gap-3">
+            {/* focus slot pips */}
+            <div className="chromatic-hairline relative flex items-center gap-3 overflow-hidden rounded-card border border-white/[0.08] bg-gradient-to-b from-surface-panel/85 to-surface-inner/85 px-4 py-2.5">
+              <span className="font-mono text-[9px] uppercase tracking-[0.2em] text-text-muted">Focus</span>
+              <div className="flex gap-1.5">
+                {Array.from({ length: totalSlots }, (_, i) => (
+                  <div
+                    key={i}
+                    className={`h-[7px] w-[22px] rounded-full border ${
+                      i < usedSlots
+                        ? 'border-neon-purple/70 bg-gradient-to-r from-action-pink to-neon-purple shadow-[0_0_12px_rgba(160,90,240,0.6)]'
+                        : 'border-white/15 bg-white/5'
+                    }`}
+                  />
+                ))}
+              </div>
+              <span className="font-mono text-sm font-semibold text-text-primary">{usedSlots}/{totalSlots}</span>
+            </div>
+            {/* creative capital meter */}
+            <div className="relative flex items-center gap-2 overflow-hidden rounded-card border border-white/[0.09] bg-gradient-to-br from-neon-purple/15 to-neon-blue/10 px-4 py-2.5">
+              <Zap className="h-3 w-3 text-neon-lilac/80" />
+              <span className="font-mono text-sm font-semibold text-neon-lilac">{creativeCapital} CC</span>
+            </div>
           </div>
         </header>
 
-        <section
-          className="glass-panel chromatic-hairline hud-ticks relative overflow-hidden p-8 bg-contain bg-top bg-no-repeat min-h-[600px]"
-          style={{ backgroundImage: "url('/executivesuite_background.png')" }}
-        >
-          <div className="absolute inset-0 bg-gradient-to-br from-surface-panel/70 via-transparent to-surface-panel-alt/80" aria-hidden />
-          <div className="absolute -top-32 -right-16 h-72 w-72 rounded-full bg-neon-purple/20 blur-3xl" aria-hidden />
-          <div className="absolute -bottom-40 -left-10 h-80 w-80 rounded-full bg-neon-amber/10 blur-3xl" aria-hidden />
+        {/* ===== console deck ===== */}
+        <section className="chromatic-hairline hud-ticks glass-panel relative overflow-hidden rounded-card p-6 md:p-8">
+          {/* corner brackets */}
+          <div className="pointer-events-none absolute left-[11px] top-[11px] h-[13px] w-[13px] border-l border-t border-neon-purple/50" aria-hidden />
+          <div className="pointer-events-none absolute bottom-[11px] right-[11px] h-[13px] w-[13px] border-b border-r border-neon-cyan/50" aria-hidden />
+          {/* ambient blooms */}
+          <div className="absolute -top-32 -right-16 h-72 w-72 rounded-full bg-neon-purple/15 blur-3xl" aria-hidden />
+          <div className="absolute -bottom-40 -left-10 h-80 w-80 rounded-full bg-neon-magenta/10 blur-3xl" aria-hidden />
 
           <div className="relative z-10">
-            {/* Two Row Layout - Executive Meetings Top, Focus Slots Bottom */}
-            <div className="space-y-6">
-              {/* Top Row - Executive Meetings */}
-              <div>
-                {loading ? (
-                  <div className="text-center py-8">
-                    <Loader2 className="w-8 h-8 text-neon-purple mx-auto mb-4 animate-spin" />
-                    <p className="text-text-body">Loading available actions...</p>
-                  </div>
-                ) : error ? (
-                  <div className="text-center py-8">
-                    <AlertCircle className="w-8 h-8 text-negative mx-auto mb-4" />
-                    <p className="text-negative mb-4">Failed to load actions</p>
-                    <Button onClick={() => window.location.reload()} variant="outline" size="sm">
-                      Try Again
-                    </Button>
-                  </div>
-                ) : (
-                  <ExecutiveMeetings
-                    gameId={gameId}
-                    currentWeek={gameState.currentWeek}
-                    onActionSelected={selectAction}
-                    focusSlots={{
-                      total: gameState.focusSlots || 3,
-                      used: gameState.usedFocusSlots || 0,
-                    }}
-                    creativeCapital={gameState.creativeCapital ?? 0}
-                    arOfficeStatus={getAROfficeStatus()}
-                    onImpactPreviewUpdate={setImpactPreview}
-                  />
-                )}
-              </div>
-
-              {/* Bottom Row - Focus Slots / Selection Summary */}
-              <div>
-                <SelectionSummary
-                  selectedActions={selectedActions}
-                  onRemoveAction={removeAction}
-                  onReorderActions={reorderActions}
-                  onAdvanceWeek={handleAdvanceWeek}
-                  isAdvancing={handleIsAdvancing}
-                  impactPreview={impactPreview}
-                />
-              </div>
-            </div>
+            <ExecutiveMeetings
+              gameId={gameId}
+              currentWeek={gameState.currentWeek}
+              onActionSelected={selectAction}
+              focusSlots={{
+                total: totalSlots,
+                used: usedSlots,
+              }}
+              creativeCapital={creativeCapital}
+              arOfficeStatus={getAROfficeStatus()}
+              onImpactPreviewUpdate={setImpactPreview}
+            />
           </div>
         </section>
+
+        {/* ===== focus slots / selection summary ===== */}
+        <div className="mt-6">
+          <SelectionSummary
+            selectedActions={selectedActions}
+            onRemoveAction={removeAction}
+            onReorderActions={reorderActions}
+            onAdvanceWeek={handleAdvanceWeek}
+            isAdvancing={handleIsAdvancing}
+            impactPreview={impactPreview}
+          />
+        </div>
       </main>
     </GameLayout>
   );

--- a/client/src/pages/ExecutiveSuitePage.tsx
+++ b/client/src/pages/ExecutiveSuitePage.tsx
@@ -126,13 +126,18 @@ export default function ExecutiveSuitePage({
         </header>
 
         {/* ===== console deck ===== */}
-        <section className="chromatic-hairline hud-ticks glass-panel relative overflow-hidden rounded-card p-6 md:p-8">
+        {/* overflow-clip (not -hidden): a hidden-overflow box is still programmatically
+            scrollable, and the blooms' offscreen extent let focus/scrollIntoView shift
+            the whole deck sideways (scrollLeft > 0 → left edge visually cut). clip
+            forbids scrolling entirely; the blooms use transforms, which never create
+            scrollable overflow in the first place. */}
+        <section className="chromatic-hairline hud-ticks glass-panel relative overflow-clip rounded-card p-6 md:p-8">
           {/* corner brackets */}
           <div className="pointer-events-none absolute left-[11px] top-[11px] h-[13px] w-[13px] border-l border-t border-neon-purple/50" aria-hidden />
           <div className="pointer-events-none absolute bottom-[11px] right-[11px] h-[13px] w-[13px] border-b border-r border-neon-cyan/50" aria-hidden />
-          {/* ambient blooms */}
-          <div className="absolute -top-32 -right-16 h-72 w-72 rounded-full bg-neon-purple/15 blur-3xl" aria-hidden />
-          <div className="absolute -bottom-40 -left-10 h-80 w-80 rounded-full bg-neon-magenta/10 blur-3xl" aria-hidden />
+          {/* ambient blooms (transform-offset, see note above) */}
+          <div className="pointer-events-none absolute right-0 top-0 h-72 w-72 -translate-y-32 translate-x-16 rounded-full bg-neon-purple/15 blur-3xl" aria-hidden />
+          <div className="pointer-events-none absolute bottom-0 left-0 h-80 w-80 -translate-x-10 translate-y-40 rounded-full bg-neon-magenta/10 blur-3xl" aria-hidden />
 
           <div className="relative z-10">
             <ExecutiveMeetings

--- a/tests/client/DialogueInterface.ccGate.test.tsx
+++ b/tests/client/DialogueInterface.ccGate.test.tsx
@@ -54,16 +54,18 @@ describe('DialogueInterface — CC affordability gate', () => {
     expect(screen.getByTestId('cc-gate-creative_reset')).toHaveTextContent(
       'Needs 2 Creative Capital — you have 0'
     );
-    const buttons = screen.getAllByRole('button', { name: 'Choose This Response' });
-    // Carousel renders both cards; the CC-costing one is disabled, the free one is not.
-    expect(buttons.some((b) => (b as HTMLButtonElement).disabled)).toBe(true);
-    expect(buttons.some((b) => !(b as HTMLButtonElement).disabled)).toBe(true);
+    // Console redesign: takes render side by side; the gated one reads "Locked"
+    // and is disabled, the free one stays a live "Choose".
+    const locked = screen.getByRole('button', { name: 'Locked' }) as HTMLButtonElement;
+    expect(locked.disabled).toBe(true);
+    const choose = screen.getByRole('button', { name: 'Choose' }) as HTMLButtonElement;
+    expect(choose.disabled).toBe(false);
   });
 
   it('does not gate an affordable CC choice', () => {
     renderDialogue(5);
     expect(screen.queryByTestId('cc-gate-creative_reset')).toBeNull();
-    const buttons = screen.getAllByRole('button', { name: 'Choose This Response' });
+    const buttons = screen.getAllByRole('button', { name: 'Choose' });
     expect(buttons.every((b) => !(b as HTMLButtonElement).disabled)).toBe(true);
   });
 
@@ -75,7 +77,7 @@ describe('DialogueInterface — CC affordability gate', () => {
   it('absent prop = legacy behavior, nothing gated (other render sites unchanged)', () => {
     renderDialogue(undefined);
     expect(screen.queryByTestId('cc-gate-creative_reset')).toBeNull();
-    const buttons = screen.getAllByRole('button', { name: 'Choose This Response' });
+    const buttons = screen.getAllByRole('button', { name: 'Choose' });
     expect(buttons.every((b) => !(b as HTMLButtonElement).disabled)).toBe(true);
   });
 });

--- a/tests/client/MeetingSelector.why-now.test.tsx
+++ b/tests/client/MeetingSelector.why-now.test.tsx
@@ -72,8 +72,9 @@ describe('MeetingSelector — why-now line', () => {
         onBack={vi.fn()}
       />
     );
-    // Enter the artist-selection view by selecting the meeting.
-    screen.getByText('Select Artist').click();
+    // Enter the artist-picker view by starting the meeting (console redesign:
+    // the brief's CTA reads "Start Meeting — pick an artist").
+    screen.getByText('Start Meeting — pick an artist').click();
     expect(screen.getByTestId('why-now-line')).toHaveTextContent('Because Aurora is in crisis');
   });
 });


### PR DESCRIPTION
## Summary
Reskins the Executive Suite as **"The Board"** — a mixing-console-styled Exec Console — implementing the `Exec Meetings - Console.dc.html` direction from the claude.ai/design project (fetched via DesignSync). Includes a follow-up fix for the deck being clipped at the left edge (hidden-overflow scroll).

- **Presentation-only**: `executiveMeetingMachine`, prefetches, `SYNC_SLOTS`, and AUTO Option A semantics are untouched; shared exports (`ChoiceEffects`, `isRenderableEffectKey`, `EffectBadgeTooltip`) intact.
- Palette maps 1:1 onto the v2 "Neo-Cyber HUD" Tailwind tokens (design was authored on them) — no inline hex.
- `ArtistSelector.tsx` is now orphaned (MeetingSelector has its own console picker) but kept with its passing test.
- Three presentation-pinning tests legitimately re-pinned: strip click target (`exec-strip-<role>` testid), Choose/Locked button names, and the "Start Meeting — pick an artist" CTA.

## Verification
- `tsc` clean; full suite 1,712/1,712 green.
- Live-verified end-to-end, including the CC gate locking at 0 CC and AUTO exclusion of a queued exec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
