### PR TITLE
feat(auto-select): AUTO fills every unlocked slot — CEO lane as 4th-slot filler

### DIFF
--- a/client/src/machines/__tests__/executiveMeetingMachine.autoReview.test.ts
+++ b/client/src/machines/__tests__/executiveMeetingMachine.autoReview.test.ts
@@ -92,7 +92,11 @@ describe('executiveMeetingMachine — AUTO propose-then-confirm (PR-3)', () => {
     await waitForState(actor, 'reviewingAutoSelections');
 
     const { autoOptions } = actor.getSnapshot().context;
-    expect(autoOptions.length).toBe(2);
+    // 2 seeded execs + the CEO filler for the 3rd free slot (playtest
+    // 2026-07-25: AUTO fills every unlocked slot, drawing the leftover from
+    // the CEO meeting lane as a fallback — never competing with scored execs).
+    expect(autoOptions.length).toBe(3);
+    expect(autoOptions[2].executive.role).toBe('ceo');
     // Not committed yet — the review gate must not have called onActionSelected.
     expect(onActionSelected).not.toHaveBeenCalled();
     // AUTO's safest-choice logic is unchanged: it picks the gamble-free choice.

--- a/client/src/machines/executiveMeetingMachine.ts
+++ b/client/src/machines/executiveMeetingMachine.ts
@@ -1,7 +1,7 @@
 import { assign, fromPromise, setup } from 'xstate';
 import type { RoleMeeting, DialogueChoice, Executive } from '../../../shared/types/gameTypes';
 import { fetchExecutives, fetchRoleMeetings, fetchMeetingDialogue } from '../services/executiveService';
-import { prepareAutoSelectOptions, selectTopOptions, optionToActionData, type AutoSelectOption } from '../services/executiveAutoSelect';
+import { prepareAutoSelectOptions, selectTopOptions, appendCeoFillerOption, optionToActionData, type AutoSelectOption } from '../services/executiveAutoSelect';
 import { getMoodModifiers, applyMoodModifiersToEffects, isNeutral } from '@shared/utils/executiveMoodModifier';
 
 type DialogueData = {
@@ -408,7 +408,21 @@ export const executiveMeetingMachine = setup({
         // who already has a queued action this week.
         usedExecutiveRoles: context.usedExecutiveRoles,
       });
-      const topOptions = selectTopOptions(allOptions, slotsRemaining, context.creativeCapital);
+      let topOptions = selectTopOptions(allOptions, slotsRemaining, context.creativeCapital);
+
+      // 4th-slot CEO filler (playtest 2026-07-25): when the seeded execs can't
+      // fill every remaining slot (4th slot unlocked, or A&R head out
+      // scouting), draw the leftover slot from the CEO meeting lane.
+      if (topOptions.length < slotsRemaining) {
+        const ceoMeetings = await ensureMeetings('ceo');
+        topOptions = appendCeoFillerOption(
+          topOptions,
+          slotsRemaining,
+          ceoMeetings,
+          context.creativeCapital,
+          context.usedExecutiveRoles
+        );
+      }
 
       // Convert to AutoOption format expected by machine
       const machineOptions: AutoOption[] = topOptions.map(option => ({

--- a/client/src/services/executiveAutoSelect.ts
+++ b/client/src/services/executiveAutoSelect.ts
@@ -220,6 +220,77 @@ export function selectTopOptions(
 }
 
 /**
+ * Synthetic CEO lane for AUTO's 4th-slot filler. The CEO is the player, not a
+ * seeded executives row — no mood/loyalty state exists, so the neutral 50s only
+ * matter for display. `id` is unused for submission (optionToActionData omits
+ * executiveId for the ceo role).
+ */
+export const CEO_AUTO_EXECUTIVE: Executive = {
+  id: 'ceo',
+  role: 'ceo',
+  level: 1,
+  mood: 50,
+  loyalty: 50,
+};
+
+/**
+ * Playtest fix (2026-07-25): with the 4th focus slot unlocked, AUTO could
+ * never fill it — it proposes at most one meeting per seeded exec and only 4
+ * execs exist (fewer when the A&R head is out scouting). The CEO lane already
+ * exists in the manual UI (ceo meetings in actions.json, CEO card, ceo-aware
+ * action data); AUTO just never drew from it.
+ *
+ * The CEO is a FILLER, not a competitor: appended only when the scored picks
+ * leave slots unfilled (his role-priority score would otherwise outrank
+ * content execs and hijack a slot from a neglected exec). Respects the same
+ * rules as every other lane: skipped when the ceo role already has a queued
+ * action, `user_selected`-only pools are ineligible (findEligibleMeeting),
+ * gamble-free choice via pickSafestChoice, and never overdraws the remaining
+ * Creative Capital budget.
+ *
+ * @param selected - options already chosen by selectTopOptions (score order)
+ * @param availableSlots - total slots AUTO may fill this pass
+ * @param ceoMeetings - the ceo role's meeting pool for this week
+ * @param creativeCapitalBudget - CC budget for the WHOLE pass (the CEO filler
+ *   only spends what the selected options left over)
+ * @param usedExecutiveRoles - roles with an already-queued action this week
+ * @returns a new array with the CEO option appended, or `selected` unchanged
+ */
+export function appendCeoFillerOption(
+  selected: AutoSelectOption[],
+  availableSlots: number,
+  ceoMeetings: RoleMeeting[],
+  creativeCapitalBudget: number = Infinity,
+  usedExecutiveRoles: readonly string[] = []
+): AutoSelectOption[] {
+  if (selected.length >= availableSlots) return selected;
+  if (usedExecutiveRoles.includes('ceo')) return selected;
+  if (selected.some((option) => option.executive.role === 'ceo')) return selected;
+
+  const meeting = findEligibleMeeting(ceoMeetings);
+  if (!meeting) return selected;
+
+  const spent = selected.reduce(
+    (sum, option) => sum + getChoiceCreativeCapitalCost(option.choice),
+    0
+  );
+  const budgetLeft = creativeCapitalBudget - spent;
+
+  const choice = pickSafestChoice(meeting.choices ?? [], budgetLeft);
+  if (!choice || getChoiceCreativeCapitalCost(choice) > budgetLeft) return selected;
+
+  return [
+    ...selected,
+    {
+      executive: CEO_AUTO_EXECUTIVE,
+      meeting,
+      choice,
+      score: 0, // filler — always ranks after the scored exec picks
+    },
+  ];
+}
+
+/**
  * Convert an auto-select option to action data format
  *
  * @param option - Auto-selection option

--- a/tests/unit/executiveAutoSelect.test.ts
+++ b/tests/unit/executiveAutoSelect.test.ts
@@ -12,7 +12,9 @@ import {
   pickSafestChoice,
   prepareAutoSelectOptions,
   selectTopOptions,
+  appendCeoFillerOption,
   getChoiceCreativeCapitalCost,
+  type AutoSelectOption,
 } from '../../client/src/services/executiveAutoSelect';
 
 function choice(id: string, overrides: Partial<DialogueChoice> = {}): DialogueChoice {
@@ -340,5 +342,73 @@ describe('selectTopOptions — never overdraws Creative Capital (playtest bug #1
     const options = prepareAutoSelectOptions([exec('head_ar'), exec('cmo')], { head_ar: [m1], cmo: [m2] });
     const picked = selectTopOptions(options, 2);
     expect(picked).toHaveLength(2);
+  });
+});
+
+describe('appendCeoFillerOption — AUTO fills the 4th slot from the CEO lane (playtest 2026-07-25)', () => {
+  const exec = (role: string, mood = 50): Executive => ({ id: `exec-${role}`, role, level: 1, mood, loyalty: 50 });
+
+  function meetingWith(id: string, role: string, choices: DialogueChoice[]): RoleMeeting {
+    return { id, prompt: id, target_scope: 'global', role_id: role, choices } as RoleMeeting;
+  }
+
+  const ceoMeetings = [meetingWith('ceo_m', 'ceo', [choice('ceo_safe', { effects_immediate: { money: -500 } })])];
+
+  function execOption(role: string): AutoSelectOption {
+    const m = meetingWith(`${role}_m`, role, [choice(`${role}_safe`)]);
+    return { executive: exec(role), meeting: m, choice: m.choices![0] as DialogueChoice, score: 100 };
+  }
+
+  it('appends a CEO option when scored picks leave a slot unfilled', () => {
+    const selected = [execOption('head_ar'), execOption('cmo'), execOption('cco')];
+    const result = appendCeoFillerOption(selected, 4, ceoMeetings);
+    expect(result).toHaveLength(4);
+    expect(result[3].executive.role).toBe('ceo');
+    expect(result[3].meeting.id).toBe('ceo_m');
+  });
+
+  it('does nothing when all slots are already filled (CEO never competes)', () => {
+    const selected = [execOption('head_ar'), execOption('cmo'), execOption('cco'), execOption('head_distribution')];
+    const result = appendCeoFillerOption(selected, 4, ceoMeetings);
+    expect(result).toHaveLength(4);
+    expect(result.every((o) => o.executive.role !== 'ceo')).toBe(true);
+  });
+
+  it('skips the CEO when the ceo role already has a queued action', () => {
+    const result = appendCeoFillerOption([execOption('cmo')], 2, ceoMeetings, Infinity, ['ceo']);
+    expect(result).toHaveLength(1);
+  });
+
+  it('skips a user_selected-only CEO pool (needs the player, not AUTO)', () => {
+    const userSelectedOnly = [{
+      ...meetingWith('ceo_pick', 'ceo', [choice('c1')]),
+      target_scope: 'user_selected',
+    } as RoleMeeting];
+    const result = appendCeoFillerOption([execOption('cmo')], 2, userSelectedOnly);
+    expect(result).toHaveLength(1);
+  });
+
+  it('never overdraws the remaining Creative Capital budget', () => {
+    const costlyCeo = [meetingWith('ceo_costly', 'ceo', [
+      choice('ceo_cc', { effects_immediate: { creative_capital: -2 } }),
+    ])];
+    const spentTwo: AutoSelectOption = {
+      ...execOption('cmo'),
+      choice: choice('cmo_cc', { effects_immediate: { creative_capital: -2 } }),
+    };
+    // Budget 3, already spent 2 → only 1 left; the CEO's cheapest choice costs 2.
+    const result = appendCeoFillerOption([spentTwo], 2, costlyCeo, 3);
+    expect(result).toHaveLength(1);
+
+    // Budget 4 → 2 left; now it fits.
+    const result2 = appendCeoFillerOption([spentTwo], 2, costlyCeo, 4);
+    expect(result2).toHaveLength(2);
+    expect(result2[1].executive.role).toBe('ceo');
+  });
+
+  it('is idempotent: never appends a second CEO option', () => {
+    const once = appendCeoFillerOption([execOption('cmo')], 3, ceoMeetings);
+    const twice = appendCeoFillerOption(once, 3, ceoMeetings);
+    expect(twice.filter((o) => o.executive.role === 'ceo')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Problem (playtest 2026-07-25, item 3)

With the 4th focus slot unlocked, AUTO only ever fills 3. Root cause is structural, not a hardcoded cap: AUTO proposes at most one meeting per seeded executive, only 4 executives exist, and any exclusion (most commonly Mac out on an A&R op — which itself consumes a slot) drops the proposable pool below the slot count.

## Fix

Draw the leftover slot(s) from the **CEO meeting lane**, which already exists everywhere except AUTO: `actions.json` has 3 CEO meetings, the manual UI renders a CEO card, `optionToActionData` already handles the ceo role, and the review panel has `roleConfig.ceo`.

Design point: the CEO is a **filler, never a competitor**. Added to the scoring pool he'd outrank content execs (highest role priority + neutral mood/loyalty) and steal slots from neglected executives — so `appendCeoFillerOption` runs *after* `selectTopOptions` and only when slots remain. It honors every existing AUTO rule: already-queued ceo exclusion, `user_selected`-only pools ineligible, gamble-free choice, hard Creative Capital budget (spends only what the scored picks left over).

## Behavior change

- 4 slots + all execs available → 4 scored exec picks, no CEO (unchanged).
- 4 slots + Mac scouting → 3 exec picks **+ 1 CEO meeting** (was 3).
- 3 slots + an exec sitting out → 2 exec picks **+ 1 CEO meeting** (was 2).

## Verification

- 6 new unit tests for the filler; autoReview machine test updated (2 seeded execs + 3 slots now yields 3 options with the CEO third).
- `npm run check` clean; AUTO intent suites (header + executive-meetings + review panel + machine) all green: 74/74.
- Manual: unlock the 4th slot (rep 280 on the round-4 scale), send Mac scouting, hit AUTO → expect 3 exec picks + a CEO meeting in the review panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)