### PR TITLE
feat: mandatory side events — crisis lands next week, occupies a focus slot, gates the advance

### DIFF
--- a/client/src/admin/systemsMapData.ts
+++ b/client/src/admin/systemsMapData.ts
@@ -197,6 +197,14 @@ export const NODES: SystemNode[] = [
     row: 2,
     description: `A never-expiring pool, incremented by meeting choices (ActionProcessor.ts:1091). At campaign end: chance = min(${reputationSystem.award_chance_cap}, pool × ${reputationSystem.award_chance_per_point}) (progression.json award_chance_per_point / award_chance_cap), win adds +${reputationSystem.award_score_bonus} to the campaign score (progression.json award_score_bonus) via an isolated seeded roll — AchievementsEngine.ts:66-73. The score itself is a campaign-end abstraction with no dedicated system node, so this is not modeled as an edge.`,
   },
+  {
+    id: 'side_events',
+    label: 'Side Events (Crisis)',
+    domain: 'meetings',
+    col: 1,
+    row: 3,
+    description: `A weekly seeded roll (weekly_chance in data/balance/events.json side_events, currently 20%) draws a side event in-stream — game-engine.ts checkForEvents, the fixed C64 stream position (never moved/reordered). MANDATORY mode (data/balance/events.json mandatory_side_events.enabled, default true): the rolled event is DEFERRED — stored on flags.pending_side_event and surfaced the FOLLOWING week as a crisis card that consumes ONE focus slot (threaded like arOfficeSlotUsed through the manual UI + AUTO), blocking the advance until the player picks. Its chosen effects apply DURING that week's advance (game-engine.ts processPendingSideEventResolution → ActionProcessor.applyEffects for immediate, delayed banked triggerWeek+1). One crisis at a time (a roll while one is pending still draws but discards). Kill-switch OFF restores the legacy in-results interactive beat (resolved via POST /api/game/:id/side-event-choice, lapses if unresolved). Cooldown event_cooldown weeks per event; category weights in event_weights.`,
+  },
 
   // Artist
   {

--- a/client/src/components/CrisisSideEventCard.tsx
+++ b/client/src/components/CrisisSideEventCard.tsx
@@ -1,0 +1,114 @@
+/**
+ * Mandatory Side Events ("Crisis on the Desk") — the crisis card.
+ *
+ * Rendered in the action-selection UI (SelectionSummary) when a side event is
+ * pending. It occupies ONE focus slot and is MANDATORY: no dismiss control. The
+ * player must pick how to handle it before the week can advance.
+ *
+ * Deliberately distinct from executive meeting cards — this is the world landing
+ * on the player's desk, not an exec's agenda: urgent in-world copy, a
+ * negative/magenta alert palette, an alert glyph. v2 tokens throughout.
+ */
+import { AlertTriangle, Check } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useGameStore } from '@/store/gameStore';
+import { ChoiceEffects } from './executive-meetings/DialogueInterface';
+import type { SideEventCategory } from '@shared/types/gameTypes';
+import type { PendingCrisis } from '@/hooks/useCrisisSideEvent';
+
+const CATEGORY_LABEL: Record<SideEventCategory, string> = {
+  sync_licensing: 'Sync Licensing',
+  copyright_issues: 'Copyright Issue',
+  platform_opportunities: 'Platform Opportunity',
+  industry_drama: 'Industry Drama',
+  technical_problems: 'Technical Problem',
+  business_opportunities: 'Business Opportunity',
+  artist_personal: 'Artist Moment',
+};
+
+interface CrisisSideEventCardProps {
+  crisis: PendingCrisis;
+  chosenChoiceId: string | null;
+  /** Position label for the occupied focus slot (e.g. the slot number). */
+  slotNumber?: number;
+}
+
+export function CrisisSideEventCard({ crisis, chosenChoiceId, slotNumber }: CrisisSideEventCardProps) {
+  const setSideEventChoice = useGameStore((s) => s.setSideEventChoice);
+  const choices = crisis.choices ?? [];
+  const categoryLabel = crisis.category ? CATEGORY_LABEL[crisis.category] : 'Crisis';
+
+  return (
+    <div className="relative overflow-hidden rounded-card border border-negative/40 bg-gradient-to-br from-negative/[0.10] to-neon-magenta/[0.06] p-4">
+      {/* urgent hairline */}
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-negative/70 to-transparent"
+        aria-hidden
+      />
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {slotNumber != null && (
+            <div className="flex h-8 w-8 items-center justify-center rounded-button bg-gradient-to-br from-negative to-neon-magenta font-mono text-sm font-bold text-white">
+              {slotNumber}
+            </div>
+          )}
+          <span className="flex items-center gap-1.5 font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-negative">
+            <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+            On Your Desk
+          </span>
+        </div>
+        <Badge variant="outline" className="rounded-pill border-negative/40 font-mono text-[10px] text-negative">
+          {categoryLabel}
+        </Badge>
+      </div>
+
+      <p className="mt-3 text-sm font-medium text-white/90">
+        {crisis.prompt ? `Landed on your desk: ${crisis.prompt}` : 'A crisis has landed on your desk.'}
+      </p>
+      <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-text-muted">
+        Handling this takes the whole week — it costs one focus slot. Choose before you advance.
+      </p>
+
+      <div className="mt-3 space-y-2">
+        {choices.map((choice) => {
+          const isChosen = chosenChoiceId === choice.id;
+          return (
+            <div
+              key={choice.id}
+              className={`rounded-[12px] border p-3 transition-all ${
+                isChosen
+                  ? 'border-positive/40 bg-positive/[0.07]'
+                  : 'border-white/10 bg-surface-inner/40'
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium text-white/90">{choice.label}</span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setSideEventChoice(crisis.eventId, choice.id)}
+                  className={
+                    isChosen
+                      ? 'shrink-0 border-positive/50 text-positive hover:bg-positive/10'
+                      : 'shrink-0 border-negative/40 text-negative hover:bg-negative/10'
+                  }
+                >
+                  {isChosen ? (
+                    <>
+                      <Check className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                      Chosen
+                    </>
+                  ) : (
+                    'Choose'
+                  )}
+                </Button>
+              </div>
+              <ChoiceEffects choice={choice} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/GameHeader.tsx
+++ b/client/src/components/GameHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useLocation } from 'wouter';
 import { useGameStore } from '@/store/gameStore';
 import { useGameState } from '@/hooks/useGameState';
+import { useCrisisSideEvent } from '@/hooks/useCrisisSideEvent';
 import { toast } from '@/hooks/use-toast';
 import logger from '@/lib/logger';
 import { getWeekDateRange } from '@shared/utils/seasonalCalculations';
@@ -19,6 +20,7 @@ import { WeekTransition } from '@/components/WeekTransition';
  */
 export function GameHeader() {
   const gameState = useGameState();
+  const crisis = useCrisisSideEvent();
   const { selectedActions, isAdvancingWeek, advanceWeek } = useGameStore();
   const pendingAutoSelectIntent = useGameStore((s) => s.pendingAutoSelectIntent);
   const setPendingAutoSelectIntent = useGameStore(
@@ -31,8 +33,10 @@ export function GameHeader() {
     return null;
   }
 
+  // Mandatory Side Events ("Crisis on the Desk"): a pending crisis consumes one
+  // focus slot, so AUTO has one fewer slot to fill.
   const freeFocusSlots =
-    (gameState.focusSlots || 3) - (gameState.usedFocusSlots || 0);
+    (gameState.focusSlots || 3) - (gameState.usedFocusSlots || 0) - crisis.crisisSlotUsed;
 
   /**
    * C74: route the header AUTO button through the SAME propose-then-confirm review
@@ -118,7 +122,9 @@ export function GameHeader() {
         <button
           type="button"
           onClick={handleAdvanceWeek}
-          disabled={selectedActions.length === 0 || isAdvancingWeek}
+          // Mandatory Side Events: block while a crisis is unresolved; allow a
+          // crisis-only advance (crisis picked, zero meeting actions).
+          disabled={isAdvancingWeek || crisis.blocksAdvance || (selectedActions.length === 0 && !crisis.crisisActive)}
           className={`relative flex w-full items-center justify-center gap-2 overflow-hidden rounded-button bg-gradient-to-br from-action-pink to-action-purple px-4 py-1.5 text-[13px] font-semibold text-white shadow-action transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50${
             isCharging ? ' animate-pulse [animation-duration:1.6s]' : ''
           }`}

--- a/client/src/components/SelectionSummary.tsx
+++ b/client/src/components/SelectionSummary.tsx
@@ -9,6 +9,8 @@ import { TrendingUp, TrendingDown, Clock, Zap, BarChart3, X, Rocket, Loader2, Se
 import logger from '@/lib/logger';
 import { LIVE_EFFECT_KEYS } from '@shared/engine/processors/ActionProcessor';
 import { EffectBadgeTooltip } from '@/components/executive-meetings/EffectBadgeTooltip';
+import { useCrisisSideEvent } from '@/hooks/useCrisisSideEvent';
+import { CrisisSideEventCard } from '@/components/CrisisSideEventCard';
 
 // Badge honesty (exec-meetings-revival PR-2): same whitelist as DialogueInterface —
 // only render a badge for a key the engine actually implements, or 'executive_mood'
@@ -99,7 +101,11 @@ export function SelectionSummary({
   const { cancelAROfficeOperation } = useGameStore();
   const gameState = useGameState();
   const totalSlots = gameState?.focusSlots || 3;
-  const usedSlots = gameState?.usedFocusSlots || 0;
+  // Mandatory Side Events ("Crisis on the Desk"): a pending crisis occupies one
+  // focus slot on top of selectedActions + the A&R slot. Fold it into the used
+  // count so the slot UI, the badge, and "remaining" all read correctly.
+  const crisis = useCrisisSideEvent();
+  const usedSlots = (gameState?.usedFocusSlots || 0) + crisis.crisisSlotUsed;
   const availableSlots = totalSlots - usedSlots;
 
   logger.debug('SelectionSummary - selectedActions:', selectedActions);
@@ -220,7 +226,7 @@ export function SelectionSummary({
     }
   });
 
-  const filledSlotsCount = selectedActionObjects.length + (arOfficeActive ? 1 : 0);
+  const filledSlotsCount = selectedActionObjects.length + (arOfficeActive ? 1 : 0) + crisis.crisisSlotUsed;
   const progress = (usedSlots / totalSlots) * 100;
 
   const handleDragEnd = (result: any) => {
@@ -335,6 +341,16 @@ export function SelectionSummary({
                     </div>
                   )}
 
+                  {crisis.crisisActive && crisis.crisis && (
+                    <div className="flex-1 min-w-[260px]">
+                      <CrisisSideEventCard
+                        crisis={crisis.crisis}
+                        chosenChoiceId={crisis.chosenChoiceId}
+                        slotNumber={selectedActionObjects.length + (arOfficeActive ? 1 : 0) + 1}
+                      />
+                    </div>
+                  )}
+
                   {/* Empty slots */}
                   {Array.from({ length: Math.max(0, totalSlots - filledSlotsCount) }).map((_, index) => (
                     <div
@@ -417,9 +433,14 @@ export function SelectionSummary({
 
         {/* Advance Week Button */}
         <div className="space-y-3">
+          {crisis.blocksAdvance && (
+            <p className="text-xs text-negative font-medium text-center">
+              A crisis is on your desk — choose how to handle it before advancing.
+            </p>
+          )}
           <Button
             onClick={onAdvanceWeek}
-            disabled={(selectedActions.length === 0 && !arOfficeActive) || isAdvancing}
+            disabled={(selectedActions.length === 0 && !arOfficeActive && !crisis.crisisActive) || crisis.blocksAdvance || isAdvancing}
             className="relative overflow-hidden w-full rounded-button bg-gradient-to-br from-action-pink to-action-purple text-white hover:opacity-90 py-3 font-semibold shadow-action"
             size="lg"
           >

--- a/client/src/components/WeekSummary.tsx
+++ b/client/src/components/WeekSummary.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { TrendingUp, TrendingDown, DollarSign, Music, Trophy, Zap, X, BarChart3, Unlock, Users, Sparkles, Check, Clock3, Flame } from 'lucide-react';
+import { TrendingUp, TrendingDown, DollarSign, Music, Trophy, Zap, X, BarChart3, Unlock, Users, Sparkles, Check, Clock3, Flame, AlertTriangle } from 'lucide-react';
 import { ChartPerformanceCard } from './ChartPerformanceCard';
 import { AnimatedNumber } from './motion-primitives/animated-number';
 import { GlowEffect } from './motion-primitives/glow-effect';
@@ -278,6 +278,69 @@ export function SideEventBeat({ event, gameId, isPendingOnSpine }: SideEventBeat
   );
 }
 
+/**
+ * Mandatory Side Events ("Crisis on the Desk"): the RESOLVED beat. When a crisis
+ * is handled during a week's advance, the engine emits an EventOccurrence with
+ * `resolved: true`, the chosen label, and the applied effect maps. This renders
+ * "You spent the week handling: <event>" in place of the old interactive UI.
+ */
+function ResolvedCrisisBeat({ event }: { event: EventOccurrence }) {
+  const effects = event.effects || {};
+  const delayed = event.delayedEffects || {};
+  const renderable = (entries: Record<string, number>) =>
+    Object.entries(entries).filter(
+      ([key, value]) => typeof value === 'number' && value !== 0 && LIVE_EFFECT_KEYS.has(key)
+    );
+  const immediateBadges = renderable(effects);
+  const delayedBadges = renderable(delayed);
+
+  return (
+    <Card className="relative overflow-hidden border-negative/40">
+      <GlowEffect
+        mode="pulse"
+        blur="stronger"
+        colors={['#ff4fd8', '#f43f5e', '#a855f7']}
+        className="opacity-[0.10]"
+      />
+      <CardHeader className="relative">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <AlertTriangle className="h-4 w-4 text-negative" aria-hidden="true" />
+          <span className="text-aberration font-bold uppercase tracking-wide">Crisis Handled</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="relative space-y-3">
+        <p className="text-sm font-medium text-white/90">
+          You spent the week handling: {event.prompt || event.title}
+        </p>
+        {event.choiceLabel && (
+          <div className="flex items-center gap-2 text-xs font-mono uppercase tracking-[0.15em] text-negative">
+            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>You chose: {event.choiceLabel}</span>
+          </div>
+        )}
+        {(immediateBadges.length > 0 || delayedBadges.length > 0) && (
+          <div className="flex flex-wrap gap-1">
+            {immediateBadges.map(([key, value]) => (
+              <EffectBadgeTooltip key={`i-${key}`} effectKey={key}>
+                <Badge variant="outline" className="text-xs font-mono rounded-pill text-neon-cyan border-neon-cyan/40">
+                  {value > 0 ? '+' : ''}{value} {key.replace(/_/g, ' ')}
+                </Badge>
+              </EffectBadgeTooltip>
+            ))}
+            {delayedBadges.map(([key, value]) => (
+              <EffectBadgeTooltip key={`d-${key}`} effectKey={key}>
+                <Badge variant="outline" className="text-xs font-mono rounded-pill text-neon-lilac border-neon-lilac/40">
+                  {value > 0 ? '+' : ''}{value} {key.replace(/_/g, ' ')} (next wk)
+                </Badge>
+              </EffectBadgeTooltip>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // --- Meetings card formatting (exec-meetings-revival PR-2) -----------------
 // Module scope: pure formatting helpers, no reason to redefine per render.
 
@@ -490,6 +553,14 @@ export function WeekSummary({ weeklyStats, onAdvanceWeek, isAdvancing, isWeekRes
     pendingSideEvent.week === weeklyStats?.week
   );
 
+  // Mandatory Side Events ("Crisis on the Desk"): a crisis RESOLVED during this
+  // advance is emitted as a resolved beat (occurred + resolved), replacing the
+  // legacy interactive choice UI. "You spent the week handling: <event>".
+  const resolvedSideEvent = useMemo(
+    () => (weeklyStats?.events || []).find((e) => (e as any).resolved),
+    [weeklyStats?.events]
+  );
+
   // HERO moments now live IN the modal (fixing the missable-toast gap):
   //  - tier/access unlocks (always hero per the changeImportance classifier)
   //  - No. 1 chart outcomes (debut at #1 or climb to #1)
@@ -587,7 +658,7 @@ export function WeekSummary({ weeklyStats, onAdvanceWeek, isAdvancing, isWeekRes
     setActiveTab(value as 'overview' | 'charts' | 'projects');
   };
 
-  const hasResults = isWeekResults && (changes.length > 0 || playerChartUpdates.length > 0 || !!sideEventOccurrence);
+  const hasResults = isWeekResults && (changes.length > 0 || playerChartUpdates.length > 0 || !!sideEventOccurrence || !!resolvedSideEvent);
 
   const overviewBody = (
     <div className="space-y-6">
@@ -603,6 +674,12 @@ export function WeekSummary({ weeklyStats, onAdvanceWeek, isAdvancing, isWeekRes
             gameId={gameId ?? null}
             isPendingOnSpine={isSideEventPendingOnSpine}
           />
+        </RevealGroup>
+      )}
+
+      {resolvedSideEvent && (
+        <RevealGroup revealed={currentStage >= STAGE_HERO} instant={instant}>
+          <ResolvedCrisisBeat event={resolvedSideEvent} />
         </RevealGroup>
       )}
 

--- a/client/src/components/__tests__/SelectionSummary.tooltip.test.tsx
+++ b/client/src/components/__tests__/SelectionSummary.tooltip.test.tsx
@@ -28,6 +28,20 @@ vi.mock('@/hooks/useGameState', () => ({
   useGameState: () => ({ focusSlots: 3, usedFocusSlots: 1, arOfficeSlotUsed: false }),
 }));
 
+// Mandatory Side Events: SelectionSummary now reads the crisis-slot derivation
+// (which hits a TanStack query). Rendered here without a QueryClientProvider, so
+// stub the hook to the inert "no crisis" default.
+vi.mock('@/hooks/useCrisisSideEvent', () => ({
+  useCrisisSideEvent: () => ({
+    crisisActive: false,
+    crisis: null,
+    choicePicked: false,
+    chosenChoiceId: null,
+    crisisSlotUsed: 0,
+    blocksAdvance: false,
+  }),
+}));
+
 // @hello-pangea/dnd reads a global React; stub the drag-drop primitives to plain
 // pass-throughs so the render doesn't depend on DnD internals (irrelevant to the
 // Impact Preview badges under test).

--- a/client/src/components/__tests__/WeekSummary.sideEventBeat.test.tsx
+++ b/client/src/components/__tests__/WeekSummary.sideEventBeat.test.tsx
@@ -241,3 +241,56 @@ describe('WeekSummary side-event beat', () => {
     expect(screen.queryByRole('button', { name: 'Choose' })).not.toBeInTheDocument();
   });
 });
+
+describe('WeekSummary — Mandatory Side Events resolved beat ("Crisis Handled")', () => {
+  beforeEach(() => {
+    mockResolveSideEvent.mockReset();
+    mockInvalidateQueries.mockReset();
+    mockUseGameState.mockReset();
+  });
+  afterEach(() => {
+    mockUseReducedMotion.mockReturnValue(true);
+    vi.clearAllMocks();
+  });
+
+  it('renders "You spent the week handling: …" with the chosen label and effect badges for a resolved event', () => {
+    const resolved: EventOccurrence = {
+      id: 'gm_crisis',
+      title: 'Catalog deal',
+      occurred: true,
+      resolved: true,
+      category: 'business_opportunities',
+      prompt: 'A distributor offers a risky catalog deal.',
+      choiceId: 'accept',
+      choiceLabel: 'Take the deal',
+      effects: { money: 12000 },
+      delayedEffects: { reputation: 2 },
+    };
+    renderSummary([resolved]);
+
+    expect(screen.getByText('Crisis Handled')).toBeInTheDocument();
+    expect(
+      screen.getByText(/You spent the week handling: A distributor offers a risky catalog deal\./)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/You chose: Take the deal/)).toBeInTheDocument();
+    // Immediate + delayed effect badges (both whitelisted keys).
+    expect(screen.getByText(/\+12000 money/)).toBeInTheDocument();
+    expect(screen.getByText(/\+2 reputation \(next wk\)/)).toBeInTheDocument();
+  });
+
+  it('does not render the interactive beat for a mandatory occurrence that carries no choices', () => {
+    // Mandatory deferral: the fresh occurrence has NO choices (handled next week
+    // by the crisis card), so the legacy interactive beat must not appear.
+    const deferred: EventOccurrence = {
+      id: 'gm_crisis',
+      title: 'Catalog deal',
+      occurred: true,
+      category: 'business_opportunities',
+      prompt: 'A distributor offers a risky catalog deal.',
+    };
+    renderSummary([deferred]);
+
+    expect(screen.queryByText('And Then...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Crisis Handled')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/hooks/__tests__/useCrisisSideEvent.test.ts
+++ b/client/src/hooks/__tests__/useCrisisSideEvent.test.ts
@@ -1,0 +1,88 @@
+/**
+ * useCrisisSideEvent — Mandatory Side Events ("Crisis on the Desk") derivation.
+ *
+ * The slot-occupation and advance-gate math threads through the whole
+ * action-selection UI, so it is pinned here at the source. Mocks the three
+ * inputs the hook composes: the kill-switch, the spine's pending flag, and the
+ * store's picked resolution.
+ */
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockConfig, mockGameState, mockStorePick } = vi.hoisted(() => ({
+  mockConfig: vi.fn(),
+  mockGameState: vi.fn(),
+  mockStorePick: vi.fn(),
+}));
+
+vi.mock('@/hooks/useSideEventsConfig', () => ({
+  useSideEventsConfig: () => mockConfig(),
+}));
+vi.mock('@/hooks/useGameState', () => ({
+  useGameState: (selector?: (gs: unknown) => unknown) => {
+    const gs = mockGameState();
+    return selector ? selector(gs) : gs;
+  },
+}));
+vi.mock('@/store/gameStore', () => ({
+  useGameStore: (selector?: (s: unknown) => unknown) => {
+    const state = { pendingSideEventChoice: mockStorePick() };
+    return selector ? selector(state) : state;
+  },
+}));
+
+import { useCrisisSideEvent } from '../useCrisisSideEvent';
+
+const CRISIS = { eventId: 'sync_offer', week: 5, prompt: 'x', category: 'sync_licensing', choices: [] };
+
+describe('useCrisisSideEvent', () => {
+  beforeEach(() => {
+    mockConfig.mockReturnValue({ mandatory: true });
+    mockGameState.mockReturnValue({ flags: {} });
+    mockStorePick.mockReturnValue(null);
+  });
+
+  it('no crisis: inert (no slot, no block) when nothing is pending', () => {
+    const { result } = renderHook(() => useCrisisSideEvent());
+    expect(result.current.crisisActive).toBe(false);
+    expect(result.current.crisisSlotUsed).toBe(0);
+    expect(result.current.blocksAdvance).toBe(false);
+  });
+
+  it('pending crisis, no pick: occupies a slot AND blocks the advance', () => {
+    mockGameState.mockReturnValue({ flags: { pending_side_event: CRISIS } });
+    const { result } = renderHook(() => useCrisisSideEvent());
+    expect(result.current.crisisActive).toBe(true);
+    expect(result.current.crisisSlotUsed).toBe(1);
+    expect(result.current.blocksAdvance).toBe(true);
+    expect(result.current.choicePicked).toBe(false);
+  });
+
+  it('pending crisis WITH a matching pick: still occupies the slot but no longer blocks', () => {
+    mockGameState.mockReturnValue({ flags: { pending_side_event: CRISIS } });
+    mockStorePick.mockReturnValue({ eventId: 'sync_offer', choiceId: 'take_deal' });
+    const { result } = renderHook(() => useCrisisSideEvent());
+    expect(result.current.crisisActive).toBe(true);
+    expect(result.current.crisisSlotUsed).toBe(1);
+    expect(result.current.choicePicked).toBe(true);
+    expect(result.current.chosenChoiceId).toBe('take_deal');
+    expect(result.current.blocksAdvance).toBe(false);
+  });
+
+  it('kill-switch OFF: a pending flag is ignored (legacy in-results path)', () => {
+    mockConfig.mockReturnValue({ mandatory: false });
+    mockGameState.mockReturnValue({ flags: { pending_side_event: CRISIS } });
+    const { result } = renderHook(() => useCrisisSideEvent());
+    expect(result.current.crisisActive).toBe(false);
+    expect(result.current.crisisSlotUsed).toBe(0);
+    expect(result.current.blocksAdvance).toBe(false);
+  });
+
+  it('a pick for a DIFFERENT event does not count as resolving the current crisis', () => {
+    mockGameState.mockReturnValue({ flags: { pending_side_event: CRISIS } });
+    mockStorePick.mockReturnValue({ eventId: 'other_event', choiceId: 'x' });
+    const { result } = renderHook(() => useCrisisSideEvent());
+    expect(result.current.choicePicked).toBe(false);
+    expect(result.current.blocksAdvance).toBe(true);
+  });
+});

--- a/client/src/hooks/useCrisisSideEvent.ts
+++ b/client/src/hooks/useCrisisSideEvent.ts
@@ -1,0 +1,56 @@
+/**
+ * Mandatory Side Events ("Crisis on the Desk") — client derivation.
+ *
+ * Reads the pending crisis off the gameState spine (`flags.pending_side_event`),
+ * the kill-switch (`useSideEventsConfig`), and the player's picked resolution
+ * (store `pendingSideEventChoice`) and returns the derived slot/gate state every
+ * consumer needs. A pending crisis ALWAYS occupies one focus slot while
+ * unresolved-on-the-server (picking a choice does not free the slot — it only
+ * satisfies the advance gate).
+ */
+import { useGameState } from '@/hooks/useGameState';
+import { useGameStore } from '@/store/gameStore';
+import { useSideEventsConfig } from '@/hooks/useSideEventsConfig';
+import type { EventChoice, SideEventCategory } from '@shared/types/gameTypes';
+
+export interface PendingCrisis {
+  eventId: string;
+  week: number;
+  prompt?: string;
+  category?: SideEventCategory;
+  choices?: EventChoice[];
+}
+
+export interface CrisisSideEventState {
+  /** Kill-switch is on AND a crisis is pending on the spine. */
+  crisisActive: boolean;
+  /** The pending crisis payload (richer shape carries prompt/category/choices). */
+  crisis: PendingCrisis | null;
+  /** Player has picked a resolution for THIS crisis this session. */
+  choicePicked: boolean;
+  /** The picked choiceId (matching this crisis), or null. */
+  chosenChoiceId: string | null;
+  /** Extra focus slot consumed by the crisis (0 or 1). */
+  crisisSlotUsed: number;
+  /** Advance must be blocked: crisis active but no resolution picked yet. */
+  blocksAdvance: boolean;
+}
+
+export function useCrisisSideEvent(): CrisisSideEventState {
+  const { mandatory } = useSideEventsConfig();
+  const pending = useGameState((gs) => (gs?.flags as any)?.pending_side_event) as PendingCrisis | undefined;
+  const pick = useGameStore((s) => s.pendingSideEventChoice);
+
+  const crisisActive = mandatory && !!pending?.eventId;
+  const crisis = crisisActive ? (pending as PendingCrisis) : null;
+  const choicePicked = crisisActive && pick?.eventId === crisis!.eventId;
+
+  return {
+    crisisActive,
+    crisis,
+    choicePicked,
+    chosenChoiceId: choicePicked ? pick!.choiceId : null,
+    crisisSlotUsed: crisisActive ? 1 : 0,
+    blocksAdvance: crisisActive && !choicePicked,
+  };
+}

--- a/client/src/hooks/useSideEventsConfig.ts
+++ b/client/src/hooks/useSideEventsConfig.ts
@@ -1,0 +1,37 @@
+/**
+ * Side Events config hook — Mandatory Side Events ("Crisis on the Desk").
+ *
+ * Surfaces the server-side kill-switch `mandatory_side_events.enabled` so the
+ * client can branch between the mandatory crisis-card flow (deferred event
+ * occupies a focus slot, gates the advance) and the legacy in-results interactive
+ * beat. Read-only, process-wide config — cached with `staleTime: Infinity` (it
+ * only changes when a balance JSON is edited + the server restarts).
+ *
+ * Defaults to `mandatory: true` (the shipped default) while loading / on error so
+ * the primary path renders without a flash of the legacy behavior.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiRequest } from '@/lib/queryClient';
+
+export const SIDE_EVENTS_CONFIG_KEY = ['config:side-events'] as const;
+
+interface SideEventsConfig {
+  mandatory: boolean;
+}
+
+export function useSideEventsConfig(): SideEventsConfig {
+  const { data } = useQuery<SideEventsConfig>({
+    queryKey: SIDE_EVENTS_CONFIG_KEY,
+    queryFn: async () => {
+      const response = await apiRequest('GET', '/api/config/side-events');
+      return (await response.json()) as SideEventsConfig;
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+  });
+
+  return { mandatory: data?.mandatory ?? true };
+}

--- a/client/src/lib/helpTopics.ts
+++ b/client/src/lib/helpTopics.ts
@@ -301,17 +301,17 @@ export const HELP_TOPICS: HelpTopic[] = [
   {
     id: 'side-events',
     title: 'When the Week Fights Back: Side Events',
-    hook: 'You had the week planned to the hour. Then a payout report looks off, a rival makes a move, and suddenly the plan has company.',
-    tldr: 'Side events are the world reacting to you — not your executives\' agenda. Read each choice for the trade it is offering, and remember that "ignore it" is also a choice, with a price.',
+    hook: 'You had the week planned to the hour. Then a crisis lands on your desk, and the plan has to make room — because handling it is now part of the week.',
+    tldr: 'Side events are the world reacting to you — not your executives\' agenda. When one lands, it takes over a focus slot the following week and you cannot advance until you decide how to handle it. Read each choice for the trade it is offering.',
     body: [
-      'Your meetings are the agenda you set; side events are the industry setting one for you. They arrive uninvited — a licensing offer, a billing dispute, a mess that happened on someone else\'s stage — and they do not wait for a convenient week. This is not noise. It is the world responding to the label you are building, and the labels that do well treat these moments as decisions, not interruptions.',
-      'When one lands, slow down and read the trade. Every option in a side event is offering you something and asking for something — cash now against standing later, a quick exit against a slower play that compounds. The right answer depends on what your label needs this stretch, not on which line sounds boldest. A cash-poor week and a reputation-rich week can make opposite choices correct on the same event.',
-      'And do not mistake walking away for staying neutral. Declining to engage is an answer the industry hears, and it usually carries its own cost — quieter than the flashy options, but real. Sometimes eating that cost is right; just make sure you chose it, rather than drifted into it.',
+      'Your meetings are the agenda you set; side events are the industry setting one for you. They arrive uninvited — a licensing offer, a billing dispute, a mess that happened on someone else\'s stage — and they do not wait for a convenient week. This is not noise. It is the world responding to the label you are building.',
+      'Here is the part that matters for your planning: a crisis does not resolve itself in the margins. It lands on your desk and claims one of that week\'s focus slots, the same slots your executives compete for — because handling a real problem eats real management time. You will have one fewer meeting to run while it sits there, and the week will not advance until you have chosen how to deal with it. It is mandatory; there is no quietly ignoring it away.',
+      'So when one lands, slow down and read the trade. Every option is offering you something and asking for something — cash now against standing later, a quick exit against a slower play that compounds. The right answer depends on what your label needs this stretch, not on which line sounds boldest. A cash-poor week and a reputation-rich week can make opposite choices correct on the same crisis — and remember you are paying for it in bandwidth no matter which you pick, so make the slot count.',
     ],
     rules: [
-      'Side events are the world\'s agenda, not yours — they arrive on their schedule, and they still deserve a real read.',
+      'Side events are the world\'s agenda, not yours — they arrive on their schedule and demand a decision.',
+      'A crisis costs you a focus slot the following week and blocks the advance until you resolve it — plan for one fewer meeting when one is on your desk.',
       'Every option is a trade: name what it gives and what it takes before you pick, and match it to what this stretch of the run needs.',
-      '"Ignore it" is a choice with a price — walking away quietly costs you too, so walk away on purpose or not at all.',
     ],
   },
   {

--- a/client/src/pages/ExecutiveSuitePage.tsx
+++ b/client/src/pages/ExecutiveSuitePage.tsx
@@ -4,6 +4,7 @@ import { Zap } from 'lucide-react';
 import { SelectionSummary } from '../components/SelectionSummary';
 import { ExecutiveMeetings } from '../components/executive-meetings/ExecutiveMeetings';
 import { useGameContext } from '@/contexts/GameContext';
+import { useCrisisSideEvent } from '@/hooks/useCrisisSideEvent';
 import GameLayout from '@/layouts/GameLayout';
 import { useState } from 'react';
 import { toast } from '@/hooks/use-toast';
@@ -71,7 +72,12 @@ export default function ExecutiveSuitePage({
   if (!gameState || !gameId) return null;
 
   const totalSlots = gameState.focusSlots || 3;
-  const usedSlots = gameState.usedFocusSlots || 0;
+  // Mandatory Side Events ("Crisis on the Desk"): a pending crisis eats one slot.
+  // Folding it into `usedSlots` threads through the HUD pips AND the focusSlots
+  // prop fed to ExecutiveMeetings — so SYNC_SLOTS → the machine's slotsRemaining
+  // (manual gating) and selectTopOptions (AUTO) both propose one fewer action.
+  const crisis = useCrisisSideEvent();
+  const usedSlots = (gameState.usedFocusSlots || 0) + crisis.crisisSlotUsed;
   const slotsLeft = totalSlots - usedSlots;
   const creativeCapital = gameState.creativeCapital ?? 0;
   const gridHint = slotsLeft > 0

--- a/client/src/store/gameStore.ts
+++ b/client/src/store/gameStore.ts
@@ -416,6 +416,14 @@ interface GameStore {
 
   // UI state
   selectedActions: string[];
+  /**
+   * Mandatory Side Events ("Crisis on the Desk"): the player's picked resolution
+   * for the pending crisis card, held in session state (persisted like
+   * selectedActions) and sent WITH the next advanceWeek request. Cleared after a
+   * successful advance. `null` until the player picks. */
+  pendingSideEventChoice: { eventId: string; choiceId: string } | null;
+  setSideEventChoice: (eventId: string, choiceId: string) => void;
+  clearSideEventChoice: () => void;
   isAdvancingWeek: boolean;
   weeklyOutcome: any | null;
   campaignResults: any | null;
@@ -497,6 +505,7 @@ export const useGameStore = create<GameStore>()(
       executives: [],
       moodEvents: [],
       selectedActions: [],
+      pendingSideEventChoice: null,
       isAdvancingWeek: false,
       weeklyOutcome: null,
       campaignResults: null,
@@ -946,11 +955,22 @@ export const useGameStore = create<GameStore>()(
       },
 
       // Advance week
+      // Mandatory Side Events ("Crisis on the Desk"): record / clear the player's
+      // picked resolution. Held in session state and sent with the next advance.
+      setSideEventChoice: (eventId: string, choiceId: string) => {
+        set({ pendingSideEventChoice: { eventId, choiceId } });
+      },
+      clearSideEventChoice: () => {
+        set({ pendingSideEventChoice: null });
+      },
+
       advanceWeek: async () => {
-        const { selectedActions } = get();
+        const { selectedActions, pendingSideEventChoice } = get();
         const gameState = readGameState(get);
-        // Allow advancing the week if either there are selected actions OR an A&R operation is consuming a slot
-        if (!gameState || (selectedActions.length === 0 && !gameState.arOfficeSlotUsed)) return;
+        // Allow advancing the week if there are selected actions, an A&R operation
+        // is consuming a slot, OR a mandatory crisis resolution has been picked (a
+        // crisis-only week can legitimately have zero meeting actions).
+        if (!gameState || (selectedActions.length === 0 && !gameState.arOfficeSlotUsed && !pendingSideEventChoice)) return;
 
         set({ isAdvancingWeek: true });
 
@@ -965,6 +985,10 @@ export const useGameStore = create<GameStore>()(
             // second request 409s instead of silently advancing two weeks
             // (server enforces inside the FOR UPDATE lock, advanceWeekService.ts).
             expectedCurrentWeek: gameState.currentWeek,
+            // Mandatory Side Events: carry the picked crisis resolution with the
+            // advance so its effects apply during the week (server validates it
+            // against the pending flag before advancing). Omitted when none picked.
+            ...(pendingSideEventChoice ? { sideEventChoice: pendingSideEventChoice } : {}),
             selectedActions: selectedActions.map(actionStr => {
               // Parse the JSON string to get our structured data
               let actionData: any;
@@ -1070,6 +1094,9 @@ export const useGameStore = create<GameStore>()(
             weeklyOutcome: result.summary,
             campaignResults: result.campaignResults,
             selectedActions: [],
+            // Mandatory Side Events: the crisis was resolved during this advance
+            // (server applied it) — clear the session pick so it can't re-send.
+            pendingSideEventChoice: null,
             isAdvancingWeek: false,
             weeklyOutcomeAutoShow: true
           });
@@ -1627,6 +1654,9 @@ export const useGameStore = create<GameStore>()(
       partialize: (state) => ({
         gameState: state.gameState ? { id: state.gameState.id } : null,
         selectedActions: state.selectedActions,
+        // Mandatory Side Events: persist the crisis pick so a mid-week reload keeps
+        // the resolution the player already made (parallels selectedActions).
+        pendingSideEventChoice: state.pendingSideEventChoice,
         isAdvancingWeek: state.isAdvancingWeek
       })
     }

--- a/data/balance.ts
+++ b/data/balance.ts
@@ -66,7 +66,10 @@ const balance = {
   
   // Side events
   side_events: events.side_events,
-  
+
+  // Mandatory side events kill-switch ("Crisis on the Desk")
+  mandatory_side_events: events.mandatory_side_events,
+
   // Progression thresholds
   progression_thresholds: progression.progression_thresholds,
   

--- a/data/balance/events.json
+++ b/data/balance/events.json
@@ -1,9 +1,12 @@
 {
+  "mandatory_side_events": {
+    "enabled": true
+  },
   "side_events": {
     "weekly_chance": 0.20,
     "max_events_per_week": 1,
     "event_cooldown": 2,
-    
+
     "event_weights": {
       "sync_licensing": 0.15,
       "copyright_issues": 0.10,

--- a/docs/01-planning/implementation-specs/[READY] mandatory-side-events-plan.md
+++ b/docs/01-planning/implementation-specs/[READY] mandatory-side-events-plan.md
@@ -1,0 +1,52 @@
+# [READY] Mandatory Side Events — "Crisis on the Desk"
+
+**Status:** READY · **Branch:** `feat/mandatory-side-events` · **Author:** engine/gameplay
+**Config kill-switch:** `data/balance/events.json → mandatory_side_events.enabled` (default `true`)
+
+## Problem / product intent
+
+Today a side event rolls in-stream (seeded ~20% weekly, `game-engine.ts` `checkForEvents` — the C64 RNG discipline) and surfaces as an **interactive choice beat inside WeekSummary**. Playtest verdict: resolving a world crisis as a throwaway modal button "makes it feel less like an OH MY." A label crisis should eat real management bandwidth.
+
+**Decision:** the rolled event becomes **mandatory** and **consumes one focus slot in the following week**. The player cannot advance until they pick how to handle it; the chosen effects apply *during* that week's advance, and the WeekSummary reports "You spent the week handling: `<event>`."
+
+## Design (final)
+
+1. **The roll is untouched.** Same RNG position, same seed, byte-identical stream. `checkForEvents` still draws `getRandom(0,1) < weekly_chance` at the exact same point, and `selectSideEvent` still runs on its isolated seed. Zero drift in *when/which* events roll.
+2. **Deferred landing.** The rolled event is stored as `flags.pending_side_event` on the gameState spine (the field already exists). In mandatory mode we store a **richer payload** `{ eventId, week, prompt, category, choices }` so the next week's crisis card can render fully **after a reload** with no extra fetch. `flags` is a `jsonb` column persisted verbatim; the save snapshot's inner `gameState` schema is `.passthrough()` and `flags` is `z.record(z.any())` — additive, so **`SNAPSHOT_VERSION` stays at 2** (evidence: `shared/schema.ts` `gameSaveSnapshotSchema` lines ~538/541/559; restore rejects only on version mismatch, `saveService.ts loadRestoreSnapshot`).
+3. **Slot occupation.** The next week's action-selection UI shows the pending event as a **crisis card occupying ONE focus slot**, mirroring the `arOfficeSlotUsed` precedent — the slot is folded into the effective `usedFocusSlots` so the machine's `slotsRemaining`/`hasFocusSlots` and the manual/AUTO UI all see the reduced count. Mandatory: **no dismissal**.
+4. **Advance gating.** ADVANCE WEEK is blocked until a choice is picked — **client-side** (button disabled + reason) **and server-side** (`advanceWeekService` throws `AdvanceWeekConflictError(400, { error: 'PENDING_SIDE_EVENT' })`, mapped by the existing `gameLoop.ts` catch — mirrors the C58 stale-week guard).
+5. **Resolution timing.** The choice travels **with the advance request** as an optional `sideEventChoice: { eventId, choiceId }` on `AdvanceWeekRequest` (mirrors `expectedCurrentWeek`). The engine applies it **during that advance, queued like a weekly action**: `effects_immediate` through `ActionProcessor.applyEffects` (global scope → all signed artists, mood_events logged via `applyArtistChangesToDatabase`); `effects_delayed` banked on `flags` with `triggerWeek = currentWeek + 1` (drains next advance, exactly like meeting/dialogue delayed effects). `pending_side_event` is cleared.
+6. **One crisis at a time.** If the roll fires while one is already pending, the draws still happen (stream discipline — `getRandom` + `selectSideEvent` both run) but the **result is discarded** (no overwrite of the pending event, no `summary.events` push, no history stamp for the discarded pick). In practice the advance gate makes this unreachable in mandatory mode, but it is defensive and keeps the stream identical.
+7. **AUTO integration.** The crisis slot is folded into `focusSlots.used` fed to `ExecutiveMeetings`, so `SYNC_SLOTS → slotsRemaining` and `selectTopOptions(availableSlots)` propose one fewer action — the same threading `arOfficeSlotUsed` uses.
+8. **WeekSummary beat.** Resolution renders as its own notable beat ("You spent the week handling: `<event>`" + chosen label + effects), emitted by the engine into `summary.events` as `{ resolved: true, ... }`. In mandatory mode the **old in-results interactive beat is suppressed** for a freshly-pending event (that event is now handled by next week's crisis card). One behavior at a time.
+9. **Config kill-switch.** `mandatory_side_events { enabled: true }` in `data/balance/events.json`. When `false`, the legacy in-results interactive path is fully restored (engine lapses the pending event, WeekSummary shows the interactive `SideEventBeat`, resolution via `POST /side-event-choice`). Both paths compile and are tested.
+10. **Crisis-card fiction.** Urgent, in-world tone ("Landed on your desk: …"), v2 tokens (`neon-magenta`/`negative` accents, `.glass-panel`), visually distinct from exec meeting cards — this is the world happening to *you*, not an exec's agenda. Realism: crises eat bandwidth; that is *why* it costs a slot.
+
+## Data / persistence
+
+- **`flags.pending_side_event`** (spine `jsonb`): legacy shape `{ eventId, week }`; mandatory shape `{ eventId, week, prompt, category, choices }`. Endpoint + `checkForEvents` read only `eventId`/`week`, so the extra fields are inert for the legacy path.
+- **Client flag delivery:** `GET /api/config/side-events → { mandatory: boolean }` (public-ish, auth via existing middleware), consumed by `useSideEventsConfig()` (TanStack Query, `staleTime: Infinity`). The client branches crisis-card-vs-legacy-beat on it.
+- **Client session state:** `pendingSideEventChoice: { eventId, choiceId } | null` in the Zustand store (persisted via `partialize`, like `selectedActions`); included in the advance payload and cleared after a successful advance.
+
+## Golden-master policy
+
+Roll position unchanged. The GM harness stubs `weekly_chance: 0` so **no side event fires in any existing fixture** → zero drift. A new **additive** fixture (`sideEventMandatory`) overrides `getEventConfigSync`/`getAllEvents`/`getSideEventsConfigSync`/`getMandatorySideEventsConfigSync` to force one event and a resolution, capturing the deferred pending flag and the resolution delta. Existing snapshots stay byte-identical; audited double-run.
+
+## Edge cases (all tested)
+
+- Week 1 / nothing pending → advance ungated, no crisis card.
+- Save/load with a pending event → round-trips (richer flag passthrough).
+- Campaign end (week 52) with an unresolved pending event → resolution still applies during the final advance; end screen not bricked.
+- AUTO-confirm with a pending crisis → proposes one fewer action.
+- Meeting-selection server gate sees the reduced slot count (`executives.ts` effective-total −1 while pending in mandatory mode).
+
+## Change surface
+
+- `data/balance/events.json`, `data/balance.ts`, `shared/utils/dataLoader.ts` — config block + passthrough.
+- `server/data/gameData.ts` — `getMandatorySideEventsConfigSync()`.
+- `shared/engine/game-engine.ts` — mandatory branch in `checkForEvents`; `processPendingSideEventResolution`; `advanceWeek` options param.
+- `shared/api/contracts.ts` — `sideEventChoice` on `AdvanceWeekRequest`.
+- `server/services/advanceWeekService.ts` — gate + thread the choice.
+- `server/routes/gameLoop.ts`, `server/routes/games.ts` (config endpoint), `server/routes/executives.ts` (slot gate).
+- `client/` — `useSideEventsConfig`, store field, `CrisisCard`, `SelectionSummary`, `ExecutiveSuitePage`, `GameHeader`, `WeekSummary`.
+- Tests + docs (systems map, Label Head's Guide).

--- a/server/data/gameData.ts
+++ b/server/data/gameData.ts
@@ -873,6 +873,19 @@ export class ServerGameData {
     };
   }
 
+  /**
+   * Mandatory Side Events ("Crisis on the Desk") kill-switch. When enabled
+   * (the default), a rolled side event is DEFERRED to the following week as a
+   * mandatory crisis card that consumes a focus slot and gates the advance.
+   * When disabled, the legacy in-results interactive beat path is restored.
+   * Falls back to enabled:true (the shipped default) when balance data has not
+   * loaded — the GM harness overrides this stub explicitly.
+   */
+  getMandatorySideEventsConfigSync(): { enabled: boolean } {
+    const cfg = (this.balanceData as any)?.mandatory_side_events;
+    return { enabled: cfg?.enabled !== false };
+  }
+
   getWeeklyBurnRangeSync(): [number, number] {
     if (!this.balanceData) {
       return [3000, 6000];

--- a/server/routes/executives.ts
+++ b/server/routes/executives.ts
@@ -237,7 +237,14 @@ router.get("/api/roles/:roleId", requireClerkUser, async (req, res) => {
 
       // Check if focus slots are available
       const usedSlots = gameState.usedFocusSlots || 0;
-      const totalSlots = gameState.focusSlots || 3;
+      // Mandatory Side Events ("Crisis on the Desk"): a pending crisis occupies
+      // ONE focus slot, so the effective ceiling for meeting selection drops by
+      // one while it is unresolved (mirrors the client's crisis-slot math). This
+      // is the server enforcement of the reduced slot count the selection pipeline
+      // must respect.
+      const mandatorySideEvents = serverGameData.getMandatorySideEventsConfigSync().enabled;
+      const crisisPending = mandatorySideEvents && !!(gameState.flags as any)?.pending_side_event?.eventId;
+      const totalSlots = (gameState.focusSlots || 3) - (crisisPending ? 1 : 0);
 
       if (usedSlots >= totalSlots) {
         return res.status(400).json({

--- a/server/routes/gameLoop.ts
+++ b/server/routes/gameLoop.ts
@@ -39,9 +39,9 @@ const router = Router();
     try {
       // Validate request using shared contract
       const request = validateRequest(AdvanceWeekRequest, req.body);
-      const { gameId, selectedActions, expectedCurrentWeek } = request;
+      const { gameId, selectedActions, expectedCurrentWeek, sideEventChoice } = request;
 
-      const finalResult = await advanceWeekService.advanceWeek(gameId, selectedActions, expectedCurrentWeek);
+      const finalResult = await advanceWeekService.advanceWeek(gameId, selectedActions, expectedCurrentWeek, sideEventChoice ?? null);
 
       res.json(finalResult);
     } catch (error) {

--- a/server/routes/games.ts
+++ b/server/routes/games.ts
@@ -26,6 +26,22 @@ const patchGameStateSchema = z
   })
   .strict();
 
+  // Mandatory Side Events ("Crisis on the Desk") kill-switch, surfaced to the
+  // client so it can branch crisis-card-vs-legacy-beat and gate the advance.
+  // Read-only config; requireClerkUser keeps it behind auth like the rest of the
+  // game API. Cached client-side with staleTime: Infinity (useSideEventsConfig).
+  router.get("/api/config/side-events", requireClerkUser, async (_req, res) => {
+    try {
+      await serverGameData.initialize();
+      const mandatory = serverGameData.getMandatorySideEventsConfigSync().enabled;
+      res.json({ mandatory });
+    } catch (error) {
+      // Fail toward the shipped default (mandatory ON) rather than 500 — a config
+      // read should never block gameplay.
+      res.json({ mandatory: true });
+    }
+  });
+
   // Game state routes
   router.get("/api/game/:id", requireClerkUser, requireGameOwnerByParam('id'), async (req, res) => {
     try {

--- a/server/services/advanceWeekService.ts
+++ b/server/services/advanceWeekService.ts
@@ -146,19 +146,37 @@ export class AdvanceWeekService {
       // screen. A live campaign at week 52 (completed still false) IS gated: the
       // player resolves the crisis, then the advance completes the campaign.
       const campaignAlreadyEnded = (gameState.currentWeek ?? 1) >= 52 && !!gameState.campaignCompleted;
+      // The resolution actually forwarded to the engine. Normally the client's
+      // sideEventChoice; replaced by a synthetic one in the orphaned-event case
+      // below so the engine's self-heal path can clear the flag.
+      let effectiveSideEventChoice: { eventId: string; choiceId: string } | null = sideEventChoice ?? null;
       if (mandatorySideEvents && pendingCrisis?.eventId && !campaignAlreadyEnded) {
-        const provided = sideEventChoice ?? null;
-        let valid = false;
-        if (provided && provided.eventId === pendingCrisis.eventId) {
-          const crisisEvent = await this.serverGameData.getEventById(pendingCrisis.eventId);
-          valid = !!crisisEvent?.choices.some((c) => c.id === provided.choiceId);
-        }
-        if (!valid) {
-          throw new AdvanceWeekConflictError(400, {
-            error: 'PENDING_SIDE_EVENT',
-            message: 'A crisis is on your desk — choose how to handle it before advancing the week.',
-            eventId: pendingCrisis.eventId,
-          });
+        const crisisEvent = await this.serverGameData.getEventById(pendingCrisis.eventId);
+        if (!crisisEvent) {
+          // ORPHANED EVENT: the pending eventId no longer exists in data (e.g.
+          // deleted via the Content Editor between defer and resolve). Gating
+          // here would 400 EVERY advance forever — the engine's self-heal
+          // ("clearing without effects", processPendingSideEventResolution)
+          // would be unreachable because this gate throws first. Instead, let
+          // the advance proceed and forward a synthetic resolution matching the
+          // pending eventId: the engine finds no such event and clears the flag
+          // with no effects (its existing self-heal branch).
+          console.warn(`[SIDE EVENT] Pending event "${pendingCrisis.eventId}" no longer exists in data; advancing to let the engine self-heal.`);
+          effectiveSideEventChoice = { eventId: pendingCrisis.eventId, choiceId: '__orphaned__' };
+        } else {
+          const provided = sideEventChoice ?? null;
+          const valid = !!(
+            provided &&
+            provided.eventId === pendingCrisis.eventId &&
+            crisisEvent.choices.some((c) => c.id === provided.choiceId)
+          );
+          if (!valid) {
+            throw new AdvanceWeekConflictError(400, {
+              error: 'PENDING_SIDE_EVENT',
+              message: 'A crisis is on your desk — choose how to handle it before advancing the week.',
+              eventId: pendingCrisis.eventId,
+            });
+          }
         }
       }
 
@@ -335,8 +353,10 @@ export class AdvanceWeekService {
           weekResult = await gameEngine.advanceWeek(formattedActions, tx, {
             // Mandatory Side Events: carry the validated crisis resolution into the
             // engine so its effects apply DURING this advance (queued like a weekly
-            // action). The gate above already verified it against the pending flag.
-            sideEventChoice: sideEventChoice ?? null,
+            // action). The gate above already verified it against the pending flag
+            // (or substituted a synthetic one for an orphaned event so the engine's
+            // self-heal can clear the stale flag).
+            sideEventChoice: effectiveSideEventChoice,
           }); // Pass transaction context
           console.log('[DEBUG] Week advancement completed successfully');
           console.log('[DEBUG] WeekResult received from GameEngine:', {

--- a/server/services/advanceWeekService.ts
+++ b/server/services/advanceWeekService.ts
@@ -83,7 +83,7 @@ export class AdvanceWeekService {
    * requireGameOwner in the route. Returns the exact response envelope the
    * original handler returned ({ gameState, summary, campaignResults, debug }).
    */
-  async advanceWeek(gameId: string, selectedActions: any[], expectedCurrentWeek?: number) {
+  async advanceWeek(gameId: string, selectedActions: any[], expectedCurrentWeek?: number, sideEventChoice?: { eventId: string; choiceId: string } | null) {
     // D6 PR-3 review fix: load balance config BEFORE the transaction so the
     // FOR UPDATE row lock is never held across disk I/O. Neither call touches
     // the DB or depends on tx: getStartingValues() reads balance JSON, and
@@ -129,6 +129,37 @@ export class AdvanceWeekService {
           currentWeek: gameState.currentWeek ?? 1,
           expectedCurrentWeek,
         });
+      }
+
+      // Mandatory Side Events ("Crisis on the Desk"): a pending crisis MUST be
+      // resolved before the week can advance. Enforced INSIDE the FOR UPDATE lock
+      // off the freshly-read row (never the middleware's unlocked read), mirroring
+      // the C58 stale-week guard above. When the kill-switch is off, the pending
+      // event lapses the legacy way and this gate is inert.
+      const mandatorySideEvents = this.serverGameData.getMandatorySideEventsConfigSync().enabled;
+      const pendingCrisis = (gameState.flags as any)?.pending_side_event as
+        | { eventId: string; week: number }
+        | undefined;
+      // Don't gate a campaign that has already ended (week >= 52 + completed) —
+      // that path takes the campaign-results early return below and would never
+      // reach the engine to clear the crisis, so gating it would brick the end
+      // screen. A live campaign at week 52 (completed still false) IS gated: the
+      // player resolves the crisis, then the advance completes the campaign.
+      const campaignAlreadyEnded = (gameState.currentWeek ?? 1) >= 52 && !!gameState.campaignCompleted;
+      if (mandatorySideEvents && pendingCrisis?.eventId && !campaignAlreadyEnded) {
+        const provided = sideEventChoice ?? null;
+        let valid = false;
+        if (provided && provided.eventId === pendingCrisis.eventId) {
+          const crisisEvent = await this.serverGameData.getEventById(pendingCrisis.eventId);
+          valid = !!crisisEvent?.choices.some((c) => c.id === provided.choiceId);
+        }
+        if (!valid) {
+          throw new AdvanceWeekConflictError(400, {
+            error: 'PENDING_SIDE_EVENT',
+            message: 'A crisis is on your desk — choose how to handle it before advancing the week.',
+            eventId: pendingCrisis.eventId,
+          });
+        }
       }
 
       // Load current artists for mood calculations
@@ -301,7 +332,12 @@ export class AdvanceWeekService {
         console.log('[DEBUG] Starting GameEngine processing...');
 
         try {
-          weekResult = await gameEngine.advanceWeek(formattedActions, tx); // Pass transaction context
+          weekResult = await gameEngine.advanceWeek(formattedActions, tx, {
+            // Mandatory Side Events: carry the validated crisis resolution into the
+            // engine so its effects apply DURING this advance (queued like a weekly
+            // action). The gate above already verified it against the pending flag.
+            sideEventChoice: sideEventChoice ?? null,
+          }); // Pass transaction context
           console.log('[DEBUG] Week advancement completed successfully');
           console.log('[DEBUG] WeekResult received from GameEngine:', {
             weekResult,

--- a/shared/api/contracts.ts
+++ b/shared/api/contracts.ts
@@ -156,7 +156,15 @@ export const AdvanceWeekRequest = z.object({
   // advance click 409s on the second request instead of silently advancing
   // two weeks (see advanceWeekService.ts's guard, right after the
   // `SELECT ... FOR UPDATE` re-read).
-  expectedCurrentWeek: z.number().int().optional()
+  expectedCurrentWeek: z.number().int().optional(),
+  // Mandatory Side Events ("Crisis on the Desk"): the player's resolution for a
+  // pending crisis, carried WITH the advance (mirrors expectedCurrentWeek).
+  // OPTIONAL — absent in the legacy in-results path and week-1/no-crisis advances.
+  // The server validates it against flags.pending_side_event before advancing.
+  sideEventChoice: z.object({
+    eventId: z.string(),
+    choiceId: z.string(),
+  }).optional()
 });
 
 export const CampaignResultsSchema = z.object({

--- a/shared/engine/game-engine.ts
+++ b/shared/engine/game-engine.ts
@@ -137,7 +137,13 @@ export class GameEngine {
    * @param weeklyActions - Actions selected by the player this week
    * @returns Updated game state and summary of changes
    */
-  async advanceWeek(weeklyActions: GameEngineAction[], dbTransaction?: any): Promise<{
+  async advanceWeek(weeklyActions: GameEngineAction[], dbTransaction?: any, options?: {
+    // Mandatory Side Events ("Crisis on the Desk"): the player's resolution for
+    // the pending crisis, carried WITH the advance request (mirrors the optional
+    // expectedCurrentWeek guard). Applied during this advance, queued like a
+    // weekly action's effects. Absent in the legacy in-results path.
+    sideEventChoice?: { eventId: string; choiceId: string } | null;
+  }): Promise<{
     gameState: GameState;
     summary: WeekSummary;
     campaignResults?: CampaignResults;
@@ -197,6 +203,12 @@ export class GameEngine {
     for (const action of otherActions) {
       await this.processAction(action, summary, dbTransaction);
     }
+
+    // Mandatory Side Events ("Crisis on the Desk"): resolve the pending crisis
+    // WITHIN this advance — its immediate effects apply now (queued like weekly
+    // action effects), its delayed effects bank for next week, and the pending
+    // flag clears. No-op in the legacy path (no sideEventChoice provided).
+    await this.processPendingSideEventResolution(summary, options?.sideEventChoice ?? null, dbTransaction);
 
     // Process ongoing revenue from released projects
     await this.processReleasedProjects(summary, dbTransaction);
@@ -1019,9 +1031,19 @@ export class GameEngine {
     const flags = (this.gameState.flags || {}) as Record<string, any>;
     this.gameState.flags = flags;
 
+    // Defensive optional-chain: production ServerGameData always implements this,
+    // but some duck-typed test gameData mocks predate it. Missing → production
+    // default (mandatory ON). The legacy-path characterization test sets it false
+    // explicitly.
+    const mandatory = this.gameData.getMandatorySideEventsConfigSync?.()?.enabled ?? true;
+
     // --- LAPSE: clear a stale pending event from a prior week (no effects). ---
+    // In MANDATORY mode a pending crisis never lapses — it is resolved during the
+    // week's advance (processPendingSideEventResolution, before this runs) and the
+    // advance is gated until it is. Skipping the lapse keeps a crisis from being
+    // silently dropped if resolution somehow did not clear it (defensive).
     const pending = flags.pending_side_event as { eventId: string; week: number } | undefined;
-    if (pending && typeof pending.week === 'number' && pending.week < currentWeek) {
+    if (!mandatory && pending && typeof pending.week === 'number' && pending.week < currentWeek) {
       console.log(`[SIDE EVENT] Lapsing unresolved event "${pending.eventId}" from week ${pending.week} (now week ${currentWeek})`);
       delete flags.pending_side_event;
     }
@@ -1030,28 +1052,162 @@ export class GameEngine {
 
     if (this.getRandom(0, 1) < eventConfig.weekly_chance) {
       // --- HIT: select WHICH event on an isolated seed (weighted + cooldown). ---
+      // The draws ALWAYS run (stream discipline / C64) even when the result will
+      // be discarded, so the seeded RNG stream is byte-identical regardless of
+      // pending state.
       const events = await this.gameData.getAllEvents();
       const selectionConfig = this.gameData.getSideEventsConfigSync();
       const history = (flags.side_event_history || {}) as Record<string, number>;
 
       const event = selectSideEvent(events, selectionConfig, history, currentWeek, this.gameState.id);
-      if (event) {
+
+      // ONE CRISIS AT A TIME: if a crisis is already pending (mandatory mode), the
+      // draw above still happened, but the newly-rolled event is DISCARDED — no
+      // overwrite of the pending event, no summary push, no cooldown stamp for the
+      // discarded pick. Existing cooldown behavior for the pending event is
+      // unchanged.
+      const alreadyPending = mandatory && !!flags.pending_side_event;
+
+      if (event && !alreadyPending) {
         // Persist pending event + cooldown stamp (additive flags keys only).
         flags.side_event_history = { ...history, [event.id]: currentWeek };
-        flags.pending_side_event = { eventId: event.id, week: currentWeek };
 
-        // Push the FULL payload so PR-4 can render the beat from the outcome.
-        summary.events.push({
-          id: event.id,
-          title: event.prompt.substring(0, 50),
-          occurred: true,
-          category: event.category,
-          prompt: event.prompt,
-          choices: event.choices,
-        });
+        if (mandatory) {
+          // Deferred landing: store the RICHER payload so next week's crisis card
+          // renders fully after a reload (no second fetch). eventId/week keep their
+          // legacy positions; the extra fields are inert for the legacy readers.
+          flags.pending_side_event = {
+            eventId: event.id,
+            week: currentWeek,
+            prompt: event.prompt,
+            category: event.category,
+            choices: event.choices,
+          };
+          // In mandatory mode the event is NOT surfaced as an interactive beat this
+          // week — it lands as a mandatory crisis card in NEXT week's action
+          // selection. We still record its arrival for the outcome log/tests.
+          summary.events.push({
+            id: event.id,
+            title: event.prompt.substring(0, 50),
+            occurred: true,
+            category: event.category,
+            prompt: event.prompt,
+            // No `choices` → the client's legacy interactive beat renders nothing;
+            // the crisis card reads the pending flag instead.
+          });
+        } else {
+          // Legacy path: pending flag is the lean {eventId, week}; the full payload
+          // rides summary.events so PR-4's in-results interactive beat can render.
+          flags.pending_side_event = { eventId: event.id, week: currentWeek };
+          summary.events.push({
+            id: event.id,
+            title: event.prompt.substring(0, 50),
+            occurred: true,
+            category: event.category,
+            prompt: event.prompt,
+            choices: event.choices,
+          });
+        }
       }
-      // Empty pool (all events on cooldown) → no event fires this week.
+      // Empty pool (all events on cooldown) or a crisis already pending → nothing
+      // new fires this week.
     }
+  }
+
+  /**
+   * Mandatory Side Events ("Crisis on the Desk"): resolve the pending crisis
+   * carried with the advance request. Applies the chosen effects DURING this
+   * advance — immediate effects through ActionProcessor.applyEffects (global
+   * scope → all signed artists, mood_events logged via applyArtistChangesToDatabase),
+   * delayed effects banked on flags with triggerWeek = currentWeek + 1 (drained
+   * next advance, exactly like meeting/dialogue delayed effects). Clears the
+   * pending flag and emits a RESOLVED beat into summary.events.
+   *
+   * No-op when no choice is supplied (legacy in-results path) or no crisis is
+   * pending. If the supplied choice does not match the pending event, it is
+   * ignored and the pending flag is left intact (the server gate should have
+   * already validated the match; this is defensive).
+   */
+  private async processPendingSideEventResolution(
+    summary: WeekSummary,
+    sideEventChoice: { eventId: string; choiceId: string } | null,
+    dbTransaction?: any
+  ): Promise<void> {
+    if (!sideEventChoice) return;
+
+    const flags = (this.gameState.flags || {}) as Record<string, any>;
+    this.gameState.flags = flags;
+    const pending = flags.pending_side_event as { eventId: string; week: number } | undefined;
+    if (!pending) return;
+    if (pending.eventId !== sideEventChoice.eventId) {
+      console.warn(`[SIDE EVENT] Resolution eventId "${sideEventChoice.eventId}" does not match pending "${pending.eventId}"; ignoring.`);
+      return;
+    }
+
+    const currentWeek = this.gameState.currentWeek || 0;
+
+    // Authoritative event/choice from data (the pending flag also carries a copy,
+    // but the on-disk content is the source of truth).
+    const event = await this.gameData.getEventById(sideEventChoice.eventId);
+    if (!event) {
+      console.warn(`[SIDE EVENT] Unknown pending event "${sideEventChoice.eventId}"; clearing without effects.`);
+      delete flags.pending_side_event;
+      return;
+    }
+    const choice = event.choices.find((c) => c.id === sideEventChoice.choiceId);
+    if (!choice) {
+      console.warn(`[SIDE EVENT] Invalid choice "${sideEventChoice.choiceId}" for event "${event.id}"; leaving pending.`);
+      return;
+    }
+
+    // Apply immediate effects, queued like a weekly action (global scope — side
+    // events are label-level, so artist-scoped keys hit every signed artist).
+    const effectsImmediate: Record<string, number> = {};
+    for (const [k, v] of Object.entries(choice.effects_immediate || {})) {
+      if (typeof v === 'number') effectsImmediate[k] = v;
+    }
+    if (Object.keys(effectsImmediate).length > 0) {
+      await new ActionProcessor().applyEffects(
+        this.weekContext(summary, dbTransaction),
+        effectsImmediate,
+        undefined,
+        'global',
+        `side_event:${event.id}`,
+        choice.id
+      );
+    }
+
+    // Bank delayed effects (deterministic week-based key — never Date.now()).
+    const effectsDelayed: Record<string, number> = {};
+    for (const [k, v] of Object.entries(choice.effects_delayed || {})) {
+      if (typeof v === 'number') effectsDelayed[k] = v;
+    }
+    if (Object.keys(effectsDelayed).length > 0) {
+      const delayedKey = `side-event-${event.id}-${choice.id}-week${currentWeek}`;
+      flags[delayedKey] = {
+        triggerWeek: currentWeek + 1,
+        effects: effectsDelayed,
+        meetingName: `side_event:${event.id}`,
+        choiceId: choice.id,
+      };
+    }
+
+    // Clear the resolved crisis.
+    delete flags.pending_side_event;
+
+    // Emit the resolved beat ("You spent the week handling: …").
+    summary.events.push({
+      id: event.id,
+      title: event.prompt.substring(0, 50),
+      occurred: true,
+      resolved: true,
+      category: event.category,
+      prompt: event.prompt,
+      choiceId: choice.id,
+      choiceLabel: choice.label,
+      effects: effectsImmediate,
+      delayedEffects: effectsDelayed,
+    });
   }
 
   /**

--- a/shared/types/gameTypes.ts
+++ b/shared/types/gameTypes.ts
@@ -564,6 +564,16 @@ export interface EventOccurrence {
   category?: SideEventCategory;
   prompt?: string;
   choices?: EventChoice[];
+  // Mandatory Side Events ("Crisis on the Desk"): when a deferred crisis is
+  // RESOLVED during a week's advance, the engine emits a resolved beat instead
+  // of the interactive one. `resolved` marks it; `choiceId`/`choiceLabel` record
+  // the pick; `effects`/`delayedEffects` are the applied immediate/delayed maps
+  // (for the "You spent the week handling: …" WeekSummary card).
+  resolved?: boolean;
+  choiceId?: string;
+  choiceLabel?: string;
+  effects?: Record<string, number>;
+  delayedEffects?: Record<string, number>;
 }
 
 /**

--- a/shared/utils/dataLoader.ts
+++ b/shared/utils/dataLoader.ts
@@ -237,7 +237,10 @@ export class GameDataLoader {
       
       // Side events
       side_events: events.side_events,
-      
+
+      // Mandatory side events kill-switch ("Crisis on the Desk")
+      mandatory_side_events: events.mandatory_side_events,
+
       // Quality system
       quality_system: quality.quality_system,
       
@@ -306,6 +309,7 @@ export class GameDataLoader {
         artist_stats: z.record(z.any()).optional(),
         market_formulas: z.record(z.any()).optional(),
         side_events: z.record(z.any()).optional(),
+        mandatory_side_events: z.record(z.any()).optional(),
         progression_thresholds: z.record(z.any()).optional(),
         quality_system: z.record(z.any()).optional(),
         ui_constants: z.record(z.any()).optional(),

--- a/tests/client/game-header-anticipation.test.tsx
+++ b/tests/client/game-header-anticipation.test.tsx
@@ -39,6 +39,20 @@ vi.mock('@/hooks/useGameState', () => ({
   ),
 }));
 
+// Mandatory Side Events: the header now reads the crisis-slot derivation (which
+// itself hits a TanStack query). This suite renders GameHeader without a
+// QueryClientProvider, so stub the hook to the inert "no crisis" default.
+vi.mock('@/hooks/useCrisisSideEvent', () => ({
+  useCrisisSideEvent: () => ({
+    crisisActive: false,
+    crisis: null,
+    choicePicked: false,
+    chosenChoiceId: null,
+    crisisSlotUsed: 0,
+    blocksAdvance: false,
+  }),
+}));
+
 const fakeStore = {
   selectedActions: [] as string[],
   isAdvancingWeek: false,

--- a/tests/client/game-header-auto-intent.test.tsx
+++ b/tests/client/game-header-auto-intent.test.tsx
@@ -40,6 +40,20 @@ vi.mock('@/hooks/useGameState', () => ({
   ),
 }));
 
+// Mandatory Side Events: GameHeader reads the crisis-slot derivation (a TanStack
+// query under the hood); rendered here without a QueryClientProvider, so stub the
+// hook to the inert "no crisis" default.
+vi.mock('@/hooks/useCrisisSideEvent', () => ({
+  useCrisisSideEvent: () => ({
+    crisisActive: false,
+    crisis: null,
+    choicePicked: false,
+    chosenChoiceId: null,
+    crisisSlotUsed: 0,
+    blocksAdvance: false,
+  }),
+}));
+
 const fakeStore = {
   selectedActions: [] as string[],
   isAdvancingWeek: false,

--- a/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
+++ b/tests/endpoints/__snapshots__/route-manifest.test.ts.snap
@@ -193,6 +193,13 @@ exports[`registerRoutes route manifest > registers the exact set of routes and n
     "middleware": [
       "requireClerkUser",
     ],
+    "path": "/api/config/side-events",
+  },
+  {
+    "method": "GET",
+    "middleware": [
+      "requireClerkUser",
+    ],
     "path": "/api/debug/data-load",
   },
   {

--- a/tests/endpoints/mandatory-side-events.characterization.test.ts
+++ b/tests/endpoints/mandatory-side-events.characterization.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment node
+/**
+ * Mandatory Side Events ("Crisis on the Desk") — HTTP characterization.
+ *
+ * Pins the observable behavior of the advance-week gate + the config endpoint
+ * introduced for the mandatory side-events feature:
+ *   - POST /api/advance-week 400 PENDING_SIDE_EVENT when a crisis is pending and
+ *     no (or an invalid) resolution is supplied.
+ *   - POST /api/advance-week 200 when a valid resolution rides the payload: the
+ *     crisis clears, immediate effects apply during the advance, and the week
+ *     advances.
+ *   - GET /api/config/side-events surfaces the kill-switch.
+ *
+ * Harness copied from advance-week.characterization.test.ts (real gameLoop +
+ * games routers over supertest against the Docker test Postgres on 5433).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/music_label_test';
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+
+const TEST_USER_ID = '11111111-1111-1111-1111-111111111111';
+
+vi.mock('../../server/db', async () => {
+  const { drizzle } = await import('drizzle-orm/node-postgres');
+  const pg = await import('pg');
+  const schema = await import('@shared/schema');
+  const pool = new pg.Pool({
+    connectionString: 'postgresql://postgres:postgres@localhost:5433/music_label_test',
+    max: 5,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+  const db = drizzle(pool, { schema });
+  return { pool, db, testDatabaseConnection: async () => true };
+});
+
+let currentUserId = TEST_USER_ID;
+vi.mock('../../server/auth', () => ({
+  requireClerkUser: (req: any, _res: any, next: any) => {
+    req.userId = currentUserId;
+    req.clerkUserId = 'clerk_test_user';
+    next();
+  },
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+  handleClerkWebhook: (_req: any, res: any) => res.status(200).end(),
+}));
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import crypto from 'crypto';
+import { db } from '../../server/db';
+import { serverGameData } from '../../server/data/gameData';
+import { gameStates, users, artists, executives } from '@shared/schema';
+import gameLoopRouter from '../../server/routes/gameLoop';
+import gamesRouter from '../../server/routes/games';
+
+// A real authored event + choice from data/events.json.
+const EVENT_ID = 'sync_offer';
+const CHOICE_ID = 'take_deal'; // effects_immediate: { money: 20000 }
+
+let app: Express;
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(gameLoopRouter);
+  app.use(gamesRouter);
+  await serverGameData.initialize();
+});
+
+afterAll(async () => {
+  await (db as any).$client?.end?.();
+});
+
+async function seedGameWithPendingCrisis(opts: { pending?: boolean; currentWeek?: number } = {}) {
+  const gameId = crypto.randomUUID();
+  const week = opts.currentWeek ?? 5;
+  await db.insert(gameStates).values({
+    id: gameId,
+    userId: TEST_USER_ID,
+    currentWeek: week,
+    money: 100000,
+    reputation: 10,
+    creativeCapital: 5,
+    focusSlots: 3,
+    usedFocusSlots: 0,
+    venueAccess: 'clubs',
+    campaignCompleted: false,
+    flags: opts.pending
+      ? { pending_side_event: { eventId: EVENT_ID, week, prompt: 'x', category: 'sync_licensing', choices: [] } }
+      : {},
+  });
+  await db.insert(artists).values({
+    id: crypto.randomUUID(),
+    gameId,
+    name: 'Test Artist',
+    archetype: 'Workhorse',
+    genre: 'pop',
+    mood: 50,
+    energy: 50,
+    popularity: 40,
+  });
+  await db.insert(executives).values([
+    { id: crypto.randomUUID(), gameId, role: 'head_ar', level: 1, mood: 50, loyalty: 50 },
+    { id: crypto.randomUUID(), gameId, role: 'cmo', level: 1, mood: 50, loyalty: 50 },
+  ]);
+  return gameId;
+}
+
+beforeEach(async () => {
+  currentUserId = TEST_USER_ID;
+  await db.execute(
+    (await import('drizzle-orm')).sql`TRUNCATE TABLE users, game_states RESTART IDENTITY CASCADE`
+  );
+  await db.insert(users).values([
+    { id: TEST_USER_ID, clerkId: 'clerk_test_user', email: 'test@example.com', username: 'tester' },
+  ]);
+});
+
+describe('Mandatory Side Events — advance-week gate', () => {
+  it('blocks the advance with 400 PENDING_SIDE_EVENT when a crisis is pending and no resolution is sent', async () => {
+    const gameId = await seedGameWithPendingCrisis({ pending: true, currentWeek: 5 });
+
+    const res = await request(app)
+      .post('/api/advance-week')
+      .send({ gameId, selectedActions: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('PENDING_SIDE_EVENT');
+    expect(res.body.eventId).toBe(EVENT_ID);
+
+    // Week did NOT advance.
+    const { eq } = await import('drizzle-orm');
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.currentWeek).toBe(5);
+    expect((gs.flags as any).pending_side_event).toBeTruthy();
+  });
+
+  it('blocks with 400 when the resolution eventId/choiceId does not match the pending crisis', async () => {
+    const gameId = await seedGameWithPendingCrisis({ pending: true, currentWeek: 5 });
+
+    const res = await request(app)
+      .post('/api/advance-week')
+      .send({ gameId, selectedActions: [], sideEventChoice: { eventId: EVENT_ID, choiceId: 'not_a_real_choice' } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('PENDING_SIDE_EVENT');
+  });
+
+  it('advances with 200 when a valid resolution rides the payload: crisis clears + money applied', async () => {
+    const gameId = await seedGameWithPendingCrisis({ pending: true, currentWeek: 5 });
+
+    const res = await request(app)
+      .post('/api/advance-week')
+      .send({ gameId, selectedActions: [], sideEventChoice: { eventId: EVENT_ID, choiceId: CHOICE_ID } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.gameState.currentWeek).toBe(6);
+
+    const { eq } = await import('drizzle-orm');
+    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+    expect(gs.currentWeek).toBe(6);
+    // Pending cleared.
+    expect((gs.flags as any).pending_side_event).toBeUndefined();
+    // Immediate +20000 applied during the advance (money = 100000 + 20000 - weekly burn).
+    expect(gs.money).toBeGreaterThan(100000);
+  });
+
+  it('advances normally (no gate) when no crisis is pending', async () => {
+    const gameId = await seedGameWithPendingCrisis({ pending: false, currentWeek: 5 });
+
+    const res = await request(app)
+      .post('/api/advance-week')
+      .send({ gameId, selectedActions: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.gameState.currentWeek).toBe(6);
+  });
+});
+
+describe('Mandatory Side Events — config endpoint', () => {
+  it('GET /api/config/side-events returns the kill-switch (default ON)', async () => {
+    const res = await request(app).get('/api/config/side-events');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('mandatory');
+    expect(res.body.mandatory).toBe(true);
+  });
+});

--- a/tests/endpoints/mandatory-side-events.characterization.test.ts
+++ b/tests/endpoints/mandatory-side-events.characterization.test.ts
@@ -151,20 +151,94 @@ describe('Mandatory Side Events — advance-week gate', () => {
   it('advances with 200 when a valid resolution rides the payload: crisis clears + money applied', async () => {
     const gameId = await seedGameWithPendingCrisis({ pending: true, currentWeek: 5 });
 
-    const res = await request(app)
-      .post('/api/advance-week')
-      .send({ gameId, selectedActions: [], sideEventChoice: { eventId: EVENT_ID, choiceId: CHOICE_ID } });
+    // DETERMINISM: suppress the weekly side-event roll for this advance. With the
+    // real weekly_chance (0.20) and a random gameId (no pinned rngSeed), ~1 in 5
+    // resolve-advances would legitimately roll a NEW crisis in the same advance,
+    // and the strict pending_side_event toBeUndefined below would flake. Same
+    // pattern as the golden-master sideEventResolve fixture: isolate the
+    // resolution path from a fresh roll.
+    const eventConfigSpy = vi
+      .spyOn(serverGameData, 'getEventConfigSync')
+      .mockReturnValue({ weekly_chance: 0, cooldown_weeks: 2, max_per_year: 12 });
+    try {
+      const res = await request(app)
+        .post('/api/advance-week')
+        .send({ gameId, selectedActions: [], sideEventChoice: { eventId: EVENT_ID, choiceId: CHOICE_ID } });
 
-    expect(res.status).toBe(200);
-    expect(res.body.gameState.currentWeek).toBe(6);
+      expect(res.status).toBe(200);
+      expect(res.body.gameState.currentWeek).toBe(6);
 
-    const { eq } = await import('drizzle-orm');
-    const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
-    expect(gs.currentWeek).toBe(6);
-    // Pending cleared.
-    expect((gs.flags as any).pending_side_event).toBeUndefined();
-    // Immediate +20000 applied during the advance (money = 100000 + 20000 - weekly burn).
-    expect(gs.money).toBeGreaterThan(100000);
+      const { eq } = await import('drizzle-orm');
+      const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+      expect(gs.currentWeek).toBe(6);
+      // Pending cleared.
+      expect((gs.flags as any).pending_side_event).toBeUndefined();
+      // Immediate +20000 applied during the advance (money = 100000 + 20000 - weekly burn).
+      expect(gs.money).toBeGreaterThan(100000);
+    } finally {
+      eventConfigSpy.mockRestore();
+    }
+  });
+
+  it('orphaned pending event (id deleted from data): advance proceeds, engine self-heals the flag, no effects applied', async () => {
+    // Seed a pending crisis whose eventId does not exist in data/events.json —
+    // simulates a Content Editor deletion between defer and resolve. The gate
+    // must NOT deadlock the run on a permanent 400: it lets the advance proceed
+    // (forwarding a synthetic resolution) and the engine's self-heal clears the
+    // orphaned flag without effects.
+    const ORPHANED_ID = 'deleted_via_content_editor';
+    const gameId = crypto.randomUUID();
+    await db.insert(gameStates).values({
+      id: gameId,
+      userId: TEST_USER_ID,
+      currentWeek: 5,
+      money: 100000,
+      reputation: 10,
+      creativeCapital: 5,
+      focusSlots: 3,
+      usedFocusSlots: 0,
+      venueAccess: 'clubs',
+      campaignCompleted: false,
+      flags: { pending_side_event: { eventId: ORPHANED_ID, week: 5, prompt: 'x', category: 'sync_licensing', choices: [] } },
+    });
+    await db.insert(artists).values({
+      id: crypto.randomUUID(),
+      gameId,
+      name: 'Test Artist',
+      archetype: 'Workhorse',
+      genre: 'pop',
+      mood: 50,
+      energy: 50,
+      popularity: 40,
+    });
+    await db.insert(executives).values([
+      { id: crypto.randomUUID(), gameId, role: 'head_ar', level: 1, mood: 50, loyalty: 50 },
+    ]);
+
+    // Suppress the weekly roll (determinism — see the resolve test above).
+    const eventConfigSpy = vi
+      .spyOn(serverGameData, 'getEventConfigSync')
+      .mockReturnValue({ weekly_chance: 0, cooldown_weeks: 2, max_per_year: 12 });
+    try {
+      // No sideEventChoice sent — the player CANNOT pick for a deleted event.
+      const res = await request(app)
+        .post('/api/advance-week')
+        .send({ gameId, selectedActions: [] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.gameState.currentWeek).toBe(6);
+
+      const { eq } = await import('drizzle-orm');
+      const [gs] = await db.select().from(gameStates).where(eq(gameStates.id, gameId));
+      expect(gs.currentWeek).toBe(6);
+      // Orphaned flag cleared by the engine self-heal.
+      expect((gs.flags as any).pending_side_event).toBeUndefined();
+      // No side-event effects applied: money only moved by normal weekly costs
+      // (never up — the orphaned event granted nothing).
+      expect(gs.money).toBeLessThanOrEqual(100000);
+    } finally {
+      eventConfigSpy.mockRestore();
+    }
   });
 
   it('advances normally (no gate) when no crisis is pending', async () => {

--- a/tests/engine/__snapshots__/golden-master-advance-week.test.ts.snap
+++ b/tests/engine/__snapshots__/golden-master-advance-week.test.ts.snap
@@ -5717,6 +5717,772 @@ Performance Indicators:
 }
 `;
 
+exports[`GameEngine.advanceWeek — golden master > side-event defer: a rolled crisis lands as a pending flag (deferred, no effects this week) 1`] = `
+{
+  "digest": {
+    "artists": [
+      {
+        "age": null,
+        "archetype": "Workhorse",
+        "bio": null,
+        "creativity": 50,
+        "energy": 53,
+        "experience": 0,
+        "gameId": "<id>",
+        "genre": "pop",
+        "id": "<id>",
+        "lastAttentionWeek": 1,
+        "lastMoodEvent": null,
+        "massAppeal": 50,
+        "mood": 50,
+        "moodHistory": [],
+        "moodTrend": 0,
+        "name": "Crisis Artist",
+        "popularity": 50,
+        "signed": true,
+        "signedWeek": null,
+        "signingCost": null,
+        "stress": 0,
+        "talent": 60,
+        "temperament": 50,
+        "weeklyCost": 1200,
+        "workEthic": 70,
+      },
+    ],
+    "charts": {
+      "competitorChecksum": -86029892,
+      "competitorCount": 98,
+      "playerEntries": [],
+    },
+    "emails": [
+      {
+        "body": {
+          "amount": 0,
+          "description": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+          "greeting": "Boss,",
+          "narrative": "Revenue threshold achieved. New distribution tier unlocked.
+
+TIER: 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.
+
+New capabilities are live:
+• Expanded playlist access
+• Higher inclusion probability
+
+System automatically grants access. No action required.",
+          "narrativeBody": "Boss,
+
+Revenue threshold achieved. New distribution tier unlocked.
+
+TIER: 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.
+
+New capabilities are live:
+• Expanded playlist access
+• Higher inclusion probability
+
+System automatically grants access. No action required.
+
+Per our projections,
+- Patricia Williams, PhD",
+          "signOff": "Per our projections,
+- Patricia Williams, PhD",
+          "subject": "Playlist Tier Unlocked – 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        },
+        "category": "financial",
+        "createdAt": "<timestamp>",
+        "gameId": "<id>",
+        "id": "<id>",
+        "isRead": false,
+        "metadata": {
+          "amount": 0,
+          "description": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+          "moodBand": "neutral",
+          "narrativeBody": "Boss,
+
+Revenue threshold achieved. New distribution tier unlocked.
+
+TIER: 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.
+
+New capabilities are live:
+• Expanded playlist access
+• Higher inclusion probability
+
+System automatically grants access. No action required.
+
+Per our projections,
+- Patricia Williams, PhD",
+          "tierKind": "playlist",
+        },
+        "preview": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        "sender": "Patricia "Pat" Williams, PhD",
+        "senderRoleId": "<id>",
+        "subject": "Playlist Tier Unlocked – 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        "updatedAt": "<timestamp>",
+        "week": 4,
+      },
+      {
+        "body": {
+          "amount": 0,
+          "description": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+          "greeting": "Boss,",
+          "narrative": "You just opened doors most labels take years to access.
+
+NEW TIER: 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.
+
+Translation? We can now pitch to publications that actually move markets. This isn't just press access—it's narrative control at scale.",
+          "narrativeBody": "Boss,
+
+You just opened doors most labels take years to access.
+
+NEW TIER: 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.
+
+Translation? We can now pitch to publications that actually move markets. This isn't just press access—it's narrative control at scale.
+
+By the numbers,
+- Samara Chen
+
+P.S. – Already have three story angles ready to deploy.",
+          "quirk": "P.S. – Already have three story angles ready to deploy.",
+          "signOff": "By the numbers,
+- Samara Chen",
+          "subject": "Press Tier Unlocked – 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        },
+        "category": "financial",
+        "createdAt": "<timestamp>",
+        "gameId": "<id>",
+        "id": "<id>",
+        "isRead": false,
+        "metadata": {
+          "amount": 0,
+          "description": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+          "moodBand": "neutral",
+          "narrativeBody": "Boss,
+
+You just opened doors most labels take years to access.
+
+NEW TIER: 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.
+
+Translation? We can now pitch to publications that actually move markets. This isn't just press access—it's narrative control at scale.
+
+By the numbers,
+- Samara Chen
+
+P.S. – Already have three story angles ready to deploy.",
+          "tierKind": "press",
+        },
+        "preview": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        "sender": "Samara "Sam" Chen",
+        "senderRoleId": "<id>",
+        "subject": "Press Tier Unlocked – 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        "updatedAt": "<timestamp>",
+        "week": 4,
+      },
+      {
+        "body": {
+          "expenseBreakdown": {
+            "artistSalaries": 1200,
+            "executiveSalaries": 0,
+            "marketingCosts": 0,
+            "projectCosts": 0,
+            "roleMeetingCosts": 0,
+            "signingBonuses": 0,
+            "weeklyOperations": 2156,
+          },
+          "expenses": 3356,
+          "financialBreakdown": "$500,000 - $2,156 (operations) - $1,200 (artists) = $496,644",
+          "greeting": "Financial Report – Week 4",
+          "narrative": "REVENUE: $0
+EXPENSES: $3,356
+NET: -$3,356
+
+⚠ Warning Indicators:
+• Expense ratio: 0% (target: <70%)
+• Cash flow: Negative
+• Burn rate: $3,356/week
+
+Immediate attention recommended.",
+          "narrativeBody": "Financial Report – Week 4
+
+REVENUE: $0
+EXPENSES: $3,356
+NET: -$3,356
+
+⚠ Warning Indicators:
+• Expense ratio: 0% (target: <70%)
+• Cash flow: Negative
+• Burn rate: $3,356/week
+
+Immediate attention recommended.
+
+— Finance Department",
+          "revenue": 0,
+          "signOff": "— Finance Department",
+          "streams": 0,
+          "subject": "Week 4 Financial Summary",
+        },
+        "category": "financial",
+        "createdAt": "<timestamp>",
+        "gameId": "<id>",
+        "id": "<id>",
+        "isRead": false,
+        "metadata": {
+          "expenseBreakdown": {
+            "artistSalaries": 1200,
+            "executiveSalaries": 0,
+            "marketingCosts": 0,
+            "projectCosts": 0,
+            "roleMeetingCosts": 0,
+            "signingBonuses": 0,
+            "weeklyOperations": 2156,
+          },
+          "expenses": 3356,
+          "financialBreakdown": "$500,000 - $2,156 (operations) - $1,200 (artists) = $496,644",
+          "isProfit": false,
+          "narrativeBody": "Financial Report – Week 4
+
+REVENUE: $0
+EXPENSES: $3,356
+NET: -$3,356
+
+⚠ Warning Indicators:
+• Expense ratio: 0% (target: <70%)
+• Cash flow: Negative
+• Burn rate: $3,356/week
+
+Immediate attention recommended.
+
+— Finance Department",
+          "net": -3356,
+          "revenue": 0,
+          "streams": 0,
+        },
+        "preview": "Revenue $0 • Expenses $3356",
+        "sender": "Finance Department",
+        "senderRoleId": null,
+        "subject": "Week 4 Financial Summary",
+        "updatedAt": "<timestamp>",
+        "week": 4,
+      },
+    ],
+    "executives": [],
+    "projects": [],
+    "releaseSongs": [],
+    "releases": [],
+    "songs": [],
+  },
+  "stateDelta": {
+    "currentWeek": {
+      "after": 4,
+      "before": 3,
+    },
+    "flags": {
+      "after": {
+        "pending_side_event": {
+          "category": "business_opportunities",
+          "choices": [
+            {
+              "effects_delayed": {
+                "reputation": 2,
+              },
+              "effects_immediate": {
+                "money": 12000,
+              },
+              "id": "<id>",
+              "label": "Take the deal",
+            },
+            {
+              "effects_delayed": {},
+              "effects_immediate": {
+                "reputation": 1,
+              },
+              "id": "<id>",
+              "label": "Walk away",
+            },
+          ],
+          "eventId": "gm_crisis",
+          "prompt": "A distributor offers a lucrative but risky catalog deal.",
+          "week": 4,
+        },
+        "side_event_history": {
+          "gm_crisis": 4,
+        },
+        "unlocked_producer_tiers": [
+          "local",
+        ],
+      },
+      "before": {},
+    },
+    "money": {
+      "after": 496644,
+      "before": 500000,
+    },
+    "playlistAccess": {
+      "after": "niche",
+      "before": "none",
+    },
+    "pressAccess": {
+      "after": "blogs",
+      "before": "none",
+    },
+  },
+  "summary": {
+    "arOffice": {
+      "completed": false,
+    },
+    "artistChanges": {
+      "<uuid-key>": {
+        "energy": 0,
+        "mood": 0,
+      },
+    },
+    "changes": [
+      {
+        "amount": 3,
+        "artistId": "<id>",
+        "description": "Crisis Artist: +3 energy — a week to breathe",
+        "importance": "routine",
+        "type": "energy",
+      },
+      {
+        "amount": -3356,
+        "description": "Weekly operational costs",
+        "importance": "routine",
+        "type": "expense",
+      },
+      {
+        "amount": 0,
+        "description": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        "importance": "hero",
+        "type": "unlock",
+      },
+      {
+        "amount": 0,
+        "description": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        "importance": "hero",
+        "type": "unlock",
+      },
+    ],
+    "chartUpdates": {
+      "competitorChecksum": -1590080495,
+      "competitorCount": 98,
+      "playerEntries": [],
+    },
+    "events": [
+      {
+        "category": "business_opportunities",
+        "id": "<id>",
+        "occurred": true,
+        "prompt": "A distributor offers a lucrative but risky catalog deal.",
+        "title": "A distributor offers a lucrative but risky catalog",
+      },
+    ],
+    "expenseBreakdown": {
+      "artistSalaries": 1200,
+      "executiveSalaries": 0,
+      "marketingCosts": 0,
+      "projectCosts": 0,
+      "roleMeetingCosts": 0,
+      "signingBonuses": 0,
+      "weeklyOperations": 2156,
+    },
+    "expenses": 3356,
+    "financialBreakdown": "$500,000 - $2,156 (operations) - $1,200 (artists) = $496,644",
+    "generatedEmails": 3,
+    "reputationChanges": {},
+    "revenue": 0,
+    "usedExecutives": {},
+    "week": 4,
+  },
+}
+`;
+
+exports[`GameEngine.advanceWeek — golden master > side-event resolve: a pending crisis carried with the advance applies its effects and clears 1`] = `
+{
+  "digest": {
+    "artists": [
+      {
+        "age": null,
+        "archetype": "Workhorse",
+        "bio": null,
+        "creativity": 50,
+        "energy": 53,
+        "experience": 0,
+        "gameId": "<id>",
+        "genre": "pop",
+        "id": "<id>",
+        "lastAttentionWeek": 1,
+        "lastMoodEvent": null,
+        "massAppeal": 50,
+        "mood": 50,
+        "moodHistory": [],
+        "moodTrend": 0,
+        "name": "Resolver Artist",
+        "popularity": 50,
+        "signed": true,
+        "signedWeek": null,
+        "signingCost": null,
+        "stress": 0,
+        "talent": 60,
+        "temperament": 50,
+        "weeklyCost": 1200,
+        "workEthic": 70,
+      },
+    ],
+    "charts": {
+      "competitorChecksum": 38080924,
+      "competitorCount": 98,
+      "playerEntries": [],
+    },
+    "emails": [
+      {
+        "body": {
+          "amount": 0,
+          "description": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+          "greeting": "Boss,",
+          "narrative": "Revenue threshold achieved. New distribution tier unlocked.
+
+TIER: 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.
+
+New capabilities are live:
+• Expanded playlist access
+• Higher inclusion probability
+
+System automatically grants access. No action required.",
+          "narrativeBody": "Boss,
+
+Revenue threshold achieved. New distribution tier unlocked.
+
+TIER: 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.
+
+New capabilities are live:
+• Expanded playlist access
+• Higher inclusion probability
+
+System automatically grants access. No action required.
+
+Per our projections,
+- Patricia Williams, PhD",
+          "signOff": "Per our projections,
+- Patricia Williams, PhD",
+          "subject": "Playlist Tier Unlocked – 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        },
+        "category": "financial",
+        "createdAt": "<timestamp>",
+        "gameId": "<id>",
+        "id": "<id>",
+        "isRead": false,
+        "metadata": {
+          "amount": 0,
+          "description": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+          "moodBand": "neutral",
+          "narrativeBody": "Boss,
+
+Revenue threshold achieved. New distribution tier unlocked.
+
+TIER: 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.
+
+New capabilities are live:
+• Expanded playlist access
+• Higher inclusion probability
+
+System automatically grants access. No action required.
+
+Per our projections,
+- Patricia Williams, PhD",
+          "tierKind": "playlist",
+        },
+        "preview": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        "sender": "Patricia "Pat" Williams, PhD",
+        "senderRoleId": "<id>",
+        "subject": "Playlist Tier Unlocked – 🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        "updatedAt": "<timestamp>",
+        "week": 4,
+      },
+      {
+        "body": {
+          "amount": 0,
+          "description": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+          "greeting": "Boss,",
+          "narrative": "You just opened doors most labels take years to access.
+
+NEW TIER: 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.
+
+Translation? We can now pitch to publications that actually move markets. This isn't just press access—it's narrative control at scale.",
+          "narrativeBody": "Boss,
+
+You just opened doors most labels take years to access.
+
+NEW TIER: 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.
+
+Translation? We can now pitch to publications that actually move markets. This isn't just press access—it's narrative control at scale.
+
+By the numbers,
+- Samara Chen",
+          "signOff": "By the numbers,
+- Samara Chen",
+          "subject": "Press Tier Unlocked – 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        },
+        "category": "financial",
+        "createdAt": "<timestamp>",
+        "gameId": "<id>",
+        "id": "<id>",
+        "isRead": false,
+        "metadata": {
+          "amount": 0,
+          "description": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+          "moodBand": "neutral",
+          "narrativeBody": "Boss,
+
+You just opened doors most labels take years to access.
+
+NEW TIER: 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.
+
+Translation? We can now pitch to publications that actually move markets. This isn't just press access—it's narrative control at scale.
+
+By the numbers,
+- Samara Chen",
+          "tierKind": "press",
+        },
+        "preview": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        "sender": "Samara "Sam" Chen",
+        "senderRoleId": "<id>",
+        "subject": "Press Tier Unlocked – 📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        "updatedAt": "<timestamp>",
+        "week": 4,
+      },
+      {
+        "body": {
+          "expenseBreakdown": {
+            "artistSalaries": 1200,
+            "executiveSalaries": 0,
+            "marketingCosts": 0,
+            "projectCosts": 0,
+            "roleMeetingCosts": 0,
+            "signingBonuses": 0,
+            "weeklyOperations": 2299,
+          },
+          "expenses": 3499,
+          "financialBreakdown": "$500,000 - $2,299 (operations) - $1,200 (artists) + $12,000 (streaming) = $508,501",
+          "greeting": "Financial Report – Week 4",
+          "narrative": "REVENUE: $12,000
+EXPENSES: $3,499
+NET: +$8,501
+
+Performance Indicators:
+✓ Expense ratio: 29% (target: <70%)
+✓ Cash flow: Positive
+",
+          "narrativeBody": "Financial Report – Week 4
+
+REVENUE: $12,000
+EXPENSES: $3,499
+NET: +$8,501
+
+Performance Indicators:
+✓ Expense ratio: 29% (target: <70%)
+✓ Cash flow: Positive
+
+
+— Finance Department",
+          "revenue": 12000,
+          "signOff": "— Finance Department",
+          "streams": 0,
+          "subject": "Week 4 Financial Summary",
+        },
+        "category": "financial",
+        "createdAt": "<timestamp>",
+        "gameId": "<id>",
+        "id": "<id>",
+        "isRead": false,
+        "metadata": {
+          "expenseBreakdown": {
+            "artistSalaries": 1200,
+            "executiveSalaries": 0,
+            "marketingCosts": 0,
+            "projectCosts": 0,
+            "roleMeetingCosts": 0,
+            "signingBonuses": 0,
+            "weeklyOperations": 2299,
+          },
+          "expenses": 3499,
+          "financialBreakdown": "$500,000 - $2,299 (operations) - $1,200 (artists) + $12,000 (streaming) = $508,501",
+          "isProfit": true,
+          "narrativeBody": "Financial Report – Week 4
+
+REVENUE: $12,000
+EXPENSES: $3,499
+NET: +$8,501
+
+Performance Indicators:
+✓ Expense ratio: 29% (target: <70%)
+✓ Cash flow: Positive
+
+
+— Finance Department",
+          "net": 8501,
+          "revenue": 12000,
+          "streams": 0,
+        },
+        "preview": "Revenue $12000 • Expenses $3499",
+        "sender": "Finance Department",
+        "senderRoleId": null,
+        "subject": "Week 4 Financial Summary",
+        "updatedAt": "<timestamp>",
+        "week": 4,
+      },
+    ],
+    "executives": [],
+    "projects": [],
+    "releaseSongs": [],
+    "releases": [],
+    "songs": [],
+  },
+  "stateDelta": {
+    "currentWeek": {
+      "after": 4,
+      "before": 3,
+    },
+    "flags": {
+      "after": {
+        "side-event-gm_crisis-accept-week4": {
+          "choiceId": "<id>",
+          "effects": {
+            "reputation": 2,
+          },
+          "meetingName": "side_event:gm_crisis",
+          "triggerWeek": 5,
+        },
+        "unlocked_producer_tiers": [
+          "local",
+        ],
+      },
+      "before": {
+        "pending_side_event": {
+          "category": "business_opportunities",
+          "choices": [
+            {
+              "effects_delayed": {
+                "reputation": 2,
+              },
+              "effects_immediate": {
+                "money": 12000,
+              },
+              "id": "<id>",
+              "label": "Take the deal",
+            },
+            {
+              "effects_delayed": {},
+              "effects_immediate": {
+                "reputation": 1,
+              },
+              "id": "<id>",
+              "label": "Walk away",
+            },
+          ],
+          "eventId": "gm_crisis",
+          "prompt": "A distributor offers a lucrative but risky catalog deal.",
+          "week": 3,
+        },
+      },
+    },
+    "money": {
+      "after": 508501,
+      "before": 500000,
+    },
+    "playlistAccess": {
+      "after": "niche",
+      "before": "none",
+    },
+    "pressAccess": {
+      "after": "blogs",
+      "before": "none",
+    },
+  },
+  "summary": {
+    "arOffice": {
+      "completed": false,
+    },
+    "artistChanges": {
+      "<uuid-key>": {
+        "energy": 0,
+        "mood": 0,
+      },
+    },
+    "changes": [
+      {
+        "amount": 12000,
+        "description": "Executive meeting benefit",
+        "importance": "routine",
+        "type": "revenue",
+      },
+      {
+        "amount": 3,
+        "artistId": "<id>",
+        "description": "Resolver Artist: +3 energy — a week to breathe",
+        "importance": "routine",
+        "type": "energy",
+      },
+      {
+        "amount": -3499,
+        "description": "Weekly operational costs",
+        "importance": "routine",
+        "type": "expense",
+      },
+      {
+        "amount": 0,
+        "description": "🎵 Playlist Access Upgraded: Niche playlists unlocked! Your releases can now reach wider audiences.",
+        "importance": "hero",
+        "type": "unlock",
+      },
+      {
+        "amount": 0,
+        "description": "📰 Press Access Upgraded: Music Blogs coverage unlocked! Your projects will get better media attention.",
+        "importance": "hero",
+        "type": "unlock",
+      },
+    ],
+    "chartUpdates": {
+      "competitorChecksum": 1613480601,
+      "competitorCount": 98,
+      "playerEntries": [],
+    },
+    "events": [
+      {
+        "category": "business_opportunities",
+        "choiceId": "<id>",
+        "choiceLabel": "Take the deal",
+        "delayedEffects": {
+          "reputation": 2,
+        },
+        "effects": {
+          "money": 12000,
+        },
+        "id": "<id>",
+        "occurred": true,
+        "prompt": "A distributor offers a lucrative but risky catalog deal.",
+        "resolved": true,
+        "title": "A distributor offers a lucrative but risky catalog",
+      },
+    ],
+    "expenseBreakdown": {
+      "artistSalaries": 1200,
+      "executiveSalaries": 0,
+      "marketingCosts": 0,
+      "projectCosts": 0,
+      "roleMeetingCosts": 0,
+      "signingBonuses": 0,
+      "weeklyOperations": 2299,
+    },
+    "expenses": 3499,
+    "financialBreakdown": "$500,000 - $2,299 (operations) - $1,200 (artists) + $12,000 (streaming) = $508,501",
+    "generatedEmails": 3,
+    "reputationChanges": {},
+    "revenue": 12000,
+    "usedExecutives": {},
+    "week": 4,
+  },
+}
+`;
+
 exports[`GameEngine.advanceWeek — golden master > tour-week: active Mini-Tour produces city revenue + variance + mood impacts 1`] = `
 {
   "digest": {

--- a/tests/engine/golden-master-advance-week.test.ts
+++ b/tests/engine/golden-master-advance-week.test.ts
@@ -56,7 +56,36 @@ const IDS = {
   lowMoodRecording: '00000000-0000-4000-8000-00000000000c',
   underEnergyTour: '00000000-0000-4000-8000-00000000000d',
   saturatedTour: '00000000-0000-4000-8000-00000000000e',
+  // Mandatory Side Events additive fixtures ("Crisis on the Desk", 2026-07-11).
+  sideEventDefer: '00000000-0000-4000-8000-00000000000f',
+  sideEventResolve: '00000000-0000-4000-8000-000000000010',
 };
+
+// A deterministic single-event catalog + config decorator forcing a side-event
+// hit (weekly_chance 1) in mandatory mode. Used only by the two additive
+// side-event fixtures below — every other scenario keeps weekly_chance 0 (no
+// event), so their snapshots are untouched.
+const CRISIS_EVENT = {
+  id: 'gm_crisis',
+  role_hint: 'x',
+  category: 'business_opportunities' as const,
+  prompt: 'A distributor offers a lucrative but risky catalog deal.',
+  choices: [
+    { id: 'accept', label: 'Take the deal', effects_immediate: { money: 12000 }, effects_delayed: { reputation: 2 } },
+    { id: 'decline', label: 'Walk away', effects_immediate: { reputation: 1 }, effects_delayed: {} },
+  ],
+};
+
+function forceCrisisGameData(gd: any): any {
+  return {
+    ...gd,
+    getMandatorySideEventsConfigSync: () => ({ enabled: true }),
+    getEventConfigSync: () => ({ weekly_chance: 1, cooldown_weeks: 2, max_per_year: 12 }),
+    getSideEventsConfigSync: () => ({ event_weights: { business_opportunities: 1 }, event_cooldown: 2 }),
+    getAllEvents: async () => [CRISIS_EVENT],
+    getEventById: async (id: string) => (id === CRISIS_EVENT.id ? CRISIS_EVENT : undefined),
+  };
+}
 
 let db: TestDb;
 
@@ -98,9 +127,17 @@ async function seedArtist(gameId: string, over: Record<string, any> = {}) {
  * Runs advanceWeek inside a real transaction (mirrors production gameLoop.ts).
  * Returns the (normalized) snapshot payload for the scenario.
  */
-async function runScenario(gameId: string, gameStateOverrides: Record<string, any>, actions: any[] = [], catalogArtists: any[] = []) {
+async function runScenario(
+  gameId: string,
+  gameStateOverrides: Record<string, any>,
+  actions: any[] = [],
+  catalogArtists: any[] = [],
+  opts: { decorateGameData?: (gd: any) => any; sideEventChoice?: { eventId: string; choiceId: string } } = {}
+) {
   const storage = new DatabaseStorage(db);
-  const gameData = createGameData(storage, catalogArtists);
+  const gameData = opts.decorateGameData
+    ? opts.decorateGameData(createGameData(storage, catalogArtists))
+    : createGameData(storage, catalogArtists);
   const gameState = makeGameState(gameId, gameStateOverrides);
 
   const before = snapshotState(gameState);
@@ -111,7 +148,7 @@ async function runScenario(gameId: string, gameStateOverrides: Record<string, an
 
   let summary: any;
   await (db as any).transaction(async (tx: any) => {
-    const result = await engine.advanceWeek(actions, tx);
+    const result = await engine.advanceWeek(actions, tx, { sideEventChoice: opts.sideEventChoice ?? null });
     summary = result.summary;
   });
 
@@ -583,6 +620,58 @@ describe('GameEngine.advanceWeek — golden master', () => {
     });
 
     const snap = await runScenario(IDS.saturatedTour, { id: IDS.saturatedTour, currentWeek: 3, venueAccess: 'clubs' });
+    expect(snap).toMatchSnapshot();
+  });
+
+  // --- Mandatory Side Events ("Crisis on the Desk") additive fixtures ---------
+  // These force a side-event hit (weekly_chance 1) so the mandatory deferral +
+  // resolution paths are captured in the golden master. All OTHER fixtures keep
+  // weekly_chance 0, so this does NOT touch their snapshots.
+
+  it('side-event defer: a rolled crisis lands as a pending flag (deferred, no effects this week)', async () => {
+    await seedGame(IDS.sideEventDefer, 3);
+    await seedArtist(IDS.sideEventDefer, { name: 'Crisis Artist' });
+
+    const snap = await runScenario(
+      IDS.sideEventDefer,
+      { id: IDS.sideEventDefer, currentWeek: 3 },
+      [],
+      [],
+      { decorateGameData: forceCrisisGameData }
+    );
+    expect(snap).toMatchSnapshot();
+  });
+
+  it('side-event resolve: a pending crisis carried with the advance applies its effects and clears', async () => {
+    await seedGame(IDS.sideEventResolve, 3, {
+      // Pending crisis already on the spine from the prior week (arrival week 4
+      // after this advance's increment; the resolution matches by eventId).
+      flags: { pending_side_event: { eventId: CRISIS_EVENT.id, week: 3, prompt: CRISIS_EVENT.prompt, category: CRISIS_EVENT.category, choices: CRISIS_EVENT.choices } },
+    });
+    await seedArtist(IDS.sideEventResolve, { name: 'Resolver Artist' });
+
+    const snap = await runScenario(
+      IDS.sideEventResolve,
+      {
+        id: IDS.sideEventResolve,
+        currentWeek: 3,
+        flags: { pending_side_event: { eventId: CRISIS_EVENT.id, week: 3, prompt: CRISIS_EVENT.prompt, category: CRISIS_EVENT.category, choices: CRISIS_EVENT.choices } },
+      },
+      [],
+      [],
+      {
+        // weekly_chance 0 for this one so the resolution is isolated from a new
+        // roll; only the resolution path runs.
+        decorateGameData: (gd) => ({
+          ...gd,
+          getMandatorySideEventsConfigSync: () => ({ enabled: true }),
+          getEventConfigSync: () => ({ weekly_chance: 0, cooldown_weeks: 2, max_per_year: 12 }),
+          getAllEvents: async () => [CRISIS_EVENT],
+          getEventById: async (id: string) => (id === CRISIS_EVENT.id ? CRISIS_EVENT : undefined),
+        }),
+        sideEventChoice: { eventId: CRISIS_EVENT.id, choiceId: 'accept' },
+      }
+    );
     expect(snap).toMatchSnapshot();
   });
 });

--- a/tests/engine/golden-master-fixtures.ts
+++ b/tests/engine/golden-master-fixtures.ts
@@ -117,6 +117,12 @@ export function createGameData(storage: DatabaseStorage, catalogArtists: any[] =
     getAccessTiersSync: () => progression.access_tier_system,
     getMarketConfigSync: () => markets,
     getEventConfigSync: () => ({ weekly_chance: 0, event_types: [] }),
+    // Mandatory Side Events ("Crisis on the Desk"): production default (ON). With
+    // weekly_chance 0 no side event ever fires in the golden master and no fixture
+    // seeds a pending crisis, so ON vs OFF is behaviorally identical here — the
+    // engine's checkForEvents just reads this to decide lapse-vs-defer, and
+    // neither branch runs. Present so checkForEvents never TypeErrors on the call.
+    getMandatorySideEventsConfigSync: () => ({ enabled: true }),
     getWeeklyBurnRangeSync: () => balance.economy?.weekly_burn_range || [1500, 2500],
     getProgressionThresholdsSync: () => progression,
     getProducerTierSystemSync: () => progression.producer_tiers || {},

--- a/tests/engine/side-event-check-for-events.test.ts
+++ b/tests/engine/side-event-check-for-events.test.ts
@@ -28,14 +28,19 @@ function makeEvents(): SideEvent[] {
   ];
 }
 
-function makeGameData(weeklyChance: number, events: SideEvent[]): any {
+function makeGameData(weeklyChance: number, events: SideEvent[], mandatory = false): any {
   return {
     getEventConfigSync: () => ({ weekly_chance: weeklyChance, cooldown_weeks: 2, max_per_year: 12 }),
+    // Mandatory Side Events kill-switch. Defaults to OFF here so the existing
+    // characterization tests below document the LEGACY in-results path; the
+    // mandatory-mode suite passes true explicitly.
+    getMandatorySideEventsConfigSync: () => ({ enabled: mandatory }),
     getSideEventsConfigSync: () => ({
       event_weights: { sync_licensing: 1 },
       event_cooldown: 2,
     }),
     getAllEvents: async () => events,
+    getEventById: async (id: string) => events.find((e) => e.id === id),
     // FinancialSystem's constructor runs validateConfiguration(), which reads
     // tour + venue config. Minimal valid stubs so construction succeeds; these
     // are never exercised by checkForEvents.
@@ -177,5 +182,56 @@ describe('checkForEvents — lapse rule', () => {
     // The stale one lapsed and was replaced by this week's fresh pending.
     expect(flags.pending_side_event).toEqual({ eventId: 'sync_offer', week: 6 });
     expect(summary.events).toHaveLength(1);
+  });
+});
+
+describe('checkForEvents — MANDATORY mode ("Crisis on the Desk")', () => {
+  it('on a hit, stores the RICHER pending payload (prompt/category/choices) and NO choices on the summary occurrence', async () => {
+    const gs = makeGameState({ currentWeek: 5, flags: {} });
+    const summary = makeSummary();
+    await runCheck(gs, makeGameData(1, makeEvents(), true), summary);
+
+    const pending = (gs.flags as any).pending_side_event;
+    expect(pending.eventId).toBe('sync_offer');
+    expect(pending.week).toBe(5);
+    expect(pending.prompt).toBe('A blockbuster film wants your single.');
+    expect(pending.category).toBe('sync_licensing');
+    expect(pending.choices).toHaveLength(1);
+
+    // The interactive beat is suppressed this week — the occurrence carries NO
+    // choices (the crisis card reads the pending flag next week instead).
+    expect(summary.events).toHaveLength(1);
+    expect(summary.events[0].choices).toBeUndefined();
+  });
+
+  it('does NOT lapse a prior-week pending crisis (mandatory events never silently drop)', async () => {
+    const gs = makeGameState({
+      currentWeek: 6,
+      flags: { pending_side_event: { eventId: 'sync_offer', week: 5 } },
+    });
+    const summary = makeSummary();
+    // weekly_chance 0 so no new roll interferes.
+    await runCheck(gs, makeGameData(0, makeEvents(), true), summary);
+
+    // The stale pending survives (would have lapsed in legacy mode).
+    expect((gs.flags as any).pending_side_event).toEqual({ eventId: 'sync_offer', week: 5 });
+  });
+
+  it('ONE CRISIS AT A TIME: a roll while one is pending draws but discards the result (pending unchanged, no summary push)', async () => {
+    const existing = { eventId: 'sync_offer', week: 5, prompt: 'x', category: 'sync_licensing', choices: [] };
+    const gs = makeGameState({
+      currentWeek: 6,
+      flags: { pending_side_event: existing, side_event_history: { sync_offer: 5 } },
+    });
+    const summary = makeSummary();
+    // weekly_chance 1 → the draw happens (stream discipline) but the result is
+    // discarded because a crisis is already pending.
+    await runCheck(gs, makeGameData(1, makeEvents(), true), summary);
+
+    // Pending is unchanged; no new occurrence; the discarded pick did not stamp
+    // history (still week 5, not 6).
+    expect((gs.flags as any).pending_side_event).toEqual(existing);
+    expect(summary.events).toHaveLength(0);
+    expect((gs.flags as any).side_event_history.sync_offer).toBe(5);
   });
 });


### PR DESCRIPTION
## Summary
**Mandatory Side Events — "Crisis on the Desk"** (product decision from the 2026-07-11 structured playtest: side events should be mandatory and cost a focus slot).

- The seeded in-stream 20% roll is **byte-position-identical** (verifier-confirmed; discard-while-pending still draws). The rolled event now defers to `flags.pending_side_event` and lands the NEXT week as a mandatory crisis card **occupying one focus slot** (SYNC_SLOTS threading: manual UI, XState machine, AUTO, GameHeader, server meeting-selection gate — A&R-busy + crisis correctly stacks to −2).
- **Advance is gated** client-side and server-side (400 `PENDING_SIDE_EVENT`, inside the FOR UPDATE transaction, before the week runs) until a choice is picked; resolution effects apply during that advance (immediate) + delayed at +1 week. Crisis-only weeks (all slots eaten) remain playable and advanceable.
- One crisis at a time; campaign-end exemption (DB-derived, not client-injectable); save/restore round-trips at SNAPSHOT_VERSION 2 (passthrough-verified); kill-switch `mandatory_side_events.enabled`.
- WeekSummary gets a "Crisis Handled" notable beat; the legacy in-results interactive beat self-suppresses (and the legacy endpoint is mutex-safe via the shared flag + FOR UPDATE — no double-apply on any ordering).
- Verifier-driven hardening (`7ba9fc4`): de-flaked the resolve-advance characterization test (deterministic `weekly_chance: 0` stub; 10/10 consecutive green) and fixed the orphaned-event deadlock (event id deleted via Content Editor between defer and resolve → advance now proceeds and the engine self-heal clears the flag without effects, regression-tested).

Doc-sync in-slice: spec (`[READY] mandatory-side-events-plan.md`), systems-map side-events node, Label Head's Guide side-events topic.

## Verification
- tsc clean; suite **1,833/1,833** (baseline 1,815 → +18).
- GM: 14 pre-existing snapshots byte-identical (zero drift); 2 new forced-event fixtures (defer + resolve); double-run stable; zero RNG-stream changes in `shared/`.
- Fresh-context adversarial verifier: 9/10 CONFIRMED + 2 findings, both fixed same pass as prescribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
