### PR TITLE
docs(playtest-form-v2): pre-seed §12 with live-play finds

### DIFF
--- a/client/src/admin/playtestFeedbackFormV2.ts
+++ b/client/src/admin/playtestFeedbackFormV2.ts
@@ -287,7 +287,16 @@ export const PRIORITIES_SECTION_TITLE_V2 = 'Top-3 priority — what do I fix/tun
 
 export const PRIORITIES_SECTION_BLURB_V2 =
   'Rank the three things most worth my time after this round. A bug, a tuning pass, a legibility fix, or ' +
-  '"make X louder." Be specific — round one left this section blank and it was missed.';
+  '"make X louder." Be specific — round one left this section blank and it was missed. ' +
+  'Already queued from live play this session (rank against your own finds, or strike them): ' +
+  '(1) Buzz hidden-at-zero is ambiguous during the building window — a release with no banked-hype seed shows ' +
+  'no Buzz section at all in its first post-release week, indistinguishable from a dead release (this misled real ' +
+  'play: Glass Houses read as "never generated buzz" when it simply had not had its first building tick; candidate ' +
+  'fix: always show the bar during the building weeks, even empty, labeled "building"). ' +
+  '(2) Stale Admin-index link label still says Round 1. ' +
+  '(3) Context, not a bug: the campaign verdict on a fresh release is a week-one snapshot — Glass Houses flipped ' +
+  'from Underperformed to Strong Success as week-two streams landed; note here if that flip read as confusing ' +
+  'rather than dramatic.';
 
 export const PULL_BACK_PROMPT_V2 =
   "Anything from this tuning arc that overshot and you'd rather I pull back or reconsider?";

--- a/docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md
+++ b/docs/01-planning/PLAYTEST_FEEDBACK_2026-07-12.md
@@ -233,6 +233,11 @@
 
 *Rank the three things most worth my time after this round. A bug, a tuning pass, a legibility fix, or "make X louder." Be specific — round one left this section blank and it was missed.*
 
+**Already queued from live play this session (rank them against your own finds, or strike them):**
+- **Buzz hidden-at-zero is ambiguous during the building window.** A release with no banked-hype seed shows NO Buzz section in its first post-release week — indistinguishable from a dead release. This misled you in real play (Glass Houses read as "never generated buzz" when it simply hadn't had its first building tick). Candidate fix: during the building weeks, always show the bar — even empty — labeled "building"; absence then genuinely means faded out.
+- **Stale label on the Admin index:** the tools list still links "Playtest Feedback (2026-07-11)" — should read Round 2 / 2026-07-12.
+- *(For context, not a bug: the campaign verdict on a fresh release is a week-one snapshot — Glass Houses flipped from "Underperformed" to "Strong Success" as week-two streams landed. If that flip felt confusing rather than dramatic, note it here.)*
+
 1. ____________________________________________________________________
 2. ____________________________________________________________________
 3. ____________________________________________________________________


### PR DESCRIPTION
Adds three session finds to the round-2 form's priority section (markdown + served module, voice guards green): the buzz hidden-at-zero building-window ambiguity, the stale admin-index label, and verdict-flip context. tsc clean; form test suites 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)