### PR TITLE
fix(plan-release): default release week to earliest legal week, not hardcoded 6

### DIFF
--- a/client/src/lib/releaseWeekDefaults.ts
+++ b/client/src/lib/releaseWeekDefaults.ts
@@ -1,0 +1,43 @@
+/**
+ * Default-week derivation for the Plan Release flow.
+ *
+ * Server-side validation (server/services/releasePlanningService.ts) rejects
+ * any scheduledReleaseWeek <= currentWeek, so the earliest legally schedulable
+ * release week is currentWeek + 1 — the same bound PlanReleasePage passes to
+ * MusicCalendar as `minWeek`. Keep these helpers in sync with that rule.
+ */
+
+/** Minimum lead time (in weeks) enforced by release scheduling validation. */
+export const MIN_RELEASE_LEAD_WEEKS = 1;
+
+/**
+ * Earliest legally schedulable release week for a given current week.
+ * Falls back to week 1's default when the game state hasn't loaded yet
+ * (PlanReleasePage re-syncs via effect once it does).
+ */
+export function getDefaultReleaseWeek(currentWeek: number | null | undefined): number {
+  return (currentWeek ?? 1) + MIN_RELEASE_LEAD_WEEKS;
+}
+
+/**
+ * Resolve the release-week picker value when the current week (re)loads or
+ * advances:
+ * - if the player hasn't touched the picker, snap to the earliest legal week;
+ * - if the player picked a week that is no longer legal (<= currentWeek),
+ *   clamp forward to the earliest legal week;
+ * - otherwise keep the player's choice.
+ */
+export function resolveReleaseWeek(prev: number, currentWeek: number, touched: boolean): number {
+  if (!touched || prev <= currentWeek) {
+    return getDefaultReleaseWeek(currentWeek);
+  }
+  return prev;
+}
+
+/**
+ * Default lead-single week: one week before the main release (mirrors the
+ * old hardcoded 5-vs-6 pairing, but derived from the actual release week).
+ */
+export function getDefaultLeadSingleWeek(releaseWeek: number): number {
+  return releaseWeek - 1;
+}

--- a/client/src/pages/PlanReleasePage.tsx
+++ b/client/src/pages/PlanReleasePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -20,6 +20,11 @@ import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { BankedHypeAttachPreview } from '@/components/BankedHypeAttachPreview';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
+import {
+  getDefaultReleaseWeek,
+  getDefaultLeadSingleWeek,
+  resolveReleaseWeek
+} from '@/lib/releaseWeekDefaults';
 import {
   getSeasonFromWeek,
   getSeasonalMultiplierValue,
@@ -164,7 +169,21 @@ export default function PlanReleasePage() {
   const [editedTitle, setEditedTitle] = useState<string>('');
   const [songTitles, setSongTitles] = useState<Record<string, string>>({});
   const [releaseTitle, setReleaseTitle] = useState('');
-  const [releaseWeek, setReleaseWeek] = useState(6);
+  // Default to the earliest legally schedulable week (currentWeek + 1 — the
+  // server rejects scheduledReleaseWeek <= currentWeek). gameState can still be
+  // null on first render; the effect below re-syncs once it loads, and also
+  // clamps forward if the week advances past a previously picked week.
+  const [releaseWeek, setReleaseWeek] = useState(() => getDefaultReleaseWeek(gameState?.currentWeek));
+  const releaseWeekTouchedRef = useRef(false);
+  const handleReleaseWeekSelect = (week: number) => {
+    releaseWeekTouchedRef.current = true;
+    setReleaseWeek(week);
+  };
+  const currentWeek = gameState?.currentWeek;
+  useEffect(() => {
+    if (currentWeek == null) return;
+    setReleaseWeek(prev => resolveReleaseWeek(prev, currentWeek, releaseWeekTouchedRef.current));
+  }, [currentWeek]);
 
   // Marketing budget allocation per channel
   const [channelBudgets, setChannelBudgets] = useState<Record<string, number>>({
@@ -179,8 +198,21 @@ export default function PlanReleasePage() {
   // hits at launch). Steps of 10 up to 50%.
   const [preCampaignPct, setPreCampaignPct] = useState(0);
 
-  // Lead single timing (for multi-song releases)
-  const [leadSingleWeek, setLeadSingleWeek] = useState(5); // Default 1 week before main release
+  // Lead single timing (for multi-song releases) — defaults to 1 week before
+  // the main release and follows it until the player picks a week themselves.
+  const [leadSingleWeek, setLeadSingleWeek] = useState(() =>
+    getDefaultLeadSingleWeek(getDefaultReleaseWeek(gameState?.currentWeek))
+  );
+  const leadSingleWeekTouchedRef = useRef(false);
+  const handleLeadSingleWeekSelect = (week: number) => {
+    leadSingleWeekTouchedRef.current = true;
+    setLeadSingleWeek(week);
+  };
+  useEffect(() => {
+    setLeadSingleWeek(prev =>
+      leadSingleWeekTouchedRef.current ? prev : getDefaultLeadSingleWeek(releaseWeek)
+    );
+  }, [releaseWeek]);
   const [leadSingleBudget, setLeadSingleBudget] = useState<Record<string, number>>({
     radio: 0,
     digital: 1500,
@@ -1032,7 +1064,7 @@ export default function PlanReleasePage() {
                   <MusicCalendar
                     selectionMode={true}
                     selectedWeek={leadSingleWeek}
-                    onWeekSelect={setLeadSingleWeek}
+                    onWeekSelect={handleLeadSingleWeekSelect}
                     minWeek={gameState ? gameState.currentWeek + 1 : 1}
                     maxWeek={releaseWeek - 1}
                     className="max-w-lg"
@@ -1195,7 +1227,7 @@ export default function PlanReleasePage() {
                   <MusicCalendar
                     selectionMode={true}
                     selectedWeek={releaseWeek}
-                    onWeekSelect={setReleaseWeek}
+                    onWeekSelect={handleReleaseWeekSelect}
                     minWeek={gameState ? gameState.currentWeek + 1 : 1}
                     className="max-w-lg"
                   />

--- a/tests/unit/release-week-defaults.test.ts
+++ b/tests/unit/release-week-defaults.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MIN_RELEASE_LEAD_WEEKS,
+  getDefaultReleaseWeek,
+  getDefaultLeadSingleWeek,
+  resolveReleaseWeek
+} from '../../client/src/lib/releaseWeekDefaults';
+
+describe('releaseWeekDefaults', () => {
+  describe('getDefaultReleaseWeek', () => {
+    it('defaults to the earliest legally schedulable week (currentWeek + min lead)', () => {
+      // Server rejects scheduledReleaseWeek <= currentWeek (releasePlanningService),
+      // so the earliest legal week is currentWeek + 1.
+      expect(MIN_RELEASE_LEAD_WEEKS).toBe(1);
+      expect(getDefaultReleaseWeek(1)).toBe(2);
+      expect(getDefaultReleaseWeek(5)).toBe(6);
+      expect(getDefaultReleaseWeek(23)).toBe(24);
+    });
+
+    it('tracks the current week as it advances (no hardcoded week 6)', () => {
+      expect(getDefaultReleaseWeek(17)).toBe(18);
+      expect(getDefaultReleaseWeek(18)).toBe(19);
+    });
+
+    it('falls back to the week-1 default while game state is still loading', () => {
+      expect(getDefaultReleaseWeek(null)).toBe(1 + MIN_RELEASE_LEAD_WEEKS);
+      expect(getDefaultReleaseWeek(undefined)).toBe(1 + MIN_RELEASE_LEAD_WEEKS);
+    });
+  });
+
+  describe('resolveReleaseWeek', () => {
+    it('snaps an untouched picker to the earliest legal week when game state loads', () => {
+      // Page mounts before gameState is available (prev = fallback default 2),
+      // then currentWeek 12 arrives.
+      expect(resolveReleaseWeek(2, 12, false)).toBe(13);
+    });
+
+    it('keeps a player-picked week that is still legal', () => {
+      expect(resolveReleaseWeek(20, 12, true)).toBe(20);
+    });
+
+    it('clamps a player-picked week forward once it is no longer legal', () => {
+      // Picked week 13, weeks advanced to 13 — server would reject <= currentWeek.
+      expect(resolveReleaseWeek(13, 13, true)).toBe(14);
+      expect(resolveReleaseWeek(13, 15, true)).toBe(16);
+    });
+  });
+
+  describe('getDefaultLeadSingleWeek', () => {
+    it('defaults to one week before the main release', () => {
+      expect(getDefaultLeadSingleWeek(24)).toBe(23);
+    });
+  });
+});


### PR DESCRIPTION
## Bug (playtest 2026-07-25)

The Plan Release calendar defaulted to week 6 every time, regardless of game progress — a hardcoded `useState(6)` from a stale "game starts at week 1" assumption (plus a companion `useState(5)` for the lead-single week).

## Fix

Defaults derive from `gameState.currentWeek`: the picker opens on **`currentWeek + 1`** — the earliest week the server accepts (`releasePlanningService` rejects `scheduledReleaseWeek <= currentWeek`), and the same bound the page already passes to the calendar as `minWeek`. The lead single defaults to one week before the release and follows it until manually picked.

Details:
- New pure helpers in `client/src/lib/releaseWeekDefaults.ts` (default, load-resync, clamp-forward-if-now-illegal, keep-player-pick)
- `gameState` can be null on first render, so an effect re-syncs when it loads and as weeks advance; a `touched` ref ensures a player's explicit pick is never stomped
- Spine read via `useGameState()` per client state rules

## Verification (independently re-run by the reviewing session)

- `npm run check` clean
- 51/51 across the new derivation test + all existing release suites (releaseBuzz, cancel-release-copy, useReleases, release-creation-helper)
- Implemented by a subagent, diff-reviewed + re-validated by the coordinating session; lead-single edge (release at earliest week → empty lead-single range) confirmed pre-existing behavior, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)