### PR TITLE
feat(admin): round-2 playtest feedback form (v2) — versioned capture, round-1 answers preserved

### DIFF
--- a/client/src/admin/PlaytestFeedbackPage.tsx
+++ b/client/src/admin/PlaytestFeedbackPage.tsx
@@ -13,42 +13,40 @@ import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import {
-  buildEmptyPlaytestFeedbackResponses,
-  type PlaytestFeedbackResponses,
+  ACTIVE_PLAYTEST_FORM_ID,
+  buildEmptyPlaytestFeedbackResponsesFor,
+  type AnyPlaytestFeedbackResponses,
   type PlaytestFeel,
   type PlaytestStrength,
   type PlaytestSectionResponse,
 } from '@shared/api/contracts';
 import {
-  FORM_TITLE,
-  FORM_INTRO,
   FEEL_OPTIONS,
   STRENGTH_OPTIONS,
-  PLAYTEST_FORM_SECTIONS,
-  PLAYTEST_FORM_KNOBS,
-  KNOB_SECTION_TITLE,
-  KNOB_SECTION_BLURB,
-  ONE_KNOB_PROMPT,
-  PRIORITIES_SECTION_TITLE,
-  PRIORITIES_SECTION_BLURB,
-  PULL_BACK_PROMPT,
-  GUT_CHECK_PROMPT,
-  ANYTHING_OFF_PROMPT,
   type PlaytestFormSection,
+  type PlaytestFormDefinition,
 } from '@/admin/playtestFeedbackForm';
+import { PLAYTEST_FORM_V2 } from '@/admin/playtestFeedbackFormV2';
 
 /**
- * Playtest feedback recording surface (2026-07-11 form).
+ * Playtest feedback recording surface — versioned; currently serving the
+ * ROUND 2 form (2026-07-12).
  *
- * On-screen mirror of docs/01-planning/PLAYTEST_FEEDBACK_2026-07-11.md — the
+ * On-screen mirror of docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md — the
  * markdown stays the printable source. Answers persist via
- * GET/POST /api/admin/playtest-feedback (server/routes/admin.ts) into
- * docs/01-planning/playtest-feedback-2026-07-11.responses.json, so the page
- * prefills from the saved file and can be edited incrementally. Nothing is
- * required — unanswered fields simply stay empty/null.
+ * GET/POST /api/admin/playtest-feedback (server/routes/admin.ts) keyed by
+ * formId into docs/01-planning/playtest-feedback-2026-07-12.responses.json,
+ * so the page prefills from the saved file and can be edited incrementally.
+ * Nothing is required — unanswered fields simply stay empty/null.
+ *
+ * Round 1 (2026-07-11) is history: its markdown, content module, and
+ * responses file stay in the repo untouched and remain loadable through the
+ * same endpoint via ?formId=playtest-feedback-2026-07-11.
  */
 
-const PLAYTEST_FEEDBACK_QUERY_KEY = ['admin', 'playtest-feedback'] as const;
+type PlaytestFeedbackResponsesDoc = AnyPlaytestFeedbackResponses;
+
+const PLAYTEST_FEEDBACK_QUERY_KEY = ['admin', 'playtest-feedback', ACTIVE_PLAYTEST_FORM_ID] as const;
 
 function emptySection(): PlaytestSectionResponse {
   return { exposure: [], feel: null, anythingOff: '', designerAnswers: [] };
@@ -56,8 +54,8 @@ function emptySection(): PlaytestSectionResponse {
 
 // Merge a fetched document over the canonical empty default so every section
 // and knob key exists even if the saved file predates a form tweak.
-function withDefaults(fetched: PlaytestFeedbackResponses): PlaytestFeedbackResponses {
-  const base = buildEmptyPlaytestFeedbackResponses();
+function withDefaults(fetched: PlaytestFeedbackResponsesDoc): PlaytestFeedbackResponsesDoc {
+  const base = buildEmptyPlaytestFeedbackResponsesFor(ACTIVE_PLAYTEST_FORM_ID);
   return {
     ...base,
     ...fetched,
@@ -85,11 +83,12 @@ function formatSavedAt(savedAt: string | null): string | null {
 
 interface SectionCardProps {
   section: PlaytestFormSection;
+  anythingOffPrompt: string;
   value: PlaytestSectionResponse;
   onChange: (next: PlaytestSectionResponse) => void;
 }
 
-function SectionCard({ section, value, onChange }: SectionCardProps) {
+function SectionCard({ section, anythingOffPrompt, value, onChange }: SectionCardProps) {
   const toggleExposure = (optionId: string, checked: boolean) => {
     let exposure: string[];
     if (section.exposureMulti) {
@@ -169,7 +168,7 @@ function SectionCard({ section, value, onChange }: SectionCardProps) {
           htmlFor={`${section.id}-anything-off`}
           className="text-sm font-medium text-white/80"
         >
-          {ANYTHING_OFF_PROMPT}
+          {anythingOffPrompt}
         </Label>
         <Input
           id={`${section.id}-anything-off`}
@@ -210,11 +209,12 @@ function SectionCard({ section, value, onChange }: SectionCardProps) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface PlaytestFeedbackFormProps {
-  responses: PlaytestFeedbackResponses;
-  onChange: (next: PlaytestFeedbackResponses) => void;
+  form: PlaytestFormDefinition;
+  responses: PlaytestFeedbackResponsesDoc;
+  onChange: (next: PlaytestFeedbackResponsesDoc) => void;
 }
 
-export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFormProps) {
+export function PlaytestFeedbackForm({ form, responses, onChange }: PlaytestFeedbackFormProps) {
   const setSection = (id: string, next: PlaytestSectionResponse) => {
     onChange({ ...responses, sections: { ...responses.sections, [id]: next } });
   };
@@ -229,25 +229,29 @@ export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFo
     onChange({ ...responses, topPriorities });
   };
 
+  const knobSectionNumber = form.sections.length + 1;
+  const prioritiesSectionNumber = form.sections.length + 2;
+
   return (
     <div className="space-y-5">
-      {PLAYTEST_FORM_SECTIONS.map((section) => (
+      {form.sections.map((section) => (
         <SectionCard
           key={section.id}
           section={section}
+          anythingOffPrompt={form.anythingOffPrompt}
           value={responses.sections[section.id] ?? emptySection()}
           onChange={(next) => setSection(section.id, next)}
         />
       ))}
 
-      {/* §12 — Feel-knob tuning appetite */}
+      {/* Knob-strength table */}
       <section className="glass-panel rounded-xl p-5 space-y-4" data-testid="section-knob-strength">
         <header>
           <h2 className="text-lg font-semibold text-white">
-            <span className="text-neon-cyan mr-2">12.</span>
-            {KNOB_SECTION_TITLE}
+            <span className="text-neon-cyan mr-2">{knobSectionNumber}.</span>
+            {form.knobSectionTitle}
           </h2>
-          <p className="text-sm text-white/60 italic mt-1">{KNOB_SECTION_BLURB}</p>
+          <p className="text-sm text-white/60 italic mt-1">{form.knobSectionBlurb}</p>
         </header>
 
         <div className="overflow-x-auto">
@@ -263,7 +267,7 @@ export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFo
               </tr>
             </thead>
             <tbody>
-              {PLAYTEST_FORM_KNOBS.map((knob) => (
+              {form.knobs.map((knob) => (
                 <tr key={knob.id} className="border-b border-white/5">
                   <td className="py-2 pr-4 text-white/80">{knob.label}</td>
                   {STRENGTH_OPTIONS.map((option) => {
@@ -288,7 +292,7 @@ export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFo
 
         <div>
           <Label htmlFor="one-knob-change" className="text-sm font-medium text-white/80">
-            {ONE_KNOB_PROMPT}
+            {form.oneKnobPrompt}
           </Label>
           <Input
             id="one-knob-change"
@@ -299,14 +303,14 @@ export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFo
         </div>
       </section>
 
-      {/* §13 — Top-3 priority */}
+      {/* Top-3 priority */}
       <section className="glass-panel rounded-xl p-5 space-y-4" data-testid="section-priorities">
         <header>
           <h2 className="text-lg font-semibold text-white">
-            <span className="text-neon-cyan mr-2">13.</span>
-            {PRIORITIES_SECTION_TITLE}
+            <span className="text-neon-cyan mr-2">{prioritiesSectionNumber}.</span>
+            {form.prioritiesSectionTitle}
           </h2>
-          <p className="text-sm text-white/60 italic mt-1">{PRIORITIES_SECTION_BLURB}</p>
+          <p className="text-sm text-white/60 italic mt-1">{form.prioritiesSectionBlurb}</p>
         </header>
 
         <div className="space-y-2">
@@ -324,7 +328,7 @@ export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFo
 
         <div>
           <Label htmlFor="pull-back" className="text-sm font-medium text-white/80">
-            {PULL_BACK_PROMPT}
+            {form.pullBackPrompt}
           </Label>
           <Textarea
             id="pull-back"
@@ -337,7 +341,7 @@ export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFo
 
         <div>
           <Label htmlFor="gut-check" className="text-sm font-medium text-white/80">
-            {GUT_CHECK_PROMPT}
+            {form.gutCheckPrompt}
           </Label>
           <Input
             id="gut-check"
@@ -358,7 +362,7 @@ export function PlaytestFeedbackForm({ responses, onChange }: PlaytestFeedbackFo
 
 export default function PlaytestFeedbackPage() {
   const { toast } = useToast();
-  const [responses, setResponses] = useState<PlaytestFeedbackResponses | null>(null);
+  const [responses, setResponses] = useState<PlaytestFeedbackResponsesDoc | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
@@ -367,10 +371,13 @@ export default function PlaytestFeedbackPage() {
     data: fetched,
     isLoading,
     isError,
-  } = useQuery<PlaytestFeedbackResponses>({
+  } = useQuery<PlaytestFeedbackResponsesDoc>({
     queryKey: PLAYTEST_FEEDBACK_QUERY_KEY,
     queryFn: async () => {
-      const response = await apiRequest('GET', '/api/admin/playtest-feedback');
+      const response = await apiRequest(
+        'GET',
+        `/api/admin/playtest-feedback?formId=${ACTIVE_PLAYTEST_FORM_ID}`
+      );
       return response.json();
     },
   });
@@ -385,7 +392,7 @@ export default function PlaytestFeedbackPage() {
     }
   }, [fetched, responses]);
 
-  const handleChange = (next: PlaytestFeedbackResponses) => {
+  const handleChange = (next: PlaytestFeedbackResponsesDoc) => {
     setResponses(next);
     setDirty(true);
   };
@@ -419,7 +426,7 @@ export default function PlaytestFeedbackPage() {
         {/* Sticky save bar */}
         <div className="sticky top-0 z-20 -mx-2 px-2 py-3 backdrop-blur-md bg-surface-app/80 border-b border-white/10 mb-5 flex items-center justify-between gap-4">
           <div className="min-w-0">
-            <h1 className="text-xl font-bold text-white truncate">{FORM_TITLE}</h1>
+            <h1 className="text-xl font-bold text-white truncate">{PLAYTEST_FORM_V2.title}</h1>
             <p className="text-xs text-white/50">
               {savedLabel ? `Last saved ${savedLabel}` : 'Not saved yet'}
               {dirty ? ' · unsaved changes' : ''}
@@ -430,14 +437,23 @@ export default function PlaytestFeedbackPage() {
           </Button>
         </div>
 
-        <p className="text-sm text-white/60 mb-6">{FORM_INTRO}</p>
+        <p className="text-xs text-white/40 mb-3" data-testid="round1-history-note">
+          Round 1 (2026-07-11) is archived as history:{' '}
+          <code className="text-white/60">docs/01-planning/PLAYTEST_FEEDBACK_2026-07-11.md</code> +{' '}
+          <code className="text-white/60">playtest-feedback-2026-07-11.responses.json</code>. This page now
+          records Round 2.
+        </p>
+
+        <p className="text-sm text-white/60 mb-6">{PLAYTEST_FORM_V2.intro}</p>
 
         {isLoading && <p className="text-white/60">Loading saved responses…</p>}
         {isError && (
           <p className="text-negative">Failed to load saved responses — answers entered now would not prefill.</p>
         )}
 
-        {responses && <PlaytestFeedbackForm responses={responses} onChange={handleChange} />}
+        {responses && (
+          <PlaytestFeedbackForm form={PLAYTEST_FORM_V2} responses={responses} onChange={handleChange} />
+        )}
       </div>
     </GameLayout>
   );

--- a/client/src/admin/playtestFeedbackForm.ts
+++ b/client/src/admin/playtestFeedbackForm.ts
@@ -296,3 +296,42 @@ export const GUT_CHECK_PROMPT =
   'One-line gut check — does the label sim feel more alive than it did a week ago?';
 
 export const ANYTHING_OFF_PROMPT = 'Anything off / confusing / invisible?';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Versioned form bundle (added with the round-2 form). The PlaytestFeedbackForm
+// component renders whichever definition it is handed; the page serves the
+// active round. The individual constants above stay exported — they are the
+// round-1 historical content and the round-1 tests read them directly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PlaytestFormDefinition {
+  formId: string;
+  title: string;
+  intro: string;
+  sections: PlaytestFormSection[];
+  knobs: PlaytestKnobRow[];
+  knobSectionTitle: string;
+  knobSectionBlurb: string;
+  oneKnobPrompt: string;
+  prioritiesSectionTitle: string;
+  prioritiesSectionBlurb: string;
+  pullBackPrompt: string;
+  gutCheckPrompt: string;
+  anythingOffPrompt: string;
+}
+
+export const PLAYTEST_FORM_V1: PlaytestFormDefinition = {
+  formId: 'playtest-feedback-2026-07-11',
+  title: FORM_TITLE,
+  intro: FORM_INTRO,
+  sections: PLAYTEST_FORM_SECTIONS,
+  knobs: PLAYTEST_FORM_KNOBS,
+  knobSectionTitle: KNOB_SECTION_TITLE,
+  knobSectionBlurb: KNOB_SECTION_BLURB,
+  oneKnobPrompt: ONE_KNOB_PROMPT,
+  prioritiesSectionTitle: PRIORITIES_SECTION_TITLE,
+  prioritiesSectionBlurb: PRIORITIES_SECTION_BLURB,
+  pullBackPrompt: PULL_BACK_PROMPT,
+  gutCheckPrompt: GUT_CHECK_PROMPT,
+  anythingOffPrompt: ANYTHING_OFF_PROMPT,
+};

--- a/client/src/admin/playtestFeedbackFormV2.ts
+++ b/client/src/admin/playtestFeedbackFormV2.ts
@@ -1,0 +1,312 @@
+/**
+ * Playtest feedback form definition — Round 2 (2026-07-12), the results of
+ * the round-1 tuning arc (#159/#160/#161/#162).
+ *
+ * This is the on-screen mirror of docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md
+ * (the markdown stays the printable source; the /admin/playtest-feedback page
+ * is the recording surface). Wording is carried verbatim from the markdown
+ * wherever possible. House rule: NO engine numbers/multipliers in any label
+ * or copy — tests/client/playtest-feedback-form-v2.test.tsx guards this
+ * module the same way the round-1 module and helpTopics are guarded.
+ *
+ * Section/knob ids are the canonical V2 ones from @shared/api/contracts
+ * (PLAYTEST_SECTION_IDS_V2 / PLAYTEST_KNOB_IDS_V2) — the contract test
+ * asserts the two lists stay in lockstep.
+ *
+ * The round-1 module (playtestFeedbackForm.ts) stays in the repo untouched:
+ * it is the historical content behind the round-1 responses file.
+ */
+
+import {
+  type PlaytestFormDefinition,
+  type PlaytestFormSection,
+  type PlaytestKnobRow,
+  ANYTHING_OFF_PROMPT,
+} from './playtestFeedbackForm';
+
+export const FORM_TITLE_V2 = 'Playtest Feedback — Round 2: Volatility & Crisis, 2026-07-12';
+
+export const FORM_INTRO_V2 =
+  'Round 2. Your round-1 answers drove a four-PR tuning arc — energy lifecycle, reactive mood, flop drama, ' +
+  'slower reputation, richer Creative Capital, sharper meeting relevance, mandatory crisis events, hype legibility, ' +
+  'Board brief previews — and this form playtests the results. The three mechanics you never saw fire in round one ' +
+  '(flop penalty, mood-driven recording variance, energy effects) should now be encounterable; each gets an explicit ' +
+  're-test below. Same rules as before: qualitative only, "never saw it" is a real and useful answer, blank free-text ' +
+  'means nothing to report, and the designer questions are the real payload. ' +
+  'Reminder: restart the dev server before playing — server-side engine code does not hot-reload.';
+
+export const PLAYTEST_FORM_SECTIONS_V2: PlaytestFormSection[] = [
+  {
+    id: 'mandatory_crisis_events',
+    number: 1,
+    title: 'Crisis on the Desk — mandatory side events',
+    blurb:
+      'A side event that fires no longer resolves inside the weekly results — it lands on your desk the following ' +
+      'week as a mandatory crisis card that takes over one focus slot. You cannot advance the week until you decide ' +
+      'how to handle it, and the week summary then reports the week you spent handling it. This was your round-one ' +
+      'ask, near verbatim.',
+    exposurePrompt: 'Did you encounter it? (tick all you saw)',
+    exposureMulti: true,
+    exposureOptions: [
+      { id: 'crisis_card', label: 'A crisis card occupying a focus slot' },
+      { id: 'advance_blocked', label: 'The advance blocked until I resolved it' },
+      { id: 'handled_beat', label: 'The "spent the week handling it" beat in the week summary' },
+      { id: 'multiple_crises', label: 'More than one crisis across the run' },
+      { id: 'never', label: 'Never had one fire since the merge' },
+    ],
+    designerQuestions: [
+      'Round one: resolving a crisis inside the weekly results "makes it feel less like an OH MY!" — your words. ' +
+        'Is this the OH MY now? Does a crisis landing on your desk carry real dramatic weight, or has it already ' +
+        'become a chore card you click through?',
+      'The slot cost is the teeth — a crisis week is a week where you do one less thing. Does that price create the ' +
+        'right tension, or does losing the slot read as punishment stacked on bad luck?',
+      'Crises still land roughly one week in five — same rhythm as before, but now each one costs real bandwidth. ' +
+        'Does that frequency feel right lived-in, or should they be rarer-and-bigger? And did the choices on the ' +
+        'card ever feel like a real decision under pressure, or an obvious pick?',
+    ],
+  },
+  {
+    id: 'energy_lifecycle',
+    number: 2,
+    title: 'Energy lifecycle — work drains, rest recovers',
+    blurb:
+      'Energy now moves: recording weeks drain it, every tour city drains it, and an artist with nothing on their ' +
+      'plate recovers. Round one you rated energy effects "never saw it" and asked for energy tied to everything an ' +
+      'artist actively does — this is that request, shipped.',
+    exposurePrompt: 'Did you encounter it? (tick all you saw)',
+    exposureMulti: true,
+    exposureOptions: [
+      { id: 'recording_dip', label: 'Watched energy dip while an artist was recording' },
+      { id: 'tour_dip', label: 'Watched energy dip across a tour' },
+      { id: 'idle_recovery', label: 'Watched an idle artist recover' },
+      { id: 'planned_rest', label: 'Deliberately scheduled a rest week' },
+      { id: 'never', label: 'Still could not see energy move' },
+    ],
+    designerQuestions: [
+      'Round-one follow-through: energy was invisible then. Does it now visibly breathe — down when they work, up ' +
+        'when they rest — across a normal campaign?',
+      'Did the lifecycle ever change a real decision (delayed a tour, forced a rest week, staggered recordings), ' +
+        'or does the number move without ever mattering?',
+    ],
+  },
+  {
+    id: 'mood_outcomes',
+    number: 3,
+    title: 'Mood reacts to outcomes — flops hurt, breakthroughs lift, drift livelier',
+    blurb:
+      'A flop now dents the release artist\'s mood, a breakthrough lifts the song artist\'s mood, and weekly ' +
+      'natural drift is stronger. Round one: "mood was generally stable" across a twenty-week run — this aims ' +
+      'squarely at that.',
+    exposurePrompt: 'Did you encounter it? (tick all you saw)',
+    exposureMulti: true,
+    exposureOptions: [
+      { id: 'flop_mood_hit', label: "Saw a flop knock an artist's mood down" },
+      { id: 'breakthrough_lift', label: "Saw a breakthrough lift an artist's mood" },
+      { id: 'livelier_drift', label: 'Noticed livelier week-to-week drift' },
+      { id: 'still_flat', label: 'Mood still felt flat all run' },
+    ],
+    designerQuestions: [
+      'Round-one follow-through: you said mood never got volatile enough to matter. Does mood now tell a story ' +
+        'across the campaign — rough patches, hot streaks — or is it still close to a flat line?',
+      'When mood moved off an outcome, was the cause legible in the moment (you knew the flop did it), or did the ' +
+        'needle just wiggle?',
+    ],
+  },
+  {
+    id: 'mood_recording_variance_retest',
+    number: 4,
+    title: 'Re-test: low mood widens recording variance',
+    blurb:
+      'Mechanically unchanged since round one — but round one you never reached low mood, so it never had a chance ' +
+      'to fire. With mood now actually swinging, this should finally be encounterable.',
+    exposurePrompt: 'Did you encounter it?',
+    exposureMulti: false,
+    exposureOptions: [
+      { id: 'natural', label: 'Recorded with a genuinely low-mood artist this run' },
+      { id: 'hunted', label: 'Went looking for it (tanked a mood on purpose)' },
+      { id: 'never', label: "Still never got an artist's mood low enough" },
+    ],
+    designerQuestions: [
+      'You marked this "too weak" in round one without ever seeing it fire. Now that low mood is reachable: could ' +
+        "you feel the swing this time — takes landing worse or better than the artist's usual?",
+      'Is "get their head right before the studio" now a lever you actually pull, or still noise you cannot plan ' +
+        'around?',
+    ],
+  },
+  {
+    id: 'flop_drama',
+    number: 5,
+    title: 'Flops are a moment — harder sting, louder beat',
+    blurb:
+      "A flop now costs more reputation, dents the artist's mood, and lands as its own notable beat in the week " +
+      'summary instead of a quiet ledger line. Round-one verdict: "didn\'t feel dramatic enough," knob marked too ' +
+      'weak.',
+    exposurePrompt: 'Did you encounter it?',
+    exposureMulti: false,
+    exposureOptions: [
+      { id: 'natural', label: 'Had a flop land in natural play' },
+      { id: 'hunted', label: 'Engineered one to see the drama' },
+      { id: 'never', label: 'Never flopped this run' },
+    ],
+    designerQuestions: [
+      'Round-one follow-through: does a flop now read as an event — you see it, you feel it, you know what it cost ' +
+        '— or is it still something you discover later in the numbers?',
+      'Does flop risk now genuinely enter the greenlight decision on an expensive release, or is the fear still ' +
+        'theoretical?',
+    ],
+  },
+  {
+    id: 'reputation_pacing',
+    number: 6,
+    title: 'Reputation pacing — the climb is a career now',
+    blurb:
+      'Positive reputation gains are damped across every source; losses are not. Round one: "reputation gain feels ' +
+      'aggressive and quick" — you were at the ceiling barely halfway through the campaign.',
+    exposurePrompt: 'Did you encounter it?',
+    exposureMulti: false,
+    exposureOptions: [
+      { id: 'deep_run', label: 'Played deep enough into a campaign to feel the new pacing' },
+      { id: 'short_stretch', label: 'Watched reputation across a shorter stretch' },
+      { id: 'never', label: "Didn't track reputation this run" },
+    ],
+    designerQuestions: [
+      'The direct question: does a full campaign now have a reputation arc — still climbing, still earning in the ' +
+        'late game, with the ceiling out of reach until the end (if ever)?',
+      'Slower gains plus harsher flop losses: does reputation now feel like something you protect and spend, or ' +
+        'just the same number rising slower?',
+    ],
+  },
+  {
+    id: 'creative_capital_income',
+    number: 7,
+    title: 'Creative Capital income — the studio meeting pays better',
+    blurb:
+      "The recording meeting's Creative Capital grants got a real boost. Round one: \"gaining CC is a bit of a " +
+      'struggle."',
+    exposurePrompt: 'Did you encounter it?',
+    exposureMulti: false,
+    exposureOptions: [
+      { id: 'took_meeting', label: "Took the recording meeting's Creative Capital choices this run" },
+      { id: 'felt_looser', label: 'Noticed the Creative Capital economy loosen in general play' },
+      { id: 'still_starved', label: 'Still felt starved for Creative Capital' },
+    ],
+    designerQuestions: [
+      'Round-one follow-through: can you now bank toward the creative moves you want at a livable clip — or is ' +
+        'Creative Capital still the resource that stalls your plans?',
+      'Where should the scarcity sit: is Creative Capital currently doing good work (forcing real trade-offs) or ' +
+        'just throttling the fun parts of the game?',
+    ],
+  },
+  {
+    id: 'meeting_relevance_whynow',
+    number: 8,
+    title: 'Meeting relevance — why-now pushes harder',
+    blurb:
+      "Meetings that are reacting to your label's current situation now push to the front of the weekly slate more " +
+      'aggressively. Round-one knob verdict: too weak.',
+    exposurePrompt: 'Did you encounter it?',
+    exposureMulti: false,
+    exposureOptions: [
+      { id: 'noticed', label: 'Noticed the slate visibly reacting to my situation' },
+      { id: 'couldnt_tell', label: "Watched for it but couldn't tell" },
+      { id: 'never', label: "Didn't watch for it" },
+    ],
+    designerQuestions: [
+      'Round-one follow-through: does the weekly slate now chase your situation — the right meeting showing up the ' +
+        'week it matters — or does selection still read as generic rotation?',
+      'When a why-now meeting surfaced, did its line convince you it was reacting to something real you did — or ' +
+        'did it feel like flavor text stapled to a random pick?',
+    ],
+  },
+  {
+    id: 'hype_attach_ux',
+    number: 9,
+    title: 'Hype legibility — attach preview, anticipation line, named pools',
+    blurb:
+      'Release planning now previews which banked pools will pour into the release before you confirm; a weekly ' +
+      'anticipation line tracks hype building toward upcoming releases; and the dashboard hype section names what ' +
+      'is building and draining instead of the generic readout you flagged in round one.',
+    exposurePrompt: 'Did you encounter it? (tick all you saw)',
+    exposureMulti: true,
+    exposureOptions: [
+      { id: 'attach_preview', label: 'Saw the banked-hype preview while planning a release' },
+      { id: 'anticipation_line', label: 'Read the weekly anticipation line' },
+      { id: 'named_pools', label: 'Noticed the dashboard hype section got specific' },
+      { id: 'never', label: 'Saw none of them' },
+    ],
+    designerQuestions: [
+      'Round one asked for exactly this pair (attach visibility at planning, plus a de-generalized dashboard). Can ' +
+        'you now read hype end-to-end — bank it, see it attach, watch it convert — or are there still blind spots?',
+      'Honesty check: did any of the new hype copy overpromise — a "strong" read that converted into a launch that ' +
+        'felt ordinary?',
+    ],
+  },
+  {
+    id: 'board_waiting_brief',
+    number: 10,
+    title: 'The Board — waiting briefs show their hand',
+    blurb:
+      "The open-channel strip now previews the waiting meeting's name plus a one-line snippet, with a hint when " +
+      'more briefs are stacked behind it — the exact preview you asked for in round one.',
+    exposurePrompt: 'Did you encounter it?',
+    exposureMulti: false,
+    exposureOptions: [
+      { id: 'used_to_triage', label: 'Used the previews to decide who to spend a slot on' },
+      { id: 'saw_ignored', label: 'Saw them but chose the same way I always did' },
+      { id: 'never', label: "Haven't spent time in The Board since" },
+    ],
+    designerQuestions: [
+      'Round-one follow-through: does knowing what is waiting actually change how you spend focus slots on The ' +
+        'Board, or is it nice-to-have flavor?',
+      'Is the snippet the right length — enough to triage, not so much it spoils the meeting?',
+    ],
+  },
+];
+
+export const KNOB_SECTION_TITLE_V2 = 'Knob check — did the tuning land?';
+
+export const KNOB_SECTION_BLURB_V2 =
+  "Round one's table was about untouched knobs; every row here was just tuned (or newly created) in direct " +
+  'response to it. This is the second-pass read that tells me whether the tuning landed, undershot, or overshot. ' +
+  'Tick a strength read per system; leave blank if no opinion.';
+
+export const PLAYTEST_FORM_KNOBS_V2: PlaytestKnobRow[] = [
+  { id: 'energy_drain_rate', label: 'Energy drain (recording + touring)' },
+  { id: 'idle_recovery_rate', label: 'Idle-week energy recovery' },
+  { id: 'mood_swing_size', label: 'Mood swing size (outcomes + drift)' },
+  { id: 'flop_sting', label: 'Flop sting (reputation + mood)' },
+  { id: 'reputation_pacing', label: 'Reputation gain pacing' },
+  { id: 'creative_capital_income', label: 'Creative Capital income' },
+  { id: 'crisis_frequency', label: 'Crisis frequency' },
+  { id: 'crisis_slot_cost', label: 'Crisis slot cost' },
+];
+
+export const ONE_KNOB_PROMPT_V2 = "One knob you'd change today if you could, and which way:";
+
+export const PRIORITIES_SECTION_TITLE_V2 = 'Top-3 priority — what do I fix/tune next?';
+
+export const PRIORITIES_SECTION_BLURB_V2 =
+  'Rank the three things most worth my time after this round. A bug, a tuning pass, a legibility fix, or ' +
+  '"make X louder." Be specific — round one left this section blank and it was missed.';
+
+export const PULL_BACK_PROMPT_V2 =
+  "Anything from this tuning arc that overshot and you'd rather I pull back or reconsider?";
+
+export const GUT_CHECK_PROMPT_V2 =
+  "One-line gut check — round one's build felt stable to a fault; does round two have the drama?";
+
+export const PLAYTEST_FORM_V2: PlaytestFormDefinition = {
+  formId: 'playtest-feedback-2026-07-12',
+  title: FORM_TITLE_V2,
+  intro: FORM_INTRO_V2,
+  sections: PLAYTEST_FORM_SECTIONS_V2,
+  knobs: PLAYTEST_FORM_KNOBS_V2,
+  knobSectionTitle: KNOB_SECTION_TITLE_V2,
+  knobSectionBlurb: KNOB_SECTION_BLURB_V2,
+  oneKnobPrompt: ONE_KNOB_PROMPT_V2,
+  prioritiesSectionTitle: PRIORITIES_SECTION_TITLE_V2,
+  prioritiesSectionBlurb: PRIORITIES_SECTION_BLURB_V2,
+  pullBackPrompt: PULL_BACK_PROMPT_V2,
+  gutCheckPrompt: GUT_CHECK_PROMPT_V2,
+  anythingOffPrompt: ANYTHING_OFF_PROMPT,
+};

--- a/docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md
+++ b/docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md
@@ -1,0 +1,242 @@
+# Playtest Feedback — Round 2: Volatility & Crisis, 2026-07-12
+
+**Who this is for:** Nes (product owner), after real play on merged `main` (round-2 arc: #159, #160, #161, #162).
+**Why it exists:** Round 1 (`PLAYTEST_FEEDBACK_2026-07-11.md`) produced a clear verdict — the build was stable to a fault: flop penalty, mood variance, and energy effects never fired; reputation maxed halfway through the campaign; Creative Capital was starved; meeting relevance and the flop sting were "too weak"; and you asked, in your own words, for side events to be **mandatory** and cost a focus slot so a crisis feels like an "OH MY!". A four-PR arc shipped in direct response. This form playtests the *results*: every section below is a follow-through on a round-1 answer. The three mechanics you never saw fire in round 1 should now be **encounterable** — each gets an explicit re-test.
+**What changed since round 1:** energy lifecycle (recording/touring drain, idle recovery) · mood reacts to flops/breakthroughs + livelier drift · flop drama (harder sting + a notable week-summary beat) · reputation gains damped everywhere · Creative Capital grants boosted · meeting why-now weighting raised · **mandatory crisis events** (next-week crisis card, one focus slot, advance blocked until resolved) · hype legibility (attach preview, anticipation line, named pools) · The Board previews waiting briefs.
+
+**How to fill it out (~15 min):**
+- Tick the boxes with `- [x]`. One tick per question unless noted.
+- The **Feel** scale is the same everywhere: `dead` (didn't register) · `flat` (registered, no reaction) · `works` (landed as intended) · `sings` (better than intended). Pick the closest.
+- The free-text lines are for the *one thing that felt off*. Don't write essays — a phrase is fine. Blank = nothing to report.
+- The **designer questions** are the real payload. Answer those even if you skip everything else.
+- ⚠️ Reminder: restart the dev server before playing — `tsx` has no watch, server-side engine code does not hot-reload. Restart-then-verify if a mechanic seems dead.
+
+---
+
+## 1. Crisis on the Desk — mandatory side events (#162)
+
+*A side event that fires no longer resolves inside the weekly results — it lands on your desk the following week as a mandatory crisis card that takes over one focus slot. You cannot advance the week until you decide how to handle it, and the week summary then reports the week you spent handling it. This was your round-one ask, near verbatim.*
+
+**Did you encounter it?** (tick all you saw)
+- [ ] A crisis card occupying a focus slot
+- [ ] The advance blocked until I resolved it
+- [ ] The "spent the week handling it" beat in the week summary
+- [ ] More than one crisis across the run
+- [ ] Never had one fire since the merge
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round one: resolving a crisis inside the weekly results "makes it feel less like an OH MY!" — your words. Is this the OH MY now? Does a crisis landing on your desk carry real dramatic weight, or has it already become a chore card you click through?
+2. The slot cost is the teeth — a crisis week is a week where you do one less thing. Does that price create the right tension, or does losing the slot read as punishment stacked on bad luck?
+3. Crises still land roughly one week in five — same rhythm as before, but now each one costs real bandwidth. Does that frequency feel right lived-in, or should they be rarer-and-bigger? And did the choices on the card ever feel like a real decision under pressure, or an obvious pick?
+
+---
+
+## 2. Energy lifecycle — work drains, rest recovers (#159/#161)
+
+*Energy now moves: recording weeks drain it, every tour city drains it, and an artist with nothing on their plate recovers. Round one you rated energy effects "never saw it" and asked for energy tied to everything an artist actively does — this is that request, shipped.*
+
+**Did you encounter it?** (tick all you saw)
+- [ ] Watched energy dip while an artist was recording
+- [ ] Watched energy dip across a tour
+- [ ] Watched an idle artist recover
+- [ ] Deliberately scheduled a rest week
+- [ ] Still could not see energy move
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round-one follow-through: energy was invisible then. Does it now visibly breathe — down when they work, up when they rest — across a normal campaign?
+2. Did the lifecycle ever change a real decision (delayed a tour, forced a rest week, staggered recordings), or does the number move without ever mattering?
+
+---
+
+## 3. Mood reacts to outcomes — flops hurt, breakthroughs lift, drift livelier (#161)
+
+*A flop now dents the release artist's mood, a breakthrough lifts the song artist's mood, and weekly natural drift is stronger. Round one: "mood was generally stable" across a twenty-week run — this aims squarely at that.*
+
+**Did you encounter it?** (tick all you saw)
+- [ ] Saw a flop knock an artist's mood down
+- [ ] Saw a breakthrough lift an artist's mood
+- [ ] Noticed livelier week-to-week drift
+- [ ] Mood still felt flat all run
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round-one follow-through: you said mood never got volatile enough to matter. Does mood now tell a story across the campaign — rough patches, hot streaks — or is it still close to a flat line?
+2. When mood moved off an outcome, was the cause legible in the moment (you knew the flop did it), or did the needle just wiggle?
+
+---
+
+## 4. Re-test: low mood widens recording variance
+
+*Mechanically unchanged since round one — but round one you never reached low mood, so it never had a chance to fire. With mood now actually swinging, this should finally be encounterable.*
+
+**Did you encounter it?**
+- [ ] Recorded with a genuinely low-mood artist this run
+- [ ] Went looking for it (tanked a mood on purpose)
+- [ ] Still never got an artist's mood low enough
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. You marked this "too weak" in round one without ever seeing it fire. Now that low mood is reachable: could you feel the swing this time — takes landing worse or better than the artist's usual?
+2. Is "get their head right before the studio" now a lever you actually pull, or still noise you cannot plan around?
+
+---
+
+## 5. Flops are a moment — harder sting, louder beat (#161)
+
+*A flop now costs more reputation, dents the artist's mood, and lands as its own notable beat in the week summary instead of a quiet ledger line. Round-one verdict: "didn't feel dramatic enough," knob marked too weak.*
+
+**Did you encounter it?**
+- [ ] Had a flop land in natural play
+- [ ] Engineered one to see the drama
+- [ ] Never flopped this run
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round-one follow-through: does a flop now read as an event — you see it, you feel it, you know what it cost — or is it still something you discover later in the numbers?
+2. Does flop risk now genuinely enter the greenlight decision on an expensive release, or is the fear still theoretical?
+
+---
+
+## 6. Reputation pacing — the climb is a career now (#161)
+
+*Positive reputation gains are damped across every source; losses are not. Round one: "reputation gain feels aggressive and quick" — you were at the ceiling barely halfway through the campaign.*
+
+**Did you encounter it?**
+- [ ] Played deep enough into a campaign to feel the new pacing
+- [ ] Watched reputation across a shorter stretch
+- [ ] Didn't track reputation this run
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. The direct question: does a full campaign now have a reputation arc — still climbing, still earning in the late game, with the ceiling out of reach until the end (if ever)?
+2. Slower gains plus harsher flop losses: does reputation now feel like something you protect and spend, or just the same number rising slower?
+
+---
+
+## 7. Creative Capital income — the studio meeting pays better (#161)
+
+*The recording meeting's Creative Capital grants got a real boost. Round one: "gaining CC is a bit of a struggle."*
+
+**Did you encounter it?**
+- [ ] Took the recording meeting's Creative Capital choices this run
+- [ ] Noticed the Creative Capital economy loosen in general play
+- [ ] Still felt starved for Creative Capital
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round-one follow-through: can you now bank toward the creative moves you want at a livable clip — or is Creative Capital still the resource that stalls your plans?
+2. Where should the scarcity sit: is Creative Capital currently doing good work (forcing real trade-offs) or just throttling the fun parts of the game?
+
+---
+
+## 8. Meeting relevance — why-now pushes harder (#161)
+
+*Meetings that are reacting to your label's current situation now push to the front of the weekly slate more aggressively. Round-one knob verdict: too weak.*
+
+**Did you encounter it?**
+- [ ] Noticed the slate visibly reacting to my situation
+- [ ] Watched for it but couldn't tell
+- [ ] Didn't watch for it
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round-one follow-through: does the weekly slate now chase your situation — the right meeting showing up the week it matters — or does selection still read as generic rotation?
+2. When a why-now meeting surfaced, did its line convince you it was reacting to something real you did — or did it feel like flavor text stapled to a random pick?
+
+---
+
+## 9. Hype legibility — attach preview, anticipation line, named pools (#160)
+
+*Release planning now previews which banked pools will pour into the release before you confirm; a weekly anticipation line tracks hype building toward upcoming releases; and the dashboard hype section names what is building and draining instead of the generic readout you flagged in round one.*
+
+**Did you encounter it?** (tick all you saw)
+- [ ] Saw the banked-hype preview while planning a release
+- [ ] Read the weekly anticipation line
+- [ ] Noticed the dashboard hype section got specific
+- [ ] Saw none of them
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round one asked for exactly this pair (attach visibility at planning, plus a de-generalized dashboard). Can you now read hype end-to-end — bank it, see it attach, watch it convert — or are there still blind spots?
+2. Honesty check: did any of the new hype copy overpromise — a "strong" read that converted into a launch that felt ordinary?
+
+---
+
+## 10. The Board — waiting briefs show their hand (#160)
+
+*The open-channel strip now previews the waiting meeting's name plus a one-line snippet, with a hint when more briefs are stacked behind it — the exact preview you asked for in round one.*
+
+**Did you encounter it?**
+- [ ] Used the previews to decide who to spend a slot on
+- [ ] Saw them but chose the same way I always did
+- [ ] Haven't spent time in The Board since
+
+**Feel:** `dead` / `flat` / `works` / `sings` → ______
+
+**Anything off / confusing / invisible?** _______________________________________________
+
+**Designer questions:**
+1. Round-one follow-through: does knowing what is waiting actually change how you spend focus slots on The Board, or is it nice-to-have flavor?
+2. Is the snippet the right length — enough to triage, not so much it spoils the meeting?
+
+---
+
+## 11. Knob check — did the tuning land?
+
+*Round one's table was about untouched knobs; every row here was just tuned (or newly created) in direct response to it. This is the second-pass read that tells me whether the tuning landed, undershot, or overshot. Tick a strength read per system; leave blank if no opinion.*
+
+| System | Too weak | About right | Too strong |
+|---|---|---|---|
+| Energy drain (recording + touring) | [ ] | [ ] | [ ] |
+| Idle-week energy recovery | [ ] | [ ] | [ ] |
+| Mood swing size (outcomes + drift) | [ ] | [ ] | [ ] |
+| Flop sting (reputation + mood) | [ ] | [ ] | [ ] |
+| Reputation gain pacing | [ ] | [ ] | [ ] |
+| Creative Capital income | [ ] | [ ] | [ ] |
+| Crisis frequency | [ ] | [ ] | [ ] |
+| Crisis slot cost | [ ] | [ ] | [ ] |
+
+**One knob you'd change *today* if you could, and which way:** ______________________________
+
+---
+
+## 12. Top-3 priority — what do I fix/tune next?
+
+*Rank the three things most worth my time after this round. A bug, a tuning pass, a legibility fix, or "make X louder." Be specific — round one left this section blank and it was missed.*
+
+1. ____________________________________________________________________
+2. ____________________________________________________________________
+3. ____________________________________________________________________
+
+**Anything from this tuning arc that overshot and you'd rather I *pull back* or reconsider?** ____________________
+
+**One-line gut check — round one's build felt stable to a fault; does round two have the drama?** ____________

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -5,11 +5,15 @@ import { z } from 'zod';
 import {
   ActionsConfigSchema,
   EventsConfigSchema,
-  PlaytestFeedbackResponsesSchema,
-  PLAYTEST_SECTION_IDS,
-  PLAYTEST_KNOB_IDS,
-  buildEmptyPlaytestFeedbackResponses,
-  type PlaytestFeedbackResponses,
+  AnyPlaytestFeedbackResponsesSchema,
+  PLAYTEST_FEEDBACK_FORM_ID,
+  PLAYTEST_FEEDBACK_FORM_ID_V2,
+  PLAYTEST_FORM_REGISTRY,
+  ACTIVE_PLAYTEST_FORM_ID,
+  isPlaytestFormId,
+  buildEmptyPlaytestFeedbackResponsesFor,
+  type AnyPlaytestFeedbackResponses,
+  type PlaytestFormId,
 } from '@shared/api/contracts';
 import { gameStates } from '@shared/schema';
 import { db } from '../db';
@@ -191,32 +195,42 @@ router.post('/api/admin/events-config', requireClerkUser, requireAdmin, async (r
     }
   });
 
-// Playtest feedback endpoints (Admin only) — recording surface for
-// docs/01-planning/PLAYTEST_FEEDBACK_2026-07-11.md. Mirrors the
-// actions-config pattern (validate → backup → write); persists at
-// docs/01-planning/playtest-feedback-2026-07-11.responses.json. The markdown
-// form stays untouched as the printable source. No dataLoader cache clear or
-// content changelog here — this is not game content.
+// Playtest feedback endpoints (Admin only) — versioned recording surface for
+// the playtest forms (round 1: PLAYTEST_FEEDBACK_2026-07-11.md, round 2:
+// PLAYTEST_FEEDBACK_2026-07-12.md). Mirrors the actions-config pattern
+// (validate → backup → write). The SAME endpoint pair serves every form,
+// keyed by a validated formId from the fixed allowlist below (GET ?formId=…
+// defaulting to the active form; POST reads responses.formId). Each form
+// persists to its own responses file — the round-1 file is a HISTORICAL
+// RECORD that a v2 save must never touch. The markdown forms stay untouched
+// as the printable sources. No dataLoader cache clear or content changelog
+// here — this is not game content.
 
-const PLAYTEST_RESPONSES_FILENAME = 'playtest-feedback-2026-07-11.responses.json';
+const PLAYTEST_RESPONSES_FILENAMES: Record<PlaytestFormId, string> = {
+  [PLAYTEST_FEEDBACK_FORM_ID_V2]: 'playtest-feedback-2026-07-12.responses.json',
+  [PLAYTEST_FEEDBACK_FORM_ID]: 'playtest-feedback-2026-07-11.responses.json',
+};
 
-function playtestResponsesPath(): string {
-  return path.join(process.cwd(), 'docs', '01-planning', PLAYTEST_RESPONSES_FILENAME);
+function playtestResponsesPath(formId: PlaytestFormId): string {
+  return path.join(process.cwd(), 'docs', '01-planning', PLAYTEST_RESPONSES_FILENAMES[formId]);
 }
 
 // Rebuilds the response document with keys in canonical order (formId first,
-// sections/knobs in form order, extras appended) so the pretty-printed JSON
-// file is stable and diffable across saves.
-function stablePlaytestResponses(parsed: PlaytestFeedbackResponses): PlaytestFeedbackResponses {
-  const sections: PlaytestFeedbackResponses['sections'] = {};
-  for (const id of PLAYTEST_SECTION_IDS) {
+// sections/knobs in the given form's order, extras appended) so the
+// pretty-printed JSON file is stable and diffable across saves.
+function stablePlaytestResponses(
+  parsed: AnyPlaytestFeedbackResponses
+): AnyPlaytestFeedbackResponses {
+  const registry = PLAYTEST_FORM_REGISTRY[parsed.formId];
+  const sections: AnyPlaytestFeedbackResponses['sections'] = {};
+  for (const id of registry.sectionIds) {
     if (parsed.sections[id]) sections[id] = parsed.sections[id];
   }
   for (const id of Object.keys(parsed.sections)) {
     if (!(id in sections)) sections[id] = parsed.sections[id];
   }
-  const knobStrength: PlaytestFeedbackResponses['knobStrength'] = {};
-  for (const id of PLAYTEST_KNOB_IDS) {
+  const knobStrength: AnyPlaytestFeedbackResponses['knobStrength'] = {};
+  for (const id of registry.knobIds) {
     if (id in parsed.knobStrength) knobStrength[id] = parsed.knobStrength[id];
   }
   for (const id of Object.keys(parsed.knobStrength)) {
@@ -231,12 +245,19 @@ function stablePlaytestResponses(parsed: PlaytestFeedbackResponses): PlaytestFee
     topPriorities: parsed.topPriorities,
     pullBack: parsed.pullBack,
     gutCheck: parsed.gutCheck,
-  };
+  } as AnyPlaytestFeedbackResponses;
 }
 
 router.get('/api/admin/playtest-feedback', requireClerkUser, requireAdmin, async (req, res) => {
   try {
-    const responsesPath = playtestResponsesPath();
+    // Optional ?formId=… selects which round to load; defaults to the active
+    // form. Anything outside the fixed allowlist is rejected.
+    const requestedFormId =
+      typeof req.query.formId === 'string' ? req.query.formId : ACTIVE_PLAYTEST_FORM_ID;
+    if (!isPlaytestFormId(requestedFormId)) {
+      return res.status(400).json({ error: `Unknown playtest form id: ${requestedFormId}` });
+    }
+    const responsesPath = playtestResponsesPath(requestedFormId);
     let raw: string;
     try {
       raw = await fs.readFile(responsesPath, 'utf8');
@@ -244,11 +265,11 @@ router.get('/api/admin/playtest-feedback', requireClerkUser, requireAdmin, async
       if (readError?.code === 'ENOENT') {
         // No responses saved yet — return the empty default so the page can
         // prefill every field.
-        return res.json(buildEmptyPlaytestFeedbackResponses());
+        return res.json(buildEmptyPlaytestFeedbackResponsesFor(requestedFormId));
       }
       throw readError;
     }
-    const responses = PlaytestFeedbackResponsesSchema.parse(JSON.parse(raw));
+    const responses = AnyPlaytestFeedbackResponsesSchema.parse(JSON.parse(raw));
     res.json(responses);
   } catch (error) {
     console.error('Failed to load playtest feedback responses:', error);
@@ -264,10 +285,12 @@ router.post('/api/admin/playtest-feedback', requireClerkUser, requireAdmin, asyn
       return res.status(400).json({ error: 'Responses data is required' });
     }
 
-    // Validate using shared schema from contracts
-    let parsed: PlaytestFeedbackResponses;
+    // Validate using shared schema from contracts. The validated formId (a
+    // closed two-literal union) keys the target file — a v2 save can never
+    // reach the round-1 historical file and vice versa.
+    let parsed: AnyPlaytestFeedbackResponses;
     try {
-      parsed = PlaytestFeedbackResponsesSchema.parse(responses);
+      parsed = AnyPlaytestFeedbackResponsesSchema.parse(responses);
     } catch (validationError) {
       if (validationError instanceof z.ZodError) {
         return res.status(400).json({
@@ -278,7 +301,7 @@ router.post('/api/admin/playtest-feedback', requireClerkUser, requireAdmin, asyn
       throw validationError;
     }
 
-    const responsesPath = playtestResponsesPath();
+    const responsesPath = playtestResponsesPath(parsed.formId);
 
     // Create backup before overwriting (actions-config precedent; the very
     // first save has nothing to back up, which is fine).

--- a/shared/api/contracts.ts
+++ b/shared/api/contracts.ts
@@ -627,15 +627,95 @@ export const PlaytestFeedbackResponsesSchema = z.object({
   gutCheck: z.string().default(''),
 });
 
+// ========================================
+// Admin Playtest Feedback Schemas — V2 (2026-07-12 "Round 2" form)
+// ========================================
+// Round 2 recording surface for docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md.
+// The round-1 (2026-07-11) constants/schemas above stay UNTOUCHED — the v1
+// responses file is a historical record and must remain loadable forever.
+// Versioning approach: the SAME /api/admin/playtest-feedback endpoint pair
+// serves both forms, keyed by a validated formId from the fixed two-entry
+// allowlist below (GET ?formId=…, POST responses.formId). No new routes, so
+// the route manifest is unchanged.
+
+export const PLAYTEST_FEEDBACK_FORM_ID_V2 = 'playtest-feedback-2026-07-12' as const;
+
+// Canonical V2 section ids, in the form's order (§1–§10).
+export const PLAYTEST_SECTION_IDS_V2 = [
+  'mandatory_crisis_events',
+  'energy_lifecycle',
+  'mood_outcomes',
+  'mood_recording_variance_retest',
+  'flop_drama',
+  'reputation_pacing',
+  'creative_capital_income',
+  'meeting_relevance_whynow',
+  'hype_attach_ux',
+  'board_waiting_brief',
+] as const;
+
+// Canonical V2 §11 knob-strength rows, in table order. Every row here was
+// tuned (or newly created) in direct response to round 1.
+export const PLAYTEST_KNOB_IDS_V2 = [
+  'energy_drain_rate',
+  'idle_recovery_rate',
+  'mood_swing_size',
+  'flop_sting',
+  'reputation_pacing',
+  'creative_capital_income',
+  'crisis_frequency',
+  'crisis_slot_cost',
+] as const;
+
+// V2 response document: identical shape to V1, distinguished only by the
+// formId literal (feel/strength scales and section-response shape are shared
+// deliberately — the whole point of the versioned system is diffable,
+// same-shaped rounds).
+export const PlaytestFeedbackResponsesV2Schema = PlaytestFeedbackResponsesSchema.extend({
+  formId: z.literal(PLAYTEST_FEEDBACK_FORM_ID_V2).default(PLAYTEST_FEEDBACK_FORM_ID_V2),
+});
+
+// Union used by the endpoint pair: V2 first so a document with no explicit
+// formId defaults to the ACTIVE form (v2). An explicit v1 formId still
+// parses via the v1 branch.
+export const AnyPlaytestFeedbackResponsesSchema = z.union([
+  PlaytestFeedbackResponsesV2Schema,
+  PlaytestFeedbackResponsesSchema,
+]);
+
+// Fixed allowlist: formId → canonical id lists. The server derives the
+// responses-file path and stable key order from this registry; anything not
+// in it is rejected with 400.
+export const PLAYTEST_FORM_REGISTRY = {
+  [PLAYTEST_FEEDBACK_FORM_ID_V2]: {
+    sectionIds: PLAYTEST_SECTION_IDS_V2 as readonly string[],
+    knobIds: PLAYTEST_KNOB_IDS_V2 as readonly string[],
+  },
+  [PLAYTEST_FEEDBACK_FORM_ID]: {
+    sectionIds: PLAYTEST_SECTION_IDS as readonly string[],
+    knobIds: PLAYTEST_KNOB_IDS as readonly string[],
+  },
+} as const;
+
+export type PlaytestFormId = keyof typeof PLAYTEST_FORM_REGISTRY;
+
+export function isPlaytestFormId(value: string): value is PlaytestFormId {
+  return value in PLAYTEST_FORM_REGISTRY;
+}
+
+// The form the admin page currently records against.
+export const ACTIVE_PLAYTEST_FORM_ID: PlaytestFormId = PLAYTEST_FEEDBACK_FORM_ID_V2;
+
 // Admin endpoints for playtest feedback
 export const adminPlaytestFeedbackEndpoints = {
   getResponses: '/api/admin/playtest-feedback',
   saveResponses: '/api/admin/playtest-feedback',
 } as const;
 
-// Request schema for saving playtest feedback responses
+// Request schema for saving playtest feedback responses (either form version;
+// the server keys the target file off the validated formId).
 export const SavePlaytestFeedbackRequestSchema = z.object({
-  responses: PlaytestFeedbackResponsesSchema,
+  responses: AnyPlaytestFeedbackResponsesSchema,
 });
 
 // Response schema for saving playtest feedback responses
@@ -646,23 +726,27 @@ export const SavePlaytestFeedbackResponseSchema = z.object({
   savedAt: z.string().optional(),
 });
 
-// Response schema for getting playtest feedback responses
-export const GetPlaytestFeedbackResponseSchema = PlaytestFeedbackResponsesSchema;
+// Response schema for getting playtest feedback responses (either version)
+export const GetPlaytestFeedbackResponseSchema = AnyPlaytestFeedbackResponsesSchema;
 
-// Builds the empty default response document (GET returns this when the
-// responses file does not exist yet), with every canonical section/knob key
-// present in stable order so the client can prefill without guessing keys.
-export function buildEmptyPlaytestFeedbackResponses(): PlaytestFeedbackResponses {
+// Builds the empty default response document for any registered form (GET
+// returns this when that form's responses file does not exist yet), with
+// every canonical section/knob key present in stable order so the client can
+// prefill without guessing keys.
+export function buildEmptyPlaytestFeedbackResponsesFor(
+  formId: PlaytestFormId
+): AnyPlaytestFeedbackResponses {
+  const registry = PLAYTEST_FORM_REGISTRY[formId];
   const sections: Record<string, PlaytestSectionResponse> = {};
-  for (const id of PLAYTEST_SECTION_IDS) {
+  for (const id of registry.sectionIds) {
     sections[id] = { exposure: [], feel: null, anythingOff: '', designerAnswers: [] };
   }
   const knobStrength: Record<string, PlaytestStrength | null> = {};
-  for (const id of PLAYTEST_KNOB_IDS) {
+  for (const id of registry.knobIds) {
     knobStrength[id] = null;
   }
   return {
-    formId: PLAYTEST_FEEDBACK_FORM_ID,
+    formId,
     savedAt: null,
     sections,
     knobStrength,
@@ -670,7 +754,21 @@ export function buildEmptyPlaytestFeedbackResponses(): PlaytestFeedbackResponses
     topPriorities: ['', '', ''],
     pullBack: '',
     gutCheck: '',
-  };
+  } as AnyPlaytestFeedbackResponses;
+}
+
+// V1 builder — kept with its original signature (historical callers + tests).
+export function buildEmptyPlaytestFeedbackResponses(): PlaytestFeedbackResponses {
+  return buildEmptyPlaytestFeedbackResponsesFor(
+    PLAYTEST_FEEDBACK_FORM_ID
+  ) as PlaytestFeedbackResponses;
+}
+
+// V2 builder — the active form's empty default.
+export function buildEmptyPlaytestFeedbackResponsesV2(): PlaytestFeedbackResponsesV2 {
+  return buildEmptyPlaytestFeedbackResponsesFor(
+    PLAYTEST_FEEDBACK_FORM_ID_V2
+  ) as PlaytestFeedbackResponsesV2;
 }
 
 // Export TypeScript types
@@ -678,6 +776,8 @@ export type PlaytestFeel = z.infer<typeof PlaytestFeelSchema>;
 export type PlaytestStrength = z.infer<typeof PlaytestStrengthSchema>;
 export type PlaytestSectionResponse = z.infer<typeof PlaytestSectionResponseSchema>;
 export type PlaytestFeedbackResponses = z.infer<typeof PlaytestFeedbackResponsesSchema>;
+export type PlaytestFeedbackResponsesV2 = z.infer<typeof PlaytestFeedbackResponsesV2Schema>;
+export type AnyPlaytestFeedbackResponses = z.infer<typeof AnyPlaytestFeedbackResponsesSchema>;
 export type SavePlaytestFeedbackRequest = z.infer<typeof SavePlaytestFeedbackRequestSchema>;
 export type SavePlaytestFeedbackResponse = z.infer<typeof SavePlaytestFeedbackResponseSchema>;
 export type GetPlaytestFeedbackResponse = z.infer<typeof GetPlaytestFeedbackResponseSchema>;

--- a/tests/client/playtest-feedback-form-v2.test.tsx
+++ b/tests/client/playtest-feedback-form-v2.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Playtest feedback form tests — Round 2 (2026-07-12 recording surface).
+ *
+ * Mirrors the round-1 suite (tests/client/playtest-feedback-form.test.tsx):
+ * 1. Lockstep guard: the V2 form definition's section/knob ids must match
+ *    PLAYTEST_SECTION_IDS_V2 / PLAYTEST_KNOB_IDS_V2 exactly and in order.
+ * 2. Voice guard (helpTopics fork-E precedent): no engine numbers/multipliers
+ *    in any label or copy.
+ * 3. Follow-through guard: every round-1 "too weak" verdict has a v2 section
+ *    that explicitly frames itself as a round-one follow-up.
+ * 4. Light render test of PlaytestFeedbackForm handed the V2 definition.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  PLAYTEST_SECTION_IDS_V2,
+  PLAYTEST_KNOB_IDS_V2,
+  PLAYTEST_FEEDBACK_FORM_ID_V2,
+  buildEmptyPlaytestFeedbackResponsesV2,
+  PlaytestFeedbackResponsesV2Schema,
+  type AnyPlaytestFeedbackResponses,
+} from '@shared/api/contracts';
+import {
+  PLAYTEST_FORM_V2,
+  PLAYTEST_FORM_SECTIONS_V2,
+  PLAYTEST_FORM_KNOBS_V2,
+} from '@/admin/playtestFeedbackFormV2';
+import { PlaytestFeedbackForm } from '@/admin/PlaytestFeedbackPage';
+
+const ALL_COPY = [
+  PLAYTEST_FORM_V2.title,
+  PLAYTEST_FORM_V2.intro,
+  PLAYTEST_FORM_V2.knobSectionTitle,
+  PLAYTEST_FORM_V2.knobSectionBlurb,
+  PLAYTEST_FORM_V2.oneKnobPrompt,
+  PLAYTEST_FORM_V2.prioritiesSectionTitle,
+  PLAYTEST_FORM_V2.prioritiesSectionBlurb,
+  PLAYTEST_FORM_V2.pullBackPrompt,
+  PLAYTEST_FORM_V2.gutCheckPrompt,
+  PLAYTEST_FORM_V2.anythingOffPrompt,
+  ...PLAYTEST_FORM_SECTIONS_V2.flatMap((s) => [
+    s.title,
+    s.blurb,
+    s.exposurePrompt,
+    ...s.exposureOptions.map((o) => o.label),
+    ...s.designerQuestions,
+  ]),
+  ...PLAYTEST_FORM_KNOBS_V2.map((k) => k.label),
+].join('\n');
+
+describe('playtestFeedbackFormV2 — contract lockstep', () => {
+  it('section ids match PLAYTEST_SECTION_IDS_V2 exactly and in order', () => {
+    expect(PLAYTEST_FORM_SECTIONS_V2.map((s) => s.id)).toEqual([...PLAYTEST_SECTION_IDS_V2]);
+  });
+
+  it('knob ids match PLAYTEST_KNOB_IDS_V2 exactly and in order', () => {
+    expect(PLAYTEST_FORM_KNOBS_V2.map((k) => k.id)).toEqual([...PLAYTEST_KNOB_IDS_V2]);
+  });
+
+  it('the bundle formId matches the canonical V2 form id', () => {
+    expect(PLAYTEST_FORM_V2.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID_V2);
+  });
+
+  it('section numbers are 1..10 in order and §1–§3 + §9 are the multi-tick sections', () => {
+    expect(PLAYTEST_FORM_SECTIONS_V2.map((s) => s.number)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const multi = PLAYTEST_FORM_SECTIONS_V2.filter((s) => s.exposureMulti).map((s) => s.number);
+    expect(multi).toEqual([1, 2, 3, 9]);
+  });
+
+  it('every section has at least one designer question and exposure option ids are unique', () => {
+    for (const section of PLAYTEST_FORM_SECTIONS_V2) {
+      expect(section.designerQuestions.length).toBeGreaterThan(0);
+      const ids = section.exposureOptions.map((o) => o.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+
+  it('the empty V2 default document parses against the V2 response schema', () => {
+    const empty = buildEmptyPlaytestFeedbackResponsesV2();
+    expect(() => PlaytestFeedbackResponsesV2Schema.parse(empty)).not.toThrow();
+    expect(Object.keys(empty.sections)).toEqual([...PLAYTEST_SECTION_IDS_V2]);
+    expect(Object.keys(empty.knobStrength)).toEqual([...PLAYTEST_KNOB_IDS_V2]);
+  });
+});
+
+describe('playtestFeedbackFormV2 — voice guards (no engine numbers)', () => {
+  it('has no multiplier-number leakage (e.g. "2x", "1.5×")', () => {
+    expect(ALL_COPY).not.toMatch(/\d+(\.\d+)?\s*[x×]/i);
+  });
+
+  it('has no percentages anywhere', () => {
+    expect(ALL_COPY).not.toContain('%');
+  });
+});
+
+describe('playtestFeedbackFormV2 — round-1 follow-through', () => {
+  // Every round-1 "too weak" verdict (flop penalty, mood variance, energy,
+  // meeting relevance) plus the two one-knob complaints (rep pacing, CC) must
+  // have a v2 section that explicitly frames itself as a round-one follow-up
+  // — the whole point of round 2 is closing those loops.
+  const FOLLOW_THROUGH_SECTION_IDS = [
+    'energy_lifecycle',
+    'mood_outcomes',
+    'mood_recording_variance_retest',
+    'flop_drama',
+    'reputation_pacing',
+    'creative_capital_income',
+    'meeting_relevance_whynow',
+  ];
+
+  it.each(FOLLOW_THROUGH_SECTION_IDS)('section %s references round one', (id) => {
+    const section = PLAYTEST_FORM_SECTIONS_V2.find((s) => s.id === id);
+    expect(section).toBeDefined();
+    const copy = [section!.blurb, ...section!.designerQuestions].join('\n');
+    expect(copy.toLowerCase()).toMatch(/round[- ]one/);
+  });
+
+  it('the crisis section quotes the round-1 "OH MY" ask', () => {
+    const crisis = PLAYTEST_FORM_SECTIONS_V2.find((s) => s.id === 'mandatory_crisis_events');
+    expect(crisis).toBeDefined();
+    expect(crisis!.designerQuestions.join('\n')).toContain('OH MY');
+  });
+});
+
+describe('PlaytestFeedbackForm — render + interaction (V2 definition)', () => {
+  function renderForm(initial?: AnyPlaytestFeedbackResponses) {
+    const onChange = vi.fn();
+    const responses = initial ?? buildEmptyPlaytestFeedbackResponsesV2();
+    render(<PlaytestFeedbackForm form={PLAYTEST_FORM_V2} responses={responses} onChange={onChange} />);
+    return { onChange, responses };
+  }
+
+  it('renders all 10 mechanic sections plus the knob table and priorities sections', () => {
+    renderForm();
+    for (const section of PLAYTEST_FORM_SECTIONS_V2) {
+      expect(screen.getByTestId(`section-${section.id}`)).toBeInTheDocument();
+    }
+    expect(screen.getByTestId('section-knob-strength')).toBeInTheDocument();
+    expect(screen.getByTestId('section-priorities')).toBeInTheDocument();
+  });
+
+  it('numbers the knob and priorities sections after the last mechanic section', () => {
+    renderForm();
+    expect(screen.getByText('11.')).toBeInTheDocument();
+    expect(screen.getByText('12.')).toBeInTheDocument();
+  });
+
+  it('single-tick exposure replaces the previous tick (one tick per question)', () => {
+    const initial = buildEmptyPlaytestFeedbackResponsesV2();
+    initial.sections.flop_drama = {
+      exposure: ['natural'],
+      feel: null,
+      anythingOff: '',
+      designerAnswers: [],
+    };
+    const { onChange } = renderForm(initial);
+
+    fireEvent.click(screen.getByLabelText('Never flopped this run'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as AnyPlaytestFeedbackResponses;
+    expect(next.sections.flop_drama.exposure).toEqual(['never']);
+  });
+
+  it('multi-tick exposure accumulates ticks (§1 crisis "tick all you saw")', () => {
+    const initial = buildEmptyPlaytestFeedbackResponsesV2();
+    initial.sections.mandatory_crisis_events = {
+      exposure: ['crisis_card'],
+      feel: null,
+      anythingOff: '',
+      designerAnswers: [],
+    };
+    const { onChange } = renderForm(initial);
+
+    fireEvent.click(screen.getByLabelText('The advance blocked until I resolved it'));
+
+    const next = onChange.mock.calls[0][0] as AnyPlaytestFeedbackResponses;
+    expect(next.sections.mandatory_crisis_events.exposure).toEqual([
+      'crisis_card',
+      'advance_blocked',
+    ]);
+  });
+
+  it('selecting a knob strength reports through onChange', () => {
+    const { onChange } = renderForm();
+
+    fireEvent.click(screen.getByLabelText('Crisis frequency — Too strong'));
+
+    const next = onChange.mock.calls[0][0] as AnyPlaytestFeedbackResponses;
+    expect(next.knobStrength.crisis_frequency).toBe('too_strong');
+  });
+
+  it('typing a top priority reports through onChange', () => {
+    const { onChange } = renderForm();
+
+    fireEvent.change(screen.getByLabelText('Priority 1'), {
+      target: { value: 'crisis slot cost feels right, keep it' },
+    });
+
+    const next = onChange.mock.calls[0][0] as AnyPlaytestFeedbackResponses;
+    expect(next.topPriorities[0]).toBe('crisis slot cost feels right, keep it');
+  });
+});

--- a/tests/client/playtest-feedback-form.test.tsx
+++ b/tests/client/playtest-feedback-form.test.tsx
@@ -33,6 +33,7 @@ import {
   PULL_BACK_PROMPT,
   GUT_CHECK_PROMPT,
   ANYTHING_OFF_PROMPT,
+  PLAYTEST_FORM_V1,
 } from '@/admin/playtestFeedbackForm';
 import { PlaytestFeedbackForm } from '@/admin/PlaytestFeedbackPage';
 
@@ -98,7 +99,9 @@ describe('PlaytestFeedbackForm — render + interaction', () => {
   function renderForm(initial?: PlaytestFeedbackResponses) {
     const onChange = vi.fn();
     const responses = initial ?? buildEmptyPlaytestFeedbackResponses();
-    render(<PlaytestFeedbackForm responses={responses} onChange={onChange} />);
+    // The page now serves round 2; the component renders whichever form
+    // definition it is handed — these tests exercise the round-1 definition.
+    render(<PlaytestFeedbackForm form={PLAYTEST_FORM_V1} responses={responses} onChange={onChange} />);
     return { onChange, responses };
   }
 

--- a/tests/server/routes/admin-playtest-feedback.test.ts
+++ b/tests/server/routes/admin-playtest-feedback.test.ts
@@ -1,13 +1,17 @@
 // @vitest-environment node
 /**
- * Admin playtest-feedback endpoint characterization test.
+ * Admin playtest-feedback endpoint characterization test — versioned (round 2).
  *
- * Mirrors the admin-events-config suite (same router, same auth/db mocks):
- * GET returns the saved responses file or the canonical empty default when
- * none exists; POST validates via PlaytestFeedbackResponsesSchema, backs up
- * the previous file, stamps savedAt server-side, and writes pretty-printed
- * JSON with stable key order to
- * docs/01-planning/playtest-feedback-2026-07-11.responses.json.
+ * Mirrors the admin-events-config suite (same router, same auth/db mocks).
+ * The single GET/POST pair now serves BOTH forms, keyed by a validated
+ * formId from the fixed two-entry allowlist:
+ * - GET defaults to the active (v2, 2026-07-12) form; ?formId= selects a
+ *   round; unknown ids are rejected with 400.
+ * - POST validates via the union schema, keys the target file off the
+ *   validated responses.formId, backs up the previous file, stamps savedAt
+ *   server-side, and writes pretty-printed JSON with stable key order.
+ * - The round-1 responses file is a HISTORICAL RECORD: a v2 save must never
+ *   touch it (proven byte-for-byte below).
  *
  * Uses a temp fixture docs/01-planning directory (via process.chdir) so the
  * test never touches the real planning docs.
@@ -38,27 +42,54 @@ import express, { type Express } from 'express';
 import request from 'supertest';
 import {
   buildEmptyPlaytestFeedbackResponses,
+  buildEmptyPlaytestFeedbackResponsesV2,
+  PLAYTEST_FEEDBACK_FORM_ID,
+  PLAYTEST_FEEDBACK_FORM_ID_V2,
   PLAYTEST_SECTION_IDS,
   PLAYTEST_KNOB_IDS,
+  PLAYTEST_SECTION_IDS_V2,
+  PLAYTEST_KNOB_IDS_V2,
 } from '@shared/api/contracts';
 
-const RESPONSES_REL_PATH = path.join(
+const V1_RESPONSES_REL_PATH = path.join(
   'docs',
   '01-planning',
   'playtest-feedback-2026-07-11.responses.json'
 );
+const V2_RESPONSES_REL_PATH = path.join(
+  'docs',
+  '01-planning',
+  'playtest-feedback-2026-07-12.responses.json'
+);
 
-function sampleResponses() {
+function sampleV2Responses() {
+  const responses = buildEmptyPlaytestFeedbackResponsesV2();
+  responses.sections.mandatory_crisis_events = {
+    exposure: ['crisis_card', 'advance_blocked', 'handled_beat'],
+    feel: 'sings',
+    anythingOff: '',
+    designerAnswers: [
+      'Yes — this is the OH MY.',
+      'Fair price, real tension.',
+      'One in five feels right now that it costs a slot.',
+    ],
+  };
+  responses.knobStrength.crisis_frequency = 'about_right';
+  responses.oneKnobChange = 'mood swing size, up a touch';
+  responses.topPriorities = ['audio audition', 'more crisis variety', ''];
+  responses.gutCheck = 'round two has the drama';
+  return responses;
+}
+
+function sampleV1Responses() {
   const responses = buildEmptyPlaytestFeedbackResponses();
   responses.sections.flop_penalty = {
-    exposure: ['natural'],
+    exposure: ['never'],
     feel: 'works',
-    anythingOff: 'took a while to find in the Achievements card',
-    designerAnswers: ['Connected it to the flop immediately.', 'Yes, it enters the decision now.'],
+    anythingOff: 'historical answer',
+    designerAnswers: ['N/A', 'In theory yes.'],
   };
-  responses.knobStrength.flop_reputation_penalty = 'about_right';
-  responses.oneKnobChange = 'side-event frequency, up a notch';
-  responses.topPriorities = ['make breakthroughs louder', 'tour energy drain', ''];
+  responses.knobStrength.flop_reputation_penalty = 'too_weak';
   responses.gutCheck = 'yes, noticeably';
   return responses;
 }
@@ -67,7 +98,7 @@ let app: Express;
 let originalCwd: string;
 let tmpDir: string;
 
-describe('admin playtest-feedback endpoints', () => {
+describe('admin playtest-feedback endpoints (versioned)', () => {
   beforeAll(async () => {
     const adminRouter = (await import('../../../server/routes/admin')).default;
     app = express();
@@ -87,18 +118,35 @@ describe('admin playtest-feedback endpoints', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('GET returns the empty default when no responses file exists', async () => {
+  it('GET without formId returns the empty ACTIVE (v2) default when no file exists', async () => {
     const res = await request(app).get('/api/admin/playtest-feedback');
     expect(res.status).toBe(200);
-    expect(res.body.formId).toBe('playtest-feedback-2026-07-11');
+    expect(res.body.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID_V2);
     expect(res.body.savedAt).toBeNull();
-    expect(Object.keys(res.body.sections)).toEqual([...PLAYTEST_SECTION_IDS]);
-    expect(Object.keys(res.body.knobStrength)).toEqual([...PLAYTEST_KNOB_IDS]);
+    expect(Object.keys(res.body.sections)).toEqual([...PLAYTEST_SECTION_IDS_V2]);
+    expect(Object.keys(res.body.knobStrength)).toEqual([...PLAYTEST_KNOB_IDS_V2]);
     expect(res.body.topPriorities).toEqual(['', '', '']);
   });
 
-  it('POST writes the file with a server-stamped savedAt and GET round-trips it', async () => {
-    const responses = sampleResponses();
+  it('GET ?formId=<v1> returns the empty round-1 default when no file exists', async () => {
+    const res = await request(app).get(
+      `/api/admin/playtest-feedback?formId=${PLAYTEST_FEEDBACK_FORM_ID}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID);
+    expect(Object.keys(res.body.sections)).toEqual([...PLAYTEST_SECTION_IDS]);
+    expect(Object.keys(res.body.knobStrength)).toEqual([...PLAYTEST_KNOB_IDS]);
+  });
+
+  it('GET with a formId outside the allowlist returns 400', async () => {
+    const res = await request(app).get(
+      '/api/admin/playtest-feedback?formId=playtest-feedback-2027-01-01'
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST writes the v2 file with a server-stamped savedAt and GET round-trips it', async () => {
+    const responses = sampleV2Responses();
 
     const postRes = await request(app)
       .post('/api/admin/playtest-feedback')
@@ -108,12 +156,13 @@ describe('admin playtest-feedback endpoints', () => {
     expect(postRes.body.success).toBe(true);
     expect(typeof postRes.body.savedAt).toBe('string');
 
-    const writtenRaw = await fs.readFile(path.join(tmpDir, RESPONSES_REL_PATH), 'utf8');
+    const writtenRaw = await fs.readFile(path.join(tmpDir, V2_RESPONSES_REL_PATH), 'utf8');
     const written = JSON.parse(writtenRaw);
+    expect(written.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID_V2);
     expect(written.savedAt).toBe(postRes.body.savedAt);
-    expect(written.sections.flop_penalty.feel).toBe('works');
+    expect(written.sections.mandatory_crisis_events.feel).toBe('sings');
     // Pretty-printed, stable key order: top-level keys and section keys are
-    // in canonical order regardless of what order the client sent.
+    // in canonical V2 order regardless of what order the client sent.
     expect(writtenRaw).toContain('\n  "formId"');
     expect(Object.keys(written)).toEqual([
       'formId',
@@ -125,20 +174,20 @@ describe('admin playtest-feedback endpoints', () => {
       'pullBack',
       'gutCheck',
     ]);
-    expect(Object.keys(written.sections)).toEqual([...PLAYTEST_SECTION_IDS]);
-    expect(Object.keys(written.knobStrength)).toEqual([...PLAYTEST_KNOB_IDS]);
+    expect(Object.keys(written.sections)).toEqual([...PLAYTEST_SECTION_IDS_V2]);
+    expect(Object.keys(written.knobStrength)).toEqual([...PLAYTEST_KNOB_IDS_V2]);
 
     const getRes = await request(app).get('/api/admin/playtest-feedback');
     expect(getRes.status).toBe(200);
-    expect(getRes.body.sections.flop_penalty.designerAnswers).toHaveLength(2);
+    expect(getRes.body.sections.mandatory_crisis_events.designerAnswers).toHaveLength(3);
     expect(getRes.body.savedAt).toBe(postRes.body.savedAt);
   });
 
-  it('POST backs up the previous responses file before overwriting', async () => {
-    const first = sampleResponses();
+  it('POST backs up the previous v2 responses file before overwriting', async () => {
+    const first = sampleV2Responses();
     await request(app).post('/api/admin/playtest-feedback').send({ responses: first });
 
-    const second = sampleResponses();
+    const second = sampleV2Responses();
     second.gutCheck = 'revised answer';
     const res = await request(app)
       .post('/api/admin/playtest-feedback')
@@ -147,26 +196,86 @@ describe('admin playtest-feedback endpoints', () => {
     expect(res.status).toBe(200);
     expect(res.body.backupCreated).toBe(true);
 
-    const backupRaw = await fs.readFile(`${path.join(tmpDir, RESPONSES_REL_PATH)}.backup`, 'utf8');
+    const backupRaw = await fs.readFile(
+      `${path.join(tmpDir, V2_RESPONSES_REL_PATH)}.backup`,
+      'utf8'
+    );
     const backup = JSON.parse(backupRaw);
-    expect(backup.gutCheck).toBe('yes, noticeably');
+    expect(backup.gutCheck).toBe('round two has the drama');
 
-    const currentRaw = await fs.readFile(path.join(tmpDir, RESPONSES_REL_PATH), 'utf8');
+    const currentRaw = await fs.readFile(path.join(tmpDir, V2_RESPONSES_REL_PATH), 'utf8');
     expect(JSON.parse(currentRaw).gutCheck).toBe('revised answer');
   });
 
+  it('POST of a v2 document NEVER touches the round-1 historical file', async () => {
+    // Seed a round-1 file exactly as the owner's machine has one.
+    const v1Path = path.join(tmpDir, V1_RESPONSES_REL_PATH);
+    const historicalRaw = JSON.stringify(
+      { ...sampleV1Responses(), savedAt: '2026-07-11T21:47:07.073Z' },
+      null,
+      2
+    );
+    await fs.writeFile(v1Path, historicalRaw, 'utf8');
+
+    const res = await request(app)
+      .post('/api/admin/playtest-feedback')
+      .send({ responses: sampleV2Responses() });
+    expect(res.status).toBe(200);
+
+    // v1 file byte-identical, and no v1 backup was created (nothing wrote near it).
+    const afterRaw = await fs.readFile(v1Path, 'utf8');
+    expect(afterRaw).toBe(historicalRaw);
+    await expect(fs.readFile(`${v1Path}.backup`, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    // And the v2 file landed in its own slot.
+    await expect(fs.readFile(path.join(tmpDir, V2_RESPONSES_REL_PATH), 'utf8')).resolves.toContain(
+      PLAYTEST_FEEDBACK_FORM_ID_V2
+    );
+  });
+
+  it('POST of a v1 document still writes the v1 file (history stays editable) and not the v2 file', async () => {
+    const res = await request(app)
+      .post('/api/admin/playtest-feedback')
+      .send({ responses: sampleV1Responses() });
+    expect(res.status).toBe(200);
+
+    const writtenRaw = await fs.readFile(path.join(tmpDir, V1_RESPONSES_REL_PATH), 'utf8');
+    const written = JSON.parse(writtenRaw);
+    expect(written.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID);
+    expect(Object.keys(written.sections)).toEqual([...PLAYTEST_SECTION_IDS]);
+
+    await expect(
+      fs.readFile(path.join(tmpDir, V2_RESPONSES_REL_PATH), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('POST with an invalid feel rating returns 400 and does not write', async () => {
-    const invalid: any = sampleResponses();
-    invalid.sections.flop_penalty.feel = 'transcendent';
+    const invalid: any = sampleV2Responses();
+    invalid.sections.mandatory_crisis_events.feel = 'transcendent';
 
     const res = await request(app)
       .post('/api/admin/playtest-feedback')
       .send({ responses: invalid });
 
     expect(res.status).toBe(400);
-    await expect(fs.readFile(path.join(tmpDir, RESPONSES_REL_PATH), 'utf8')).rejects.toMatchObject({
-      code: 'ENOENT',
-    });
+    await expect(
+      fs.readFile(path.join(tmpDir, V2_RESPONSES_REL_PATH), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('POST with a formId outside the allowlist returns 400 and does not write', async () => {
+    const foreign: any = sampleV2Responses();
+    foreign.formId = 'playtest-feedback-2027-01-01';
+
+    const res = await request(app)
+      .post('/api/admin/playtest-feedback')
+      .send({ responses: foreign });
+
+    expect(res.status).toBe(400);
+    await expect(
+      fs.readFile(path.join(tmpDir, V2_RESPONSES_REL_PATH), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('POST without responses returns 400', async () => {

--- a/tests/shared/api/playtest-feedback-contract.test.ts
+++ b/tests/shared/api/playtest-feedback-contract.test.ts
@@ -3,12 +3,26 @@
  * precedent). Guards the recording-surface document shape for the
  * 2026-07-11 playtest form: defaults fill every field, the feel/strength
  * enums are closed, and topPriorities is exactly three slots.
+ *
+ * Round 2 (2026-07-12) adds: the V2 schema (same shape, V2 formId literal),
+ * the endpoint union that routes by formId, the fixed two-entry form
+ * registry, and a loadability guard for the round-1 historical responses
+ * file (when present on disk).
  */
 import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
 import {
   PlaytestFeedbackResponsesSchema,
+  PlaytestFeedbackResponsesV2Schema,
+  AnyPlaytestFeedbackResponsesSchema,
   buildEmptyPlaytestFeedbackResponses,
+  buildEmptyPlaytestFeedbackResponsesV2,
   PLAYTEST_FEEDBACK_FORM_ID,
+  PLAYTEST_FEEDBACK_FORM_ID_V2,
+  PLAYTEST_FORM_REGISTRY,
+  ACTIVE_PLAYTEST_FORM_ID,
+  isPlaytestFormId,
 } from '@shared/api/contracts';
 
 describe('PlaytestFeedbackResponsesSchema', () => {
@@ -46,5 +60,82 @@ describe('PlaytestFeedbackResponsesSchema', () => {
 
   it('rejects a foreign formId', () => {
     expect(() => PlaytestFeedbackResponsesSchema.parse({ formId: 'some-other-form' })).toThrow();
+  });
+});
+
+describe('PlaytestFeedbackResponsesV2Schema (round 2)', () => {
+  it('parses an empty object into a V2-defaulted document', () => {
+    const parsed = PlaytestFeedbackResponsesV2Schema.parse({});
+    expect(parsed.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID_V2);
+    expect(parsed.savedAt).toBeNull();
+    expect(parsed.topPriorities).toEqual(['', '', '']);
+  });
+
+  it('round-trips the canonical empty V2 default unchanged', () => {
+    const empty = buildEmptyPlaytestFeedbackResponsesV2();
+    expect(PlaytestFeedbackResponsesV2Schema.parse(empty)).toEqual(empty);
+  });
+
+  it('rejects the V1 formId (each round is its own document)', () => {
+    expect(() =>
+      PlaytestFeedbackResponsesV2Schema.parse({ formId: PLAYTEST_FEEDBACK_FORM_ID })
+    ).toThrow();
+  });
+
+  it('shares the closed feel scale with V1', () => {
+    const bad = {
+      sections: {
+        flop_drama: { exposure: [], feel: 'transcendent', anythingOff: '', designerAnswers: [] },
+      },
+    };
+    expect(() => PlaytestFeedbackResponsesV2Schema.parse(bad)).toThrow();
+  });
+});
+
+describe('AnyPlaytestFeedbackResponsesSchema — formId routing', () => {
+  it('routes a document with no formId to the ACTIVE (v2) form', () => {
+    const parsed = AnyPlaytestFeedbackResponsesSchema.parse({});
+    expect(parsed.formId).toBe(ACTIVE_PLAYTEST_FORM_ID);
+    expect(ACTIVE_PLAYTEST_FORM_ID).toBe(PLAYTEST_FEEDBACK_FORM_ID_V2);
+  });
+
+  it('still parses an explicit V1 document (historical record stays loadable)', () => {
+    const v1 = buildEmptyPlaytestFeedbackResponses();
+    const parsed = AnyPlaytestFeedbackResponsesSchema.parse(v1);
+    expect(parsed.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID);
+  });
+
+  it('rejects a formId outside the fixed allowlist', () => {
+    expect(() =>
+      AnyPlaytestFeedbackResponsesSchema.parse({ formId: 'playtest-feedback-2027-01-01' })
+    ).toThrow();
+    expect(isPlaytestFormId('playtest-feedback-2027-01-01')).toBe(false);
+  });
+
+  it('the registry holds exactly the two known form ids, active first in the union', () => {
+    expect(Object.keys(PLAYTEST_FORM_REGISTRY).sort()).toEqual(
+      [PLAYTEST_FEEDBACK_FORM_ID, PLAYTEST_FEEDBACK_FORM_ID_V2].sort()
+    );
+    expect(isPlaytestFormId(PLAYTEST_FEEDBACK_FORM_ID)).toBe(true);
+    expect(isPlaytestFormId(PLAYTEST_FEEDBACK_FORM_ID_V2)).toBe(true);
+  });
+});
+
+describe('round-1 responses file — historical record stays loadable', () => {
+  // The real round-1 responses file lives on the owner's machine (written at
+  // runtime by the admin page; not committed). When it is present, it must
+  // keep parsing against the V1 branch of the union — this is the regression
+  // tripwire for any future schema change that would strand the history.
+  const v1FilePath = path.join(
+    process.cwd(),
+    'docs',
+    '01-planning',
+    'playtest-feedback-2026-07-11.responses.json'
+  );
+
+  it.skipIf(!existsSync(v1FilePath))('parses against the union with the V1 formId', () => {
+    const raw = JSON.parse(readFileSync(v1FilePath, 'utf8'));
+    const parsed = AnyPlaytestFeedbackResponsesSchema.parse(raw);
+    expect(parsed.formId).toBe(PLAYTEST_FEEDBACK_FORM_ID);
   });
 });


### PR DESCRIPTION
## Summary
Round-2 playtest feedback capture, closing the loop on the implementation arc (#159–#162):

- **New form** `docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md` — 10 sections grounded in what actually merged and in the owner's round-1 answers: mandatory crisis events (drama / slot-cost / pacing), energy lifecycle, mood↔outcomes, explicit RE-TESTS of round 1's three "never saw it" mechanics, reputation pacing (full-campaign arc question), CC income, why-now relevance, hype attach UX, Board brief preview + knob-strength table incl. crisis frequency/slot cost.
- **Versioning without new routes**: same GET/POST `/api/admin/playtest-feedback` pair keyed by a validated formId from a fixed two-entry allowlist (`PLAYTEST_FORM_REGISTRY`); active form = v2; v2 saves write `playtest-feedback-2026-07-12.responses.json`. The round-1 responses file is structurally unreachable from a v2 save (byte-for-byte endpoint test + a conditional tripwire that parses the real v1 file when present). Route manifest byte-identical.
- `/admin/playtest-feedback` now serves the v2 form; v1 module/markdown retained as history; render component made version-agnostic (additive exports only).

## Verification
- tsc clean; suite **1,868 passed + 1 conditional skip** (baseline 1,833 → +35).
- No engine/gameplay surface; no route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
