### PR TITLE
feat(client): hype visibility + Board brief preview (playtest feedback UX arc)

### DIFF
--- a/client/src/components/BankedHypeAttachPreview.tsx
+++ b/client/src/components/BankedHypeAttachPreview.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+import {
+  summarizeHypeAttachPreview,
+  type HypeAttachPreview,
+} from '@/lib/releaseBuzz';
+
+/**
+ * Hype-board UX arc, Task 1 — banked-hype attach preview on the release
+ * planning page.
+ *
+ * The buzz-v2 arc attaches banked pools at PLAN time (the selected artist's
+ * pool + the entire label pool drain onto the release the moment you confirm
+ * — releasePlanningService, fork B "first-planned takes all"). Before this
+ * component, the player only learned that AFTER confirming (the plan toast's
+ * "Hype applied" line). This preview shows, BEFORE the confirm button, which
+ * pool(s) will convert and a qualitative strength band.
+ *
+ * DISPLAY-ONLY: reads the same client-visible flag fields the dashboard chip
+ * reads (flags.pendingAwarenessBoost + flags.hypeArtistPools) via the pure
+ * summarizeHypeAttachPreview helper — no engine math re-derived, and the
+ * server's returned hypeApplied remains the source of truth at confirm time.
+ * Fork E standing rule: a point value ("+N Hype") is fine, NO multiplier
+ * numbers anywhere.
+ */
+export function BankedHypeAttachPreview({
+  flags,
+  artistId,
+  artistNameById = {},
+}: {
+  flags: Record<string, any> | undefined | null;
+  artistId: string | null | undefined;
+  artistNameById?: Record<string, string>;
+}) {
+  if (!artistId) return null;
+  const preview: HypeAttachPreview = summarizeHypeAttachPreview(
+    flags,
+    artistId,
+    artistNameById
+  );
+  if (preview.pools.length === 0) return null;
+
+  const headline = preview.suppressed
+    ? 'Banked buzz: suppressed — this hype works against the launch.'
+    : preview.strength
+      ? `Banked buzz: ${preview.strength} — converts into this release's launch.`
+      : 'Banked buzz converts into this release’s launch.';
+
+  return (
+    <section
+      data-testid="banked-hype-attach-preview"
+      className="glass-panel chromatic-hairline p-4"
+    >
+      <div className="mb-2 flex items-center gap-2">
+        <Sparkles className="h-3.5 w-3.5 text-neon-cyan" />
+        <h3 className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-text-label">
+          Banked Hype — attaches when you confirm
+        </h3>
+      </div>
+      <ul className="space-y-1">
+        {preview.pools.map((pool) => (
+          <li
+            key={pool.scope === 'label' ? 'label' : pool.artistId}
+            data-testid="attach-preview-pool"
+            className="flex items-baseline justify-between gap-3 text-[12px]"
+          >
+            <span className="text-text-body truncate">
+              {pool.scope === 'label' ? 'Label pool' : `${pool.name}'s pool`}
+            </span>
+            <span
+              className={`font-mono whitespace-nowrap ${pool.amount > 0 ? 'text-money' : 'text-negative'}`}
+            >
+              {pool.amount > 0 ? '+' : ''}
+              {pool.amount} Hype
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p
+        data-testid="attach-preview-headline"
+        className={`mt-2 text-[11.5px] ${preview.suppressed ? 'text-negative' : 'text-neon-cyan'}`}
+      >
+        {headline}
+      </p>
+      <p className="mt-1 text-[10.5px] text-text-muted">
+        Planning this release drains these pools into its starting Buzz — they
+        stop fading and stop being available to other releases.
+      </p>
+    </section>
+  );
+}

--- a/client/src/components/MetricsDashboard.tsx
+++ b/client/src/components/MetricsDashboard.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 import { useGameStore } from '@/store/gameStore';
 import { useGameState } from '@/hooks/useGameState';
 import { useSongs } from '@/hooks/useSongs';
-import { summarizeCatalogBuzz, summarizeBankedHype, BANKED_HYPE_EXPIRY_WEEKS, BANKED_HYPE_TOOLTIP } from '@/lib/releaseBuzz';
+import {
+  summarizeCatalogBuzz,
+  listBankedHypePools,
+  summarizeAnticipation,
+  BANKED_HYPE_TOOLTIP,
+  type BankedHypePool,
+} from '@/lib/releaseBuzz';
+import { getReleaseSongs } from '@/lib/releaseAnalytics';
+import { useArtists } from '@/hooks/useArtists';
+import { useReleases } from '@/hooks/useReleases';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { TrendingUp, TrendingDown, Clock, Zap, BarChart3 } from 'lucide-react';
@@ -24,31 +33,38 @@ import { AnimatedNumber } from '@/components/motion-primitives/animated-number';
  * ReleaseBuzzSection) so it unit-tests from plain song fixtures without
  * mounting the full dashboard.
  */
+export interface AnticipationPreviewEntry {
+  releaseId: string;
+  title: string;
+  /** Qualitative strength word from summarizeAnticipation, or null (early). */
+  strength: string | null;
+  weeksToLaunch: number;
+}
+
 export function BuzzStatusStat({
   songs,
   currentWeek,
-  bankedHype = 0,
-  bankedHypeWeek,
+  pools = [],
+  anticipations = [],
   className = '',
 }: {
   songs: any[] | undefined;
   currentWeek: number;
-  /** flags.pendingAwarenessBoost — banked-hype pool (buzz-v2 slice 1). */
-  bankedHype?: number;
-  /** flags.pendingAwarenessBoostWeek — week the pool was last stamped. */
-  bankedHypeWeek?: number | null;
+  /**
+   * Hype-board UX Task 3 — per-pool banked hype (from listBankedHypePools,
+   * positive pools only: a negative pool suppresses discovery — not a resource
+   * to advertise). Replaces the former aggregate "+N Hype banked" chip with
+   * named per-artist/label lines and per-pool expiry hints.
+   */
+  pools?: BankedHypePool[];
+  /** Planned releases currently building pre-release anticipation. */
+  anticipations?: AnticipationPreviewEntry[];
   className?: string;
 }) {
   const { building, fading } = summarizeCatalogBuzz(songs, currentWeek);
   const hasBuzz = building > 0 || fading > 0;
 
-  // Buzz-v2 slice 1: banked-hype chip. Only the POSITIVE banked channel gets a
-  // "seeds your next release" chip (a negative pool suppresses discovery — not a
-  // resource to advertise). Expiry week = stamped week + N (mirrors the engine's
-  // pending_awareness_boost_expiry_weeks); omit the countdown if we can't date it.
-  const showBankedHype = bankedHype > 0;
-  const fadesWeek =
-    typeof bankedHypeWeek === 'number' ? bankedHypeWeek + BANKED_HYPE_EXPIRY_WEEKS : null;
+  const positivePools = pools.filter((p) => p.amount > 0);
 
   return (
     <div className={`min-w-0 ${className}`} data-testid="buzz-status-stat">
@@ -77,25 +93,48 @@ export function BuzzStatusStat({
         )}
       </div>
       <div className="text-[11.5px] text-text-muted mt-1.5">Buzz</div>
-      {showBankedHype && (
+      {/* Hype-board UX Task 3: named per-pool lines instead of one generic
+          aggregate chip. Same tooltip contract as the old chip (the block is
+          the trigger); per-pool expiry hint reads "fading wk W if unused". */}
+      {positivePools.length > 0 && (
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
               <div
                 data-testid="banked-hype-chip"
-                className="text-[11.5px] font-mono text-money mt-1 whitespace-nowrap cursor-help"
+                className="mt-1 cursor-help space-y-0.5"
                 aria-label={`Banked Hype: ${BANKED_HYPE_TOOLTIP}`}
               >
-                +{bankedHype} Hype banked
-                {fadesWeek !== null && (
-                  <span className="text-text-muted"> · fades wk {fadesWeek}</span>
-                )}
+                {positivePools.map((pool) => (
+                  <div
+                    key={pool.scope === 'label' ? 'label' : pool.artistId}
+                    data-testid="banked-hype-pool"
+                    className="text-[11.5px] font-mono text-money whitespace-nowrap"
+                  >
+                    +{pool.amount} Hype — {pool.name}
+                    {pool.fadesWeek !== null && (
+                      <span className="text-text-muted"> · fading wk {pool.fadesWeek} if unused</span>
+                    )}
+                  </div>
+                ))}
               </div>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs">{BANKED_HYPE_TOOLTIP}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       )}
+      {/* Hype-board UX Task 3: planned releases building anticipation, by name.
+          Qualitative strength word only (fork E) — no numbers beyond the week. */}
+      {anticipations.map((entry) => (
+        <div
+          key={entry.releaseId}
+          data-testid="anticipation-status-line"
+          className="mt-1 text-[11.5px] text-neon-cyan whitespace-nowrap"
+        >
+          “{entry.title}” {entry.strength ? `${entry.strength} anticipation` : 'anticipation building'}
+          <span className="text-text-muted"> · launches wk {currentWeek + entry.weeksToLaunch}</span>
+        </div>
+      ))}
     </div>
   );
 }
@@ -119,14 +158,49 @@ export function MetricsDashboard() {
   const { selectedActions } = useGameStore();
   // Catalog-wide songs for the core-status "Buzz" stat (live derivation).
   const { data: songs } = useSongs();
-  // Buzz-v2 slice 1+2: banked-hype pools read via the useGameState() façade
-  // (NEVER useGameStore for spine fields). Slice 2 sums ALL unattached pools —
-  // the label pool (flags.pendingAwarenessBoost) AND every per-artist pool
-  // (flags.hypeArtistPools) — and shows the soonest fade week among them, feeding
-  // the "+N Hype banked · fades wk W" chip on BuzzStatusStat.
-  const bankedHypeSummary = summarizeBankedHype(gameState?.flags as Record<string, any> | undefined);
-  const bankedHype = bankedHypeSummary.total;
-  const bankedHypeWeek = bankedHypeSummary.soonestWeek;
+  // Buzz-v2 slice 1+2 / hype-board UX Task 3: banked-hype pools read via the
+  // useGameState() façade (NEVER useGameStore for spine fields). Task 3
+  // de-genericized the readout: instead of one summed "+N Hype banked" chip,
+  // every unattached pool renders by NAME (artist pools via the roster cache,
+  // plus the label pool) with its own "fading wk W if unused" hint — all from
+  // the SAME cached flag fields the old chip read.
+  const { data: rosterArtists = [] } = useArtists();
+  const { data: releases = [] } = useReleases();
+  const artistNameById = React.useMemo(
+    () => Object.fromEntries((rosterArtists as any[]).map((a) => [a.id, a.name])),
+    [rosterArtists]
+  );
+  const hypePools = listBankedHypePools(
+    gameState?.flags as Record<string, any> | undefined,
+    artistNameById
+  );
+  // Task 3: planned releases currently building pre-release anticipation —
+  // same detection rule as ReleaseWorkflowCard's ramp line (planned status,
+  // preCampaign.pct > 0, at least one lead-up week), strength word from the
+  // release's songs' pre-built awareness (summarizeAnticipation, fork E bands).
+  const currentWeekNumber = gameState?.currentWeek || 1;
+  const anticipations = React.useMemo(
+    () =>
+      (releases as any[])
+        .filter((release) => {
+          const preCampaign = release?.metadata?.preCampaign;
+          const weeksToLaunch = (release?.releaseWeek || 0) - currentWeekNumber;
+          return (
+            release?.status === 'planned' &&
+            !!preCampaign &&
+            typeof preCampaign.pct === 'number' &&
+            preCampaign.pct > 0 &&
+            weeksToLaunch >= 1
+          );
+        })
+        .map((release) => ({
+          releaseId: release.id,
+          title: release.title ?? 'Untitled',
+          strength: summarizeAnticipation(getReleaseSongs(release.id, songs ?? [])),
+          weeksToLaunch: (release.releaseWeek || 0) - currentWeekNumber,
+        })),
+    [releases, songs, currentWeekNumber]
+  );
   const [impactPreview, setImpactPreview] = useState<ImpactPreview>({
     immediate: {},
     delayed: {},
@@ -473,8 +547,8 @@ export function MetricsDashboard() {
                 <BuzzStatusStat
                   songs={songs}
                   currentWeek={gameState.currentWeek || 1}
-                  bankedHype={bankedHype}
-                  bankedHypeWeek={bankedHypeWeek}
+                  pools={hypePools}
+                  anticipations={anticipations}
                 />
               </div>
             </div>
@@ -596,8 +670,8 @@ export function MetricsDashboard() {
                 <BuzzStatusStat
                   songs={songs}
                   currentWeek={gameState.currentWeek || 1}
-                  bankedHype={bankedHype}
-                  bankedHypeWeek={bankedHypeWeek}
+                  pools={hypePools}
+                  anticipations={anticipations}
                   className="text-center p-2 bg-surface-inner/50 rounded-chip"
                 />
               </div>
@@ -733,8 +807,8 @@ export function MetricsDashboard() {
                 <BuzzStatusStat
                   songs={songs}
                   currentWeek={gameState.currentWeek || 1}
-                  bankedHype={bankedHype}
-                  bankedHypeWeek={bankedHypeWeek}
+                  pools={hypePools}
+                  anticipations={anticipations}
                   className="text-center p-2 bg-surface-inner/50 rounded-chip"
                 />
               </div>

--- a/client/src/components/WeekSummary.tsx
+++ b/client/src/components/WeekSummary.tsx
@@ -26,6 +26,7 @@ import {
   findTourCompletion,
 } from './week-summary/categorizeChanges';
 import { TourCityCard } from './week-summary/TourCityCard';
+import { AnticipationLine } from './week-summary/AnticipationLine';
 
 interface WeekSummaryProps {
   weeklyStats: WeekSummaryType;
@@ -1016,14 +1017,22 @@ export function WeekSummary({ weeklyStats, onAdvanceWeek, isAdvancing, isWeekRes
         {categorizedChanges.hypeRoutine.length > 0 && (
           <RevealGroup revealed={currentStage >= STAGE_ROUTINE} instant={instant}>
             <div className="space-y-2">
-              {categorizedChanges.hypeRoutine.map((change: GameChange, index: number) => (
-                <div
-                  key={`hype-routine-${index}`}
-                  className="p-3 rounded-[12px] border border-white/10 bg-surface-inner/40"
-                >
-                  <span className="text-sm font-medium text-white/80">{change.description}</span>
-                </div>
-              ))}
+              {/* Hype-board UX Task 2: 'pre_campaign' entries render as the
+                  structured momentum readout (AnticipationLine — qualitative
+                  band + direction arrow, never the raw gain number); other
+                  hype-routine entries (hype_banked) keep the plain line. */}
+              {categorizedChanges.hypeRoutine.map((change: GameChange, index: number) =>
+                change.type === 'pre_campaign' ? (
+                  <AnticipationLine key={`hype-routine-${index}`} change={change} />
+                ) : (
+                  <div
+                    key={`hype-routine-${index}`}
+                    className="p-3 rounded-[12px] border border-white/10 bg-surface-inner/40"
+                  >
+                    <span className="text-sm font-medium text-white/80">{change.description}</span>
+                  </div>
+                )
+              )}
             </div>
           </RevealGroup>
         )}

--- a/client/src/components/executive-meetings/ExecutiveCard.tsx
+++ b/client/src/components/executive-meetings/ExecutiveCard.tsx
@@ -33,6 +33,16 @@ interface ExecutiveCardProps {
    * line is the payoff on open).
    */
   hasReactiveMeeting?: boolean;
+  /**
+   * Hype-board UX Task 4 (playtest feedback): the open-channel state previews
+   * WHAT is waiting — the pool's first meeting's name + a one-line prompt
+   * snippet, prefetched by ExecutiveMeetings' existing sit-out/urgency sweep
+   * (zero new requests). This deliberately revises the earlier "no meeting
+   * name on the card" stance for the MEETING itself; the reactive TRIGGER
+   * ("why now" copy) still only reveals on open — the urgency dot stays a
+   * content-free pulse.
+   */
+  meetingPreview?: { name: string; snippet: string; moreCount?: number };
   onSelect: () => void;
   weeklySalary?: number;
   arOfficeStatus?: {
@@ -106,6 +116,25 @@ export const roleConfig = {
   },
 } as const;
 
+/**
+ * Display name for a meeting (Task 4 preview) — same fallback rule as
+ * MeetingSelector's meetingTitle: prefer the authored name, else prettify id.
+ */
+export function meetingDisplayName(meeting: { id: string; name?: string }): string {
+  return meeting.name || meeting.id.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
+}
+
+/** One-line prompt snippet for the strip preview — word-boundary truncation. */
+export const MEETING_SNIPPET_MAX = 90;
+
+export function snippetOf(text: string | undefined | null, max: number = MEETING_SNIPPET_MAX): string {
+  const clean = (text || '').trim();
+  if (clean.length <= max) return clean;
+  const cut = clean.slice(0, max + 1);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${cut.slice(0, lastSpace > 40 ? lastSpace : max).trimEnd()}…`;
+}
+
 function VerticalFader({ value, label, fillClass, valueClass }: {
   value: number;
   label: string;
@@ -132,6 +161,7 @@ export function ExecutiveCard({
   disabled = false,
   sitOut = false,
   hasReactiveMeeting = false,
+  meetingPreview,
   onSelect,
   weeklySalary,
   arOfficeStatus,
@@ -185,8 +215,10 @@ export function ExecutiveCard({
           };
 
   // Console status readout (foot of the strip) — precedence mirrors the design:
-  // busy > queued > sit-out > no-slots > open for business.
-  const status = isArBusy
+  // busy > queued > sit-out > no-slots > open for business. Task 4: the open
+  // state previews the waiting brief (meeting name + prompt snippet) when the
+  // prefetch supplied one; generic copy is the fail-open fallback.
+  const status: { text: string; className: string; snippet?: string; moreCount?: number } = isArBusy
     ? { text: 'Running a scouting op — back next week', className: 'bg-neon-amber/10 border-neon-amber/30 text-neon-amber' }
     : queued
       ? { text: 'Meeting queued for this week', className: 'bg-neon-green/10 border-neon-green/30 text-neon-green' }
@@ -194,7 +226,14 @@ export function ExecutiveCard({
         ? { text: isCEO ? 'Nothing needs your call this week' : 'Nothing needs their call this week', className: 'bg-white/[0.03] border-white/10 text-text-muted' }
         : noSlots
           ? { text: 'No focus slots remaining', className: 'bg-negative/10 border-negative/25 text-negative' }
-          : { text: 'Has something for you', className: 'bg-neon-purple/10 border-neon-purple/35 text-neon-lilac' };
+          : meetingPreview
+            ? {
+                text: meetingPreview.name,
+                snippet: meetingPreview.snippet,
+                moreCount: meetingPreview.moreCount,
+                className: 'bg-neon-purple/10 border-neon-purple/35 text-neon-lilac',
+              }
+            : { text: 'Has something for you', className: 'bg-neon-purple/10 border-neon-purple/35 text-neon-lilac' };
 
   const queuedChip = (
     <span className="flex items-center gap-1.5 rounded-pill border border-neon-green/40 bg-neon-green/15 px-2 py-0.5 font-mono text-[9px] font-semibold text-neon-green">
@@ -229,6 +268,17 @@ export function ExecutiveCard({
         <div className="mt-1 text-center font-mono text-[9px] uppercase tracking-[0.16em] text-money/70">
           {queued ? 'meeting queued' : noSlots ? 'no slots left' : 'quarterly vision'}
         </div>
+        {/* Task 4: the master strip previews the waiting brief's name too
+            (narrow strip — name only; the prompt snippet lives on the wider
+            exec channel strips). */}
+        {!queued && !sitOut && !noSlots && meetingPreview && (
+          <div
+            data-testid="meeting-preview-ceo"
+            className="mt-2 line-clamp-2 text-center text-[10.5px] font-medium text-text-primary"
+          >
+            {meetingPreview.name}
+          </div>
+        )}
         <div className="flex-1 min-h-4" />
         {queued ? (
           queuedChip
@@ -323,9 +373,25 @@ export function ExecutiveCard({
 
       <div className="flex-1" />
 
-      {/* status readout */}
-      <div className={`flex min-h-[44px] w-full items-center justify-center rounded-lg border px-2.5 py-1.5 text-center text-[11px] leading-snug ${status.className}`}>
-        {status.text}
+      {/* status readout (Task 4: open state previews the waiting brief) */}
+      <div
+        data-testid={`status-readout-${executive.role}`}
+        className={`flex min-h-[44px] w-full flex-col items-center justify-center gap-0.5 rounded-lg border px-2.5 py-1.5 text-center text-[11px] leading-snug ${status.className}`}
+      >
+        <span className={status.snippet ? 'font-semibold' : undefined}>{status.text}</span>
+        {status.snippet && (
+          <span
+            data-testid={`meeting-preview-snippet-${executive.role}`}
+            className="line-clamp-2 text-[10px] text-text-muted"
+          >
+            {status.snippet}
+          </span>
+        )}
+        {typeof status.moreCount === 'number' && status.moreCount > 0 && (
+          <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-text-muted">
+            +{status.moreCount} more brief{status.moreCount === 1 ? '' : 's'}
+          </span>
+        )}
       </div>
 
       {/* Meeting-relevance Tier 0 (PR-1): sit-out testid anchor (copy lives in the

--- a/client/src/components/executive-meetings/ExecutiveMeetings.tsx
+++ b/client/src/components/executive-meetings/ExecutiveMeetings.tsx
@@ -3,7 +3,7 @@ import { useMachine } from '@xstate/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { executiveMeetingMachine } from '../../machines/executiveMeetingMachine';
 import { makeCachedFetchExecutives } from '../../hooks/useExecutives';
-import { ExecutiveCard, roleConfig } from './ExecutiveCard';
+import { ExecutiveCard, roleConfig, meetingDisplayName, snippetOf } from './ExecutiveCard';
 import { MeetingSelector } from './MeetingSelector';
 import { DialogueInterface } from './DialogueInterface';
 import { AutoSelectReviewPanel } from './AutoSelectReviewPanel';
@@ -109,6 +109,17 @@ export function ExecutiveMeetings({
    * payoff on open (MeetingSelector / AutoSelectReviewPanel).
    */
   const [reactiveRoles, setReactiveRoles] = useState<Set<string>>(new Set());
+  /**
+   * Hype-board UX Task 4 (playtest feedback): the console strip's open-channel
+   * state should preview WHAT is waiting, not just that something is. Piggybacks
+   * on the SAME sit-out/urgency prefetch below — zero new requests. Stores the
+   * pool's first meeting's name + a one-line prompt snippet per role (the
+   * reactive "why now" TRIGGER copy still only reveals on open — see
+   * MeetingSelector's WhyNowLine).
+   */
+  const [meetingPreviews, setMeetingPreviews] = useState<
+    Record<string, { name: string; snippet: string; moreCount: number }>
+  >({});
 
   const { getAROfficeStatus, selectedActions } = useGameStore();
   // C74: the global GameHeader AUTO button sets this session intent + navigates
@@ -225,15 +236,31 @@ export function ExecutiveMeetings({
           try {
             const meetings = await fetchRoleMeetings(roleId, gameId, currentWeek);
             const isReactive = meetings.some((m) => !!m.reactiveContext);
-            return [roleId, meetings.length, isReactive] as const;
+            // Task 4: brief preview from the SAME response — first meeting's
+            // display name + prompt snippet. Fetch errors fall through to no
+            // preview (the strip keeps its generic open-channel copy).
+            const first = meetings[0];
+            const preview = first
+              ? {
+                  name: meetingDisplayName(first),
+                  snippet: snippetOf(first.prompt_before_selection || first.prompt),
+                  moreCount: meetings.length - 1,
+                }
+              : null;
+            return [roleId, meetings.length, isReactive, preview] as const;
           } catch {
-            return [roleId, -1, false] as const; // unknown → fail open
+            return [roleId, -1, false, null] as const; // unknown → fail open
           }
         })
       );
       if (isCancelled) return;
       setSitOutRoles(new Set(results.filter(([, count]) => count === 0).map(([roleId]) => roleId)));
       setReactiveRoles(new Set(results.filter(([, , isReactive]) => isReactive).map(([roleId]) => roleId)));
+      setMeetingPreviews(
+        Object.fromEntries(
+          results.filter(([, , , preview]) => !!preview).map(([roleId, , , preview]) => [roleId, preview!])
+        )
+      );
     })();
 
     return () => {
@@ -545,6 +572,7 @@ export function ExecutiveMeetings({
                 queued={isExecutiveUsed('ceo')}
                 sitOut={sitOutRoles.has('ceo')}
                 hasReactiveMeeting={reactiveRoles.has('ceo')}
+                meetingPreview={meetingPreviews['ceo']}
                 onSelect={() => send({ type: 'SELECT_EXECUTIVE', executive: orderedExecutives.ceo! })}
                 weeklySalary={roleSalaries['ceo']}
                 arOfficeStatus={arOfficeStatus}
@@ -562,6 +590,7 @@ export function ExecutiveMeetings({
               queued={isExecutiveUsed(executive.role)}
               sitOut={sitOutRoles.has(executive.role)}
               hasReactiveMeeting={reactiveRoles.has(executive.role)}
+              meetingPreview={meetingPreviews[executive.role]}
               onSelect={() => send({ type: 'SELECT_EXECUTIVE', executive })}
               weeklySalary={roleSalaries[executive.role]}
               arOfficeStatus={arOfficeStatus}

--- a/client/src/components/executive-meetings/__tests__/ExecutiveCard.meetingPreview.test.tsx
+++ b/client/src/components/executive-meetings/__tests__/ExecutiveCard.meetingPreview.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Hype-board UX Task 4 — The Board's open-channel state previews WHAT is
+ * waiting: the meeting name + a one-line prompt snippet (prefetched by the
+ * existing sit-out/urgency sweep — zero new requests).
+ *
+ * Precedence contract: the preview ONLY replaces the generic "Has something
+ * for you" open state — busy/queued/sit-out/no-slots status copy always wins.
+ * The reactive TRIGGER ("why now" copy) still reveals only on open; the
+ * urgency dot stays a content-free pulse (ExecutiveCard.urgency-dot.test.tsx).
+ */
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { ExecutiveCard, meetingDisplayName, snippetOf, MEETING_SNIPPET_MAX } from '../ExecutiveCard';
+import type { Executive } from '../../../../../shared/types/gameTypes';
+
+afterEach(() => cleanup());
+
+function exec(role = 'cmo'): Executive {
+  return { id: `e-${role}`, role, level: 1, mood: 50, loyalty: 50 } as any;
+}
+
+const preview = {
+  name: 'CMO: Brand Crossroads',
+  snippet: 'A lifestyle brand wants your artist for a national campaign…',
+  moreCount: 1,
+};
+
+describe('ExecutiveCard — meeting preview (Task 4)', () => {
+  it('previews the waiting meeting name + prompt snippet in the open state', () => {
+    render(<ExecutiveCard executive={exec()} meetingPreview={preview} onSelect={vi.fn()} />);
+    const readout = screen.getByTestId('status-readout-cmo');
+    expect(readout).toHaveTextContent('CMO: Brand Crossroads');
+    expect(screen.getByTestId('meeting-preview-snippet-cmo')).toHaveTextContent(
+      'A lifestyle brand wants your artist'
+    );
+    expect(readout).toHaveTextContent('+1 more brief');
+    expect(readout).not.toHaveTextContent('Has something for you');
+  });
+
+  it('falls back to the generic open copy when no preview was prefetched', () => {
+    render(<ExecutiveCard executive={exec()} onSelect={vi.fn()} />);
+    expect(screen.getByTestId('status-readout-cmo')).toHaveTextContent('Has something for you');
+  });
+
+  it('queued status wins over the preview', () => {
+    render(<ExecutiveCard executive={exec()} meetingPreview={preview} queued onSelect={vi.fn()} />);
+    const readout = screen.getByTestId('status-readout-cmo');
+    expect(readout).toHaveTextContent('Meeting queued for this week');
+    expect(readout).not.toHaveTextContent('Brand Crossroads');
+  });
+
+  it('sit-out status wins over the preview', () => {
+    render(<ExecutiveCard executive={exec()} meetingPreview={preview} sitOut onSelect={vi.fn()} />);
+    const readout = screen.getByTestId('status-readout-cmo');
+    expect(readout).toHaveTextContent('Nothing needs their call this week');
+    expect(readout).not.toHaveTextContent('Brand Crossroads');
+  });
+
+  it('no-slots status wins over the preview', () => {
+    render(
+      <ExecutiveCard executive={exec()} meetingPreview={preview} noSlots disabled onSelect={vi.fn()} />
+    );
+    const readout = screen.getByTestId('status-readout-cmo');
+    expect(readout).toHaveTextContent('No focus slots remaining');
+    expect(readout).not.toHaveTextContent('Brand Crossroads');
+  });
+
+  it('the CEO master strip previews the meeting name (narrow strip — name only)', () => {
+    render(<ExecutiveCard executive={exec('ceo')} meetingPreview={preview} onSelect={vi.fn()} />);
+    expect(screen.getByTestId('meeting-preview-ceo')).toHaveTextContent('CMO: Brand Crossroads');
+  });
+
+  it('the CEO strip suppresses the preview when queued or sitting out', () => {
+    render(
+      <ExecutiveCard executive={exec('ceo')} meetingPreview={preview} queued onSelect={vi.fn()} />
+    );
+    expect(screen.queryByTestId('meeting-preview-ceo')).toBeNull();
+    cleanup();
+    render(
+      <ExecutiveCard executive={exec('ceo')} meetingPreview={preview} sitOut onSelect={vi.fn()} />
+    );
+    expect(screen.queryByTestId('meeting-preview-ceo')).toBeNull();
+  });
+});
+
+describe('meetingDisplayName / snippetOf (preview helpers)', () => {
+  it('prefers the authored name, else prettifies the id (MeetingSelector rule)', () => {
+    expect(meetingDisplayName({ id: 'cmo_brand', name: 'CMO: Brand Crossroads' })).toBe(
+      'CMO: Brand Crossroads'
+    );
+    expect(meetingDisplayName({ id: 'brand_crossroads' })).toBe('Brand Crossroads');
+  });
+
+  it('returns short prompts untouched and truncates long ones at a word boundary', () => {
+    expect(snippetOf('Short prompt.')).toBe('Short prompt.');
+    const long = 'word '.repeat(40).trim();
+    const snippet = snippetOf(long);
+    expect(snippet.length).toBeLessThanOrEqual(MEETING_SNIPPET_MAX + 1); // +1 for the ellipsis
+    expect(snippet.endsWith('…')).toBe(true);
+    expect(snippet).not.toMatch(/\swor…$/); // no mid-word cut
+    expect(snippetOf(undefined)).toBe('');
+  });
+});

--- a/client/src/components/week-summary/AnticipationLine.tsx
+++ b/client/src/components/week-summary/AnticipationLine.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { TrendingUp, Minus } from 'lucide-react';
+import { anticipationMomentum } from '@/lib/releaseBuzz';
+import type { GameChange } from '@shared/types/gameTypes';
+
+/**
+ * Hype-board UX arc, Task 2 — weekly "Anticipation building" readout.
+ *
+ * Renders ONE 'pre_campaign' WeekSummary entry (the engine emits one per
+ * building release per week, with structured releaseName / weeksToLaunch /
+ * amount fields — buzz-v2 slice 3). Replaces the raw description line with a
+ * momentum readout: release name, a direction arrow, a qualitative band word
+ * from the week's applied gain, and the launch countdown.
+ *
+ * Fork E standing rule: strictly qualitative — the entry's raw awareness gain
+ * (`change.amount`) is NEVER rendered; only the derived direction + word are.
+ * Routing note: 'pre_campaign' entries land in the hypeRoutine bucket
+ * (categorizeChanges.ts), which WeekSummary DOES render — never the
+ * never-rendered `other` bucket (this repo's recurring swallow-bug class).
+ */
+export function AnticipationLine({ change }: { change: GameChange }) {
+  const momentum = anticipationMomentum((change as any).amount);
+  const releaseName = (change as any).releaseName as string | undefined;
+  const weeksToLaunch = (change as any).weeksToLaunch as number | undefined;
+  const Icon = momentum.direction === 'up' ? TrendingUp : Minus;
+
+  // Fall back to the engine's player-ready description if the structured
+  // fields are missing (tolerant-parse convention, mirrors categorizeChanges).
+  if (!releaseName) {
+    return (
+      <div
+        data-testid="anticipation-line"
+        className="p-3 rounded-[12px] border border-white/10 bg-surface-inner/40"
+      >
+        <span className="text-sm font-medium text-white/80">{change.description}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="anticipation-line"
+      className="flex items-center gap-3 p-3 rounded-[12px] border border-neon-cyan/20 bg-surface-inner/40"
+    >
+      <Icon
+        aria-label={momentum.direction === 'up' ? 'anticipation rising' : 'anticipation holding'}
+        className={`h-4 w-4 shrink-0 ${momentum.direction === 'up' ? 'text-neon-cyan' : 'text-text-muted'}`}
+      />
+      <div className="min-w-0">
+        <span className="text-sm font-medium text-white/80">
+          “{releaseName}” — anticipation {momentum.word}
+        </span>
+        {typeof weeksToLaunch === 'number' && (
+          <span className="ml-2 text-xs text-text-muted whitespace-nowrap">
+            {weeksToLaunch} week{weeksToLaunch === 1 ? '' : 's'} to launch
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/lib/releaseBuzz.ts
+++ b/client/src/lib/releaseBuzz.ts
@@ -126,6 +126,152 @@ export function summarizeBankedHype(flags: Record<string, any> | undefined | nul
   return { total, soonestWeek };
 }
 
+// ---------------------------------------------------------------------------
+// Hype-board UX arc (July 2026, playtest feedback) — per-pool banked-hype
+// surfacing. All DISPLAY-ONLY: these helpers re-read the SAME client-visible
+// flag fields summarizeBankedHype already reads (flags.pendingAwarenessBoost +
+// flags.hypeArtistPools) — no engine math is re-derived anywhere.
+// ---------------------------------------------------------------------------
+
+/**
+ * Qualitative strength band over banked hype units (display labels only —
+ * tuning these changes wording, never mechanics). HARDCODED display bands:
+ * meetings bank a few units at a time, so 6+ across pools reads as "strong".
+ */
+export const HYPE_STRENGTH_STRONG_MIN = 6;
+export const HYPE_STRENGTH_SOLID_MIN = 3;
+
+export type HypeStrengthBand = 'strong' | 'solid' | 'modest';
+
+export function hypeStrengthBand(amount: number): HypeStrengthBand | null {
+  if (typeof amount !== 'number' || amount <= 0) return null;
+  if (amount >= HYPE_STRENGTH_STRONG_MIN) return 'strong';
+  if (amount >= HYPE_STRENGTH_SOLID_MIN) return 'solid';
+  return 'modest';
+}
+
+/** One unattached banked-hype pool, named for display. */
+export interface BankedHypePool {
+  scope: 'label' | 'artist';
+  /** Present for artist pools. */
+  artistId?: string;
+  /** Display name — the artist's name from the roster cache, or 'Label'. */
+  name: string;
+  /** Signed pool amount (a negative pool suppresses discovery). */
+  amount: number;
+  /** Last-bank week the expiry countdown runs from, or null if undated. */
+  week: number | null;
+  /** week + BANKED_HYPE_EXPIRY_WEEKS, or null when undated (display mirror). */
+  fadesWeek: number | null;
+  /** Qualitative band for positive pools; null for zero/negative pools. */
+  strength: HypeStrengthBand | null;
+}
+
+/**
+ * List every nonzero unattached pool (label + per-artist) with display names.
+ * Reads the exact same flag fields as summarizeBankedHype — the two must stay
+ * consistent (the chip total is the sum of these pools' positive amounts).
+ * Unknown artist ids fall back to 'an artist' (name is cosmetic, never blocks).
+ */
+export function listBankedHypePools(
+  flags: Record<string, any> | undefined | null,
+  artistNameById: Record<string, string> = {}
+): BankedHypePool[] {
+  const pools: BankedHypePool[] = [];
+  const f = flags || {};
+  const toPool = (
+    scope: 'label' | 'artist',
+    name: string,
+    amount: unknown,
+    week: unknown,
+    artistId?: string
+  ): BankedHypePool | null => {
+    if (typeof amount !== 'number' || amount === 0) return null;
+    const stampedWeek = typeof week === 'number' ? week : null;
+    return {
+      scope,
+      ...(artistId ? { artistId } : {}),
+      name,
+      amount,
+      week: stampedWeek,
+      fadesWeek: stampedWeek === null ? null : stampedWeek + BANKED_HYPE_EXPIRY_WEEKS,
+      strength: hypeStrengthBand(amount),
+    };
+  };
+  const label = toPool('label', 'Label', f.pendingAwarenessBoost, f.pendingAwarenessBoostWeek);
+  if (label) pools.push(label);
+  if (f.hypeArtistPools && typeof f.hypeArtistPools === 'object') {
+    for (const [artistId, pool] of Object.entries(f.hypeArtistPools as Record<string, any>)) {
+      const entry = toPool(
+        'artist',
+        artistNameById[artistId] || 'an artist',
+        pool?.amount,
+        pool?.week,
+        artistId
+      );
+      if (entry) pools.push(entry);
+    }
+  }
+  return pools;
+}
+
+/**
+ * Task 1 (banked-hype preview at release planning) — which pools will attach
+ * to a release planned NOW for this artist. Mirrors the server attach rule
+ * (releasePlanningService: the selected artist's pool PLUS the entire label
+ * pool — first-planned takes all) for DISPLAY only; the server result
+ * (hypeApplied) stays the source of truth at confirm time. Qualitative
+ * strength band per the standing fork-E rule: a point value is fine, no
+ * multiplier numbers.
+ */
+export interface HypeAttachPreview {
+  /** The pools that will drain onto this release at plan time (nonzero only). */
+  pools: BankedHypePool[];
+  /** Signed sum across those pools (negative = suppression). */
+  total: number;
+  /** Band over the positive total, or null when total <= 0. */
+  strength: HypeStrengthBand | null;
+  /** True when the net attached hype is negative (suppresses starting Buzz). */
+  suppressed: boolean;
+}
+
+export function summarizeHypeAttachPreview(
+  flags: Record<string, any> | undefined | null,
+  artistId: string | null | undefined,
+  artistNameById: Record<string, string> = {}
+): HypeAttachPreview {
+  const all = listBankedHypePools(flags, artistNameById);
+  const pools = all.filter(
+    (p) => p.scope === 'label' || (artistId != null && p.artistId === artistId)
+  );
+  const total = pools.reduce((sum, p) => sum + p.amount, 0);
+  return {
+    pools,
+    total,
+    strength: hypeStrengthBand(total),
+    suppressed: total < 0,
+  };
+}
+
+/**
+ * Task 2 (weekly hype-build readout) — momentum band for a 'pre_campaign'
+ * WeekSummary entry. `amount` is the entry's applied awareness gain for the
+ * week (structured field on the engine's pre_campaign change); the band turns
+ * it into a direction + word so the rendered line stays qualitative — the raw
+ * gain number is NEVER rendered. HARDCODED display bands (wording only).
+ */
+export const ANTICIPATION_SURGE_MIN = 4;
+
+export function anticipationMomentum(amount: unknown): {
+  direction: 'up' | 'steady';
+  word: string;
+} {
+  const gain = typeof amount === 'number' ? amount : 0;
+  if (gain >= ANTICIPATION_SURGE_MIN) return { direction: 'up', word: 'surging' };
+  if (gain >= 1) return { direction: 'up', word: 'building' };
+  return { direction: 'steady', word: 'holding' };
+}
+
 /** Catalog-wide counts backing the MetricsDashboard core-status "Buzz" stat. */
 export interface CatalogBuzzStatus {
   /** Released songs in the building window (weeks 1-4 since release) with awareness > 0. */

--- a/client/src/pages/PlanReleasePage.tsx
+++ b/client/src/pages/PlanReleasePage.tsx
@@ -17,6 +17,7 @@ import { apiRequest } from '@/lib/queryClient';
 import GameLayout from '@/layouts/GameLayout';
 import { MusicCalendar } from '@/components/MusicCalendar';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { BankedHypeAttachPreview } from '@/components/BankedHypeAttachPreview';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import {
@@ -1436,6 +1437,17 @@ export default function PlanReleasePage() {
                 )}
               </section>
             )}
+
+            {/* Hype-board UX Task 1 — banked-hype attach preview. Shows BEFORE
+                confirm which pool(s) will drain onto this release at plan time
+                (selected artist's pool + entire label pool — mirrors the server
+                attach rule for display only; the server's hypeApplied stays the
+                source of truth). Renders nothing when no pool would attach. */}
+            <BankedHypeAttachPreview
+              flags={gameState?.flags as Record<string, any> | undefined}
+              artistId={selectedArtist || null}
+              artistNameById={Object.fromEntries(artists.map(a => [a.id, a.name]))}
+            />
 
             {/* Validation & Submit */}
             <section className="glass-panel chromatic-hairline p-5">

--- a/tests/client/ExecutiveCard.urgency-dot.test.tsx
+++ b/tests/client/ExecutiveCard.urgency-dot.test.tsx
@@ -2,9 +2,15 @@
  * Tier 2 (PR-2, Nes amendment 1) — urgency indicator on the exec card.
  *
  * `hasReactiveMeeting` shows a small dot/pulse signaling "something happened"
- * this week, WITHOUT revealing the meeting's content (no name/trigger text on
- * the card itself — that's the "why now" line's job once the player opens the
- * meeting). Suppressed when the exec is sitting out (no meeting to open).
+ * this week, WITHOUT revealing the reactive TRIGGER (the "why now" line stays
+ * a reveal-on-open payoff). Suppressed when the exec is sitting out (no
+ * meeting to open).
+ *
+ * Hype-board UX Task 4 (July 2026 playtest) revised the ORIGINAL "no meeting
+ * name on the card" stance: the strip's open state may now preview the waiting
+ * meeting's name + prompt snippet (ExecutiveCard.meetingPreview.test.tsx) —
+ * but the trigger/why-now copy still never leaks onto the card, which is what
+ * this file pins.
  */
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';

--- a/tests/client/anticipation-line.test.tsx
+++ b/tests/client/anticipation-line.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Hype-board UX Task 2 — weekly "Anticipation building" readout in WeekSummary
+ * (AnticipationLine renders 'pre_campaign' entries in the hypeRoutine bucket).
+ *
+ * Fork E standing rule: the entry's raw awareness gain (`amount`) is NEVER
+ * rendered — only the derived direction arrow + qualitative band word. The
+ * launch countdown (weeks) is the only number allowed.
+ *
+ * Never-rendered-'other'-bucket trap: hype-routing.test.ts already pins that
+ * 'pre_campaign' routes to hypeRoutine (a bucket WeekSummary renders); the
+ * routing re-assertion here keeps this file self-proving.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { AnticipationLine } from '@/components/week-summary/AnticipationLine';
+import { categorizeWeekChanges } from '@/components/week-summary/categorizeChanges';
+import type { GameChange } from '@shared/types/gameTypes';
+
+afterEach(() => cleanup());
+
+const entry = (overrides: Record<string, any> = {}): GameChange =>
+  ({
+    type: 'pre_campaign',
+    description: '📣 Anticipation building for "Neon Nights" — 3 weeks to launch',
+    amount: 7,
+    releaseId: 'r1',
+    releaseName: 'Neon Nights',
+    weeksToLaunch: 3,
+    ...overrides,
+  }) as GameChange;
+
+describe('AnticipationLine', () => {
+  it('renders the release name, a rising band word, and the launch countdown', () => {
+    render(<AnticipationLine change={entry()} />);
+    const line = screen.getByTestId('anticipation-line');
+    expect(line).toHaveTextContent('Neon Nights');
+    expect(line).toHaveTextContent('anticipation surging'); // amount 7 → surging band
+    expect(line).toHaveTextContent('3 weeks to launch');
+    expect(screen.getByLabelText('anticipation rising')).toBeInTheDocument();
+  });
+
+  it('NEVER renders the raw weekly gain number (fork E: qualitative only)', () => {
+    render(<AnticipationLine change={entry({ amount: 7 })} />);
+    const text = screen.getByTestId('anticipation-line').textContent!;
+    expect(text).not.toContain('7');
+    expect(text).not.toMatch(/[×x]\s*\d/);
+    expect(text).not.toMatch(/\+\d/);
+  });
+
+  it('shows a steady (holding) readout when the week applied no gain', () => {
+    render(<AnticipationLine change={entry({ amount: 0 })} />);
+    expect(screen.getByTestId('anticipation-line')).toHaveTextContent('anticipation holding');
+    expect(screen.getByLabelText('anticipation holding')).toBeInTheDocument();
+  });
+
+  it('uses the building band for a modest weekly gain', () => {
+    render(<AnticipationLine change={entry({ amount: 2 })} />);
+    expect(screen.getByTestId('anticipation-line')).toHaveTextContent('anticipation building');
+  });
+
+  it('falls back to the engine description when structured fields are missing', () => {
+    render(
+      <AnticipationLine
+        change={entry({ releaseName: undefined, weeksToLaunch: undefined })}
+      />
+    );
+    expect(screen.getByTestId('anticipation-line')).toHaveTextContent(
+      'Anticipation building for "Neon Nights"'
+    );
+  });
+
+  it("routes to a RENDERED bucket — 'pre_campaign' lands in hypeRoutine, never 'other'", () => {
+    const categories = categorizeWeekChanges([entry()]);
+    expect(categories.hypeRoutine).toHaveLength(1);
+    expect(categories.other).toEqual([]);
+  });
+});

--- a/tests/client/banked-hype-attach-preview.test.tsx
+++ b/tests/client/banked-hype-attach-preview.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Hype-board UX Task 1 — banked-hype attach preview on the release planning
+ * page (BankedHypeAttachPreview).
+ *
+ * The preview shows, BEFORE the confirm button, which pool(s) will drain onto
+ * the release at plan time (selected artist's pool + entire label pool —
+ * display mirror of the server attach rule; the server's hypeApplied stays
+ * authoritative). Fork E: qualitative strength band, point values allowed,
+ * NO multiplier numbers.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { BankedHypeAttachPreview } from '@/components/BankedHypeAttachPreview';
+
+afterEach(() => cleanup());
+
+const flags = {
+  pendingAwarenessBoost: 2,
+  pendingAwarenessBoostWeek: 5,
+  hypeArtistPools: {
+    a1: { amount: 4, week: 6 },
+    a2: { amount: 3, week: 7 },
+  },
+};
+const names = { a1: 'Nova Sterling', a2: 'Mars Vega' };
+
+describe('BankedHypeAttachPreview', () => {
+  it('lists the converting pools by name with point values and a strength headline', () => {
+    render(<BankedHypeAttachPreview flags={flags} artistId="a1" artistNameById={names} />);
+    const panel = screen.getByTestId('banked-hype-attach-preview');
+    const pools = screen.getAllByTestId('attach-preview-pool');
+    expect(pools).toHaveLength(2);
+    expect(panel).toHaveTextContent('Label pool');
+    expect(panel).toHaveTextContent('+2 Hype');
+    expect(panel).toHaveTextContent("Nova Sterling's pool");
+    expect(panel).toHaveTextContent('+4 Hype');
+    // 2 + 4 = 6 → strong band; qualitative headline, converts-at-plan wording.
+    expect(screen.getByTestId('attach-preview-headline')).toHaveTextContent(
+      "Banked buzz: strong — converts into this release's launch."
+    );
+  });
+
+  it("does NOT list another artist's pool (it stays banked)", () => {
+    render(<BankedHypeAttachPreview flags={flags} artistId="a1" artistNameById={names} />);
+    expect(screen.getByTestId('banked-hype-attach-preview')).not.toHaveTextContent('Mars Vega');
+  });
+
+  it('renders nothing when no pool would attach', () => {
+    render(<BankedHypeAttachPreview flags={{}} artistId="a1" artistNameById={names} />);
+    expect(screen.queryByTestId('banked-hype-attach-preview')).toBeNull();
+  });
+
+  it('renders nothing before an artist is selected', () => {
+    render(<BankedHypeAttachPreview flags={flags} artistId={null} artistNameById={names} />);
+    expect(screen.queryByTestId('banked-hype-attach-preview')).toBeNull();
+  });
+
+  it('marks a net-negative attachment as suppression (honesty, not a perk)', () => {
+    render(
+      <BankedHypeAttachPreview
+        flags={{ hypeArtistPools: { a2: { amount: -3, week: 4 } } }}
+        artistId="a2"
+        artistNameById={names}
+      />
+    );
+    expect(screen.getByTestId('attach-preview-headline')).toHaveTextContent('suppressed');
+    expect(screen.getByTestId('banked-hype-attach-preview')).toHaveTextContent('-3 Hype');
+  });
+
+  it('never leaks a multiplier number (fork E: qualitative only)', () => {
+    render(<BankedHypeAttachPreview flags={flags} artistId="a1" artistNameById={names} />);
+    expect(screen.getByTestId('banked-hype-attach-preview').textContent).not.toMatch(/[×x]\s*\d/);
+  });
+});

--- a/tests/client/buzz-status.test.tsx
+++ b/tests/client/buzz-status.test.tsx
@@ -20,7 +20,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { summarizeCatalogBuzz, summarizeBankedHype, SONG_BUZZ_TOOLTIP, BANKED_HYPE_EXPIRY_WEEKS, BANKED_HYPE_TOOLTIP } from '@/lib/releaseBuzz';
+import { summarizeCatalogBuzz, summarizeBankedHype, listBankedHypePools, SONG_BUZZ_TOOLTIP, BANKED_HYPE_EXPIRY_WEEKS, BANKED_HYPE_TOOLTIP } from '@/lib/releaseBuzz';
 import { BuzzStatusStat } from '@/components/MetricsDashboard';
 import { SongBuzzChip } from '@/components/SongCatalog';
 import { EFFECT_CHANNEL_DESCRIPTIONS } from '@shared/engine/processors/ActionProcessor';
@@ -187,39 +187,93 @@ describe('summarizeBankedHype (buzz-v2 slice 2 — chip aggregation)', () => {
   });
 });
 
-describe('BuzzStatusStat banked-hype chip (buzz-v2 slice 1)', () => {
-  it('renders "+N Hype banked · fades wk W" when a positive pool is banked', () => {
+describe('BuzzStatusStat banked-hype pools (hype-board UX Task 3 — re-pinned from the buzz-v2 slice 1 aggregate chip)', () => {
+  // Task 3 de-genericized the readout: named per-pool lines (label + artists)
+  // with per-pool expiry hints replace the single summed "+N Hype banked" chip.
+  const pools = (flags: any, names: Record<string, string> = {}) =>
+    listBankedHypePools(flags, names);
+
+  it('renders one named line per positive pool with its own fade hint', () => {
     render(
-      <BuzzStatusStat songs={[]} currentWeek={5} bankedHype={4} bankedHypeWeek={5} />
+      <BuzzStatusStat
+        songs={[]}
+        currentWeek={5}
+        pools={pools(
+          {
+            pendingAwarenessBoost: 2,
+            pendingAwarenessBoostWeek: 5,
+            hypeArtistPools: { a1: { amount: 3, week: 6 } },
+          },
+          { a1: 'Nova' }
+        )}
+      />
     );
     const chip = screen.getByTestId('banked-hype-chip');
-    expect(chip).toHaveTextContent('+4 Hype banked');
-    // Expiry week = stamped week + BANKED_HYPE_EXPIRY_WEEKS (mirrors the engine).
-    expect(chip).toHaveTextContent(`fades wk ${5 + BANKED_HYPE_EXPIRY_WEEKS}`);
+    const lines = screen.getAllByTestId('banked-hype-pool');
+    expect(lines).toHaveLength(2);
+    expect(chip).toHaveTextContent('+2 Hype — Label');
+    expect(chip).toHaveTextContent(`fading wk ${5 + BANKED_HYPE_EXPIRY_WEEKS} if unused`);
+    expect(chip).toHaveTextContent('+3 Hype — Nova');
+    expect(chip).toHaveTextContent(`fading wk ${6 + BANKED_HYPE_EXPIRY_WEEKS} if unused`);
     expect(chip).toHaveAttribute('aria-label', `Banked Hype: ${BANKED_HYPE_TOOLTIP}`);
   });
 
-  it('omits the countdown when the stamp week is unknown', () => {
-    render(<BuzzStatusStat songs={[]} currentWeek={5} bankedHype={2} bankedHypeWeek={null} />);
+  it('omits the fade hint when a pool cannot be dated', () => {
+    render(
+      <BuzzStatusStat songs={[]} currentWeek={5} pools={pools({ pendingAwarenessBoost: 2 })} />
+    );
     const chip = screen.getByTestId('banked-hype-chip');
-    expect(chip).toHaveTextContent('+2 Hype banked');
-    expect(chip).not.toHaveTextContent('fades wk');
+    expect(chip).toHaveTextContent('+2 Hype — Label');
+    expect(chip).not.toHaveTextContent('fading wk');
   });
 
-  it('renders no chip when nothing is banked', () => {
-    render(<BuzzStatusStat songs={[]} currentWeek={5} bankedHype={0} />);
+  it('renders no block when nothing is banked', () => {
+    render(<BuzzStatusStat songs={[]} currentWeek={5} pools={[]} />);
     expect(screen.queryByTestId('banked-hype-chip')).toBeNull();
   });
 
-  it('renders no chip for a negative pool (suppression is not advertised)', () => {
-    render(<BuzzStatusStat songs={[]} currentWeek={5} bankedHype={-3} bankedHypeWeek={5} />);
+  it('renders no line for a negative pool (suppression is not advertised)', () => {
+    render(
+      <BuzzStatusStat songs={[]} currentWeek={5} pools={pools({ pendingAwarenessBoost: -3, pendingAwarenessBoostWeek: 5 })} />
+    );
     expect(screen.queryByTestId('banked-hype-chip')).toBeNull();
   });
 
-  it('never leaks a multiplier number in the chip (fork E: qualitative only)', () => {
-    render(<BuzzStatusStat songs={[]} currentWeek={5} bankedHype={6} bankedHypeWeek={5} />);
+  it('never leaks a multiplier number (fork E: qualitative only)', () => {
+    render(
+      <BuzzStatusStat songs={[]} currentWeek={5} pools={pools({ pendingAwarenessBoost: 6, pendingAwarenessBoostWeek: 5 })} />
+    );
     expect(screen.getByTestId('banked-hype-chip').textContent).not.toMatch(/[×x]\s*\d/);
     expect(BANKED_HYPE_TOOLTIP).not.toMatch(/[×x]\s*\d/);
+  });
+});
+
+describe('BuzzStatusStat anticipation lines (hype-board UX Task 3)', () => {
+  it('names each planned release building anticipation with a strength word and launch week', () => {
+    render(
+      <BuzzStatusStat
+        songs={[]}
+        currentWeek={10}
+        anticipations={[
+          { releaseId: 'r1', title: 'Neon Nights', strength: 'strong', weeksToLaunch: 3 },
+          { releaseId: 'r2', title: 'Afterglow', strength: null, weeksToLaunch: 2 },
+        ]}
+      />
+    );
+    const lines = screen.getAllByTestId('anticipation-status-line');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toHaveTextContent('Neon Nights');
+    expect(lines[0]).toHaveTextContent('strong anticipation');
+    expect(lines[0]).toHaveTextContent('launches wk 13');
+    // No strength word yet (no pre-built awareness) -> plain building copy.
+    expect(lines[1]).toHaveTextContent('Afterglow');
+    expect(lines[1]).toHaveTextContent('anticipation building');
+    expect(lines[1]).toHaveTextContent('launches wk 12');
+  });
+
+  it('renders no anticipation lines when nothing is building', () => {
+    render(<BuzzStatusStat songs={[]} currentWeek={10} anticipations={[]} />);
+    expect(screen.queryByTestId('anticipation-status-line')).toBeNull();
   });
 });
 

--- a/tests/client/hype-board-helpers.test.ts
+++ b/tests/client/hype-board-helpers.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Hype-board UX arc — pure display helpers in lib/releaseBuzz.ts.
+ *
+ * listBankedHypePools / summarizeHypeAttachPreview read the SAME client-visible
+ * flag fields as summarizeBankedHype (flags.pendingAwarenessBoost +
+ * flags.hypeArtistPools) — the per-pool list and the aggregate chip total must
+ * stay consistent. hypeStrengthBand / anticipationMomentum are DISPLAY-ONLY
+ * qualitative bands (fork E standing rule: wording, never mechanics).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  listBankedHypePools,
+  summarizeHypeAttachPreview,
+  summarizeBankedHype,
+  hypeStrengthBand,
+  anticipationMomentum,
+  BANKED_HYPE_EXPIRY_WEEKS,
+  HYPE_STRENGTH_STRONG_MIN,
+  HYPE_STRENGTH_SOLID_MIN,
+} from '@/lib/releaseBuzz';
+
+const flags = {
+  pendingAwarenessBoost: 2,
+  pendingAwarenessBoostWeek: 5,
+  hypeArtistPools: {
+    a1: { amount: 3, week: 6 },
+    a2: { amount: -2, week: 4 },
+    a3: { amount: 0, week: 9 },
+  },
+};
+const names = { a1: 'Nova Sterling', a2: 'Mars Vega' };
+
+describe('hypeStrengthBand', () => {
+  it('bands positive amounts and returns null otherwise', () => {
+    expect(hypeStrengthBand(HYPE_STRENGTH_STRONG_MIN)).toBe('strong');
+    expect(hypeStrengthBand(HYPE_STRENGTH_SOLID_MIN)).toBe('solid');
+    expect(hypeStrengthBand(1)).toBe('modest');
+    expect(hypeStrengthBand(0)).toBeNull();
+    expect(hypeStrengthBand(-4)).toBeNull();
+  });
+});
+
+describe('listBankedHypePools', () => {
+  it('lists label + nonzero artist pools with display names and fade weeks', () => {
+    const pools = listBankedHypePools(flags, names);
+    expect(pools).toHaveLength(3); // label, a1, a2 (a3 is zero → dropped)
+    const label = pools.find((p) => p.scope === 'label')!;
+    expect(label).toMatchObject({
+      name: 'Label',
+      amount: 2,
+      week: 5,
+      fadesWeek: 5 + BANKED_HYPE_EXPIRY_WEEKS,
+      strength: 'modest',
+    });
+    const nova = pools.find((p) => p.artistId === 'a1')!;
+    expect(nova).toMatchObject({
+      scope: 'artist',
+      name: 'Nova Sterling',
+      amount: 3,
+      fadesWeek: 6 + BANKED_HYPE_EXPIRY_WEEKS,
+      strength: 'solid',
+    });
+    // Negative pool is listed (attach-preview honesty) but has no strength band.
+    const mars = pools.find((p) => p.artistId === 'a2')!;
+    expect(mars).toMatchObject({ amount: -2, strength: null });
+  });
+
+  it('falls back to "an artist" for ids missing from the roster cache', () => {
+    const pools = listBankedHypePools(flags, {});
+    expect(pools.find((p) => p.artistId === 'a1')!.name).toBe('an artist');
+  });
+
+  it('handles undated pools (null week and fadesWeek)', () => {
+    const pools = listBankedHypePools({ pendingAwarenessBoost: 4 });
+    expect(pools[0]).toMatchObject({ week: null, fadesWeek: null });
+  });
+
+  it('returns [] for empty/missing flags', () => {
+    expect(listBankedHypePools({})).toEqual([]);
+    expect(listBankedHypePools(undefined)).toEqual([]);
+    expect(listBankedHypePools(null)).toEqual([]);
+  });
+
+  it('stays consistent with the summarizeBankedHype chip total (positive pools)', () => {
+    const pools = listBankedHypePools(flags, names);
+    const positiveSum = pools.filter((p) => p.amount > 0).reduce((s, p) => s + p.amount, 0);
+    expect(positiveSum).toBe(summarizeBankedHype(flags).total);
+  });
+});
+
+describe('summarizeHypeAttachPreview (Task 1 — plan-time attach preview)', () => {
+  it('includes the selected artist pool + the entire label pool (server attach rule)', () => {
+    const preview = summarizeHypeAttachPreview(flags, 'a1', names);
+    expect(preview.pools.map((p) => p.scope).sort()).toEqual(['artist', 'label']);
+    expect(preview.total).toBe(5); // 2 label + 3 artist
+    expect(preview.strength).toBe('solid');
+    expect(preview.suppressed).toBe(false);
+  });
+
+  it("excludes OTHER artists' pools (they stay banked)", () => {
+    const preview = summarizeHypeAttachPreview(flags, 'a1', names);
+    expect(preview.pools.some((p) => p.artistId === 'a2')).toBe(false);
+  });
+
+  it('label pool alone attaches for an artist with no pool of their own', () => {
+    const preview = summarizeHypeAttachPreview(flags, 'a-none', names);
+    expect(preview.pools).toHaveLength(1);
+    expect(preview.pools[0].scope).toBe('label');
+    expect(preview.total).toBe(2);
+  });
+
+  it('flags net-negative attachments as suppressed (no strength band)', () => {
+    const preview = summarizeHypeAttachPreview(
+      { hypeArtistPools: { a2: { amount: -2, week: 4 } } },
+      'a2',
+      names
+    );
+    expect(preview.suppressed).toBe(true);
+    expect(preview.strength).toBeNull();
+  });
+
+  it('returns no pools when nothing is banked', () => {
+    expect(summarizeHypeAttachPreview({}, 'a1').pools).toEqual([]);
+    expect(summarizeHypeAttachPreview(undefined, 'a1').total).toBe(0);
+  });
+});
+
+describe('anticipationMomentum (Task 2 — weekly readout band)', () => {
+  it('bands the weekly applied gain into direction + word', () => {
+    expect(anticipationMomentum(6)).toEqual({ direction: 'up', word: 'surging' });
+    expect(anticipationMomentum(4)).toEqual({ direction: 'up', word: 'surging' });
+    expect(anticipationMomentum(2)).toEqual({ direction: 'up', word: 'building' });
+    expect(anticipationMomentum(1)).toEqual({ direction: 'up', word: 'building' });
+    expect(anticipationMomentum(0)).toEqual({ direction: 'steady', word: 'holding' });
+  });
+
+  it('tolerates missing amounts (malformed entry counts as holding)', () => {
+    expect(anticipationMomentum(undefined)).toEqual({ direction: 'steady', word: 'holding' });
+  });
+});


### PR DESCRIPTION
## Summary
Client-only UX arc from the structured playtest feedback (all four "sings-but" asks):
1. **Banked-hype attach preview** on PlanReleasePage — which pools convert + qualitative strength, before you confirm (display mirror of the server's fork-B attach rule; server stays authoritative).
2. **Weekly anticipation readout** in WeekSummary for building pre-campaigns (qualitative bands + arrows; raw gains test-pinned to never render; 'other'-bucket routing proven).
3. **Dashboard hype de-genericized** — named per-artist pools with expiry hints + per-planned-release anticipation lines.
4. **The Board previews the waiting brief** — meeting name + prompt snippet on open channels, zero new requests (piggybacks the sit-out/urgency prefetch). Revises the Tier 2 "no name on card" stance; the why-now trigger still reveals only on open (test-pinned).

## Verification
- tsc clean; suite **1,784/1,784** (baseline 1,748 → +36).
- `git diff main.. -- shared server data migrations` empty — no engine/server/GM surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
