### PR TITLE
feat(meetings): per-meeting reactive_chance — demo_ethics_one fires on 40% of signings

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -1232,6 +1232,7 @@
         "artist_signed"
       ],
       "reactive_trigger": "recent_signing",
+      "reactive_chance": 0.4,
       "prompt_before_selection": "Whose signing demo has the co-writer problem?",
       "prompt": "The demo — the one that made me sign {artistName}. There's a co-writer on it: uncleared, uncredited, and as of this morning, lawyered. I played that tape for this whole building and said I'd found a complete artist. Turns out I found most of one. I can make this quiet, I can make it right, or we cut the song again from zero — but if it gets loud before the ink dries on the profile pieces, it isn't their name that eats it. It's mine.",
       "choices": [

--- a/shared/api/contracts.ts
+++ b/shared/api/contracts.ts
@@ -547,6 +547,9 @@ export const WeeklyActionSchema = z.object({
   // Tier 2 (PR-1): optional reactive-meeting trigger. Dark launch: no
   // data/actions.json entry sets this yet (PR-2 authors the first ones).
   reactive_trigger: HappeningTypeSchema.optional(),
+  // Playtest 2026-07-25: per-meeting injection probability, 0–1 (absent =
+  // always fires when triggered) — demo_ethics_one on EVERY signing read as copy-paste.
+  reactive_chance: z.number().min(0).max(1).optional(),
   // Tier 2 (PR-1): server-attached "why now" context on the SELECTED meeting
   // (never authored in data/actions.json — response-side only).
   reactiveContext: ReactiveContextSchema.optional(),

--- a/shared/engine/meetingSelection.ts
+++ b/shared/engine/meetingSelection.ts
@@ -12,7 +12,7 @@
  * Spec: docs/01-planning/implementation-specs/[READY] meeting-relevance-tier0-1-plan.md §1-§2.
  */
 
-import { seededRandomPick, seededWeightedPick } from '../utils/seededRandom';
+import { seededRandom, seededRandomPick, seededWeightedPick } from '../utils/seededRandom';
 import type { RelevanceTag, RequiresEntry, HappeningType } from '../types/gameTypes';
 import type { WeekHappening } from './weekHappenings';
 
@@ -493,7 +493,15 @@ export function selectWeeklyMeeting<T extends RelevanceTaggable & CategoryTaggab
 
 /** Minimal shape a pool item needs to be considered for reactive injection. */
 export interface ReactiveTaggable {
+  id: string;
   reactive_trigger?: HappeningType;
+  /**
+   * Per-meeting injection probability (0–1). Absent = 1.0 (always fires when
+   * its trigger matches — back-compat for all pre-existing reactive meetings).
+   * Playtest 2026-07-25: demo_ethics_one firing on EVERY signing read as
+   * copy-paste; a sub-1 chance lets a trigger fire only sometimes.
+   */
+  reactive_chance?: number;
 }
 
 /**
@@ -551,10 +559,26 @@ export function matchReactiveMeeting<T extends ReactiveTaggable>(
     happeningsByType.set(happening.type, list);
   }
 
+  // Per-meeting chance gate (playtest 2026-07-25): a meeting with
+  // `reactive_chance` < 1 only enters candidacy when a seeded roll passes.
+  // ISOLATED seed (`${seed}-reactive-chance-${meeting.id}`) — NEVER the
+  // engine's RNG stream — so both selection sites (offer route + autonomous
+  // engine path) roll identically for the same (gameId, week, roleId).
+  // A failed roll behaves exactly as if this meeting's trigger didn't match:
+  // other reactive matches still compete by priority, and if none remain the
+  // caller falls through to the normal weighted draw.
+  const passesChanceRoll = (meeting: T): boolean => {
+    const chance = meeting.reactive_chance ?? 1;
+    if (chance >= 1) return true;
+    if (chance <= 0) return false;
+    return seededRandom(`${seed}-reactive-chance-${meeting.id}`) < chance;
+  };
+
   // Collect every (meeting, happening) pair whose trigger fires this week.
   const candidates: ReactiveMatch<T>[] = [];
   for (const meeting of eligiblePool) {
     if (!meeting.reactive_trigger) continue;
+    if (!passesChanceRoll(meeting)) continue;
     const matchingHappenings = happeningsByType.get(meeting.reactive_trigger);
     if (!matchingHappenings) continue;
     for (const happening of matchingHappenings) {

--- a/shared/types/gameTypes.ts
+++ b/shared/types/gameTypes.ts
@@ -328,6 +328,12 @@ export interface RoleMeeting {
    */
   reactive_trigger?: HappeningType;
   /**
+   * Playtest 2026-07-25: per-meeting injection probability, 0–1 (absent =
+   * always fires when triggered) — demo_ethics_one on EVERY signing read as
+   * copy-paste.
+   */
+  reactive_chance?: number;
+  /**
    * Tier 2 (PR-2): server-attached "why now" context on the SELECTED meeting —
    * present only when the route's injection stage picked this meeting via a
    * matching week happening (never authored in data/actions.json; response-side

--- a/tests/engine/meeting-selection-reactive-injection.test.ts
+++ b/tests/engine/meeting-selection-reactive-injection.test.ts
@@ -209,6 +209,115 @@ describe('matchReactiveMeeting — priority + requires', () => {
   });
 });
 
+describe('reactive_chance — per-meeting injection probability (playtest 2026-07-25)', () => {
+  it('reactive_chance absent → always injects when triggered (existing behavior pinned)', () => {
+    const pool: Pool = [
+      { id: 'normal' },
+      { id: 'always-fires', reactive_trigger: 'recent_signing' },
+    ];
+    for (let week = 1; week <= 40; week++) {
+      const seed = generateMeetingSeed('game-chance', week, 'head_ar');
+      const result = selectWeeklyMeetingWithHappenings(pool, emptyState(), seed, [happening('recent_signing')]);
+      expect(result.meeting?.id).toBe('always-fires');
+      expect(result.reactiveHappening?.type).toBe('recent_signing');
+    }
+  });
+
+  it('reactive_chance: 0 → never injects; the weighted draw proceeds over the non-reactive pool', () => {
+    const pool: Pool = [
+      { id: 'normal' },
+      { id: 'never-fires', reactive_trigger: 'recent_signing', reactive_chance: 0 },
+    ];
+    for (let week = 1; week <= 40; week++) {
+      const seed = generateMeetingSeed('game-chance', week, 'head_ar');
+      const result = selectWeeklyMeetingWithHappenings(pool, emptyState(), seed, [happening('recent_signing')]);
+      expect(result.meeting?.id).toBe('normal');
+      expect(result.reactiveHappening).toBeNull();
+    }
+  });
+
+  it('reactive_chance: 1 behaves exactly like absent (always injects)', () => {
+    const pool: Pool = [
+      { id: 'normal' },
+      { id: 'certain', reactive_trigger: 'recent_signing', reactive_chance: 1 },
+    ];
+    for (let week = 1; week <= 40; week++) {
+      const seed = generateMeetingSeed('game-chance', week, 'head_ar');
+      const result = selectWeeklyMeetingWithHappenings(pool, emptyState(), seed, [happening('recent_signing')]);
+      expect(result.meeting?.id).toBe('certain');
+    }
+  });
+
+  it('deterministic: same seed → same outcome across repeated calls, and a fractional chance produces BOTH outcomes across seeds', () => {
+    // Mirrors the authored demo_ethics_one value (0.4).
+    const pool: Pool = [
+      { id: 'normal' },
+      { id: 'demo_ethics_one', reactive_trigger: 'recent_signing', reactive_chance: 0.4 },
+    ];
+    const outcomes = new Set<string>();
+    for (let week = 1; week <= 60; week++) {
+      const seed = generateMeetingSeed('game-chance', week, 'head_ar');
+      const first = selectWeeklyMeetingWithHappenings(pool, emptyState(), seed, [happening('recent_signing')]);
+      for (let i = 0; i < 10; i++) {
+        const again = selectWeeklyMeetingWithHappenings(pool, emptyState(), seed, [happening('recent_signing')]);
+        expect(again.meeting?.id).toBe(first.meeting?.id);
+        expect(again.reactiveHappening?.type ?? null).toBe(first.reactiveHappening?.type ?? null);
+      }
+      outcomes.add(first.meeting!.id);
+    }
+    // 60 independent weekly seeds at 40%: both "fired" and "didn't fire" must
+    // occur (a chance gate that always or never fires is dead).
+    expect(outcomes).toEqual(new Set(['normal', 'demo_ethics_one']));
+  });
+
+  it('failed roll on the priority-winning reactive meeting lets a lower-priority reactive match win', () => {
+    // mood_crater outranks recent_signing, but its owner's roll always fails
+    // (chance 0) → the lower-priority recent_signing owner injects instead.
+    const pool: Pool = [
+      { id: 'normal' },
+      { id: 'mood-owner', reactive_trigger: 'mood_crater', reactive_chance: 0 },
+      { id: 'signing-owner', reactive_trigger: 'recent_signing' },
+    ];
+    const happenings = [happening('mood_crater'), happening('recent_signing')];
+    for (let week = 1; week <= 40; week++) {
+      const seed = generateMeetingSeed('game-chance', week, 'head_ar');
+      const result = selectWeeklyMeetingWithHappenings(pool, emptyState(), seed, happenings);
+      expect(result.meeting?.id).toBe('signing-owner');
+      expect(result.reactiveHappening?.type).toBe('recent_signing');
+    }
+  });
+
+  it('a failed fractional roll on the priority winner falls through to the lower-priority owner (both branches reachable across seeds)', () => {
+    const pool: Pool = [
+      { id: 'mood-owner', reactive_trigger: 'mood_crater', reactive_chance: 0.4 },
+      { id: 'signing-owner', reactive_trigger: 'recent_signing' },
+    ];
+    const happenings = [happening('mood_crater'), happening('recent_signing')];
+    const winners = new Set<string>();
+    for (let week = 1; week <= 60; week++) {
+      const seed = generateMeetingSeed('game-chance-2', week, 'head_ar');
+      const match = matchReactiveMeeting(pool, happenings, seed);
+      expect(match).not.toBeNull();
+      winners.add(match!.meeting.id);
+    }
+    // When mood-owner's roll passes it wins on priority; when it fails,
+    // signing-owner takes over — both must occur across 60 seeds.
+    expect(winners).toEqual(new Set(['mood-owner', 'signing-owner']));
+  });
+
+  it('a chance-failed reactive meeting stays event-gated: it does NOT leak into the fall-through weighted draw', () => {
+    const pool: Pool = [
+      { id: 'normal' },
+      { id: 'never-fires', reactive_trigger: 'recent_signing', reactive_chance: 0 },
+    ];
+    for (let week = 1; week <= 40; week++) {
+      const seed = generateMeetingSeed('game-chance-3', week, 'head_ar');
+      const result = selectWeeklyMeetingWithHappenings(pool, emptyState(), seed, [happening('recent_signing')]);
+      expect(result.meeting?.id).not.toBe('never-fires');
+    }
+  });
+});
+
 describe('selectWeeklyMeetingWithHappenings — replace-the-draw semantics (fork B1)', () => {
   it('no happenings (default/omitted) → byte-identical to selectWeeklyMeeting', () => {
     const pool: Pool = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }];


### PR DESCRIPTION
## Why (playtest 2026-07-25)

`demo_ethics_one` (reactive trigger: `recent_signing`) fired on EVERY artist signing — "signing is always fraught" was the intent, but verbatim repetition reads as copy-paste. Was stacked on #176 (now merged).

## What

- New authored field `reactive_chance` (0–1, optional) on reactive meetings; absent = always fires (back-compat for all other reactive meetings)
- The injection stage in `shared/engine/meetingSelection.ts` rolls `seededRandom(`${seed}-reactive-chance-${meeting.id}`)` — deterministic per (game, week, role), so save/load can't reroll it; a failed roll cedes to lower-priority reactive matches / the normal weighted draw, and the meeting stays event-gated (never leaks into the regular pool)
- Single gate shared by both selection sites (offer route + autonomous engine path) — two-site parity preserved by construction
- `demo_ethics_one` authored at `0.4`
- Schema (`WeeklyActionSchema`) + `RoleMeeting` type updated

## Verification

7 new tests (absent=always pinned, 0=never, 1≡absent, determinism across 60 seeds, priority cede, no pool leak) + requires-gates, two-site parity, and all data-lint suites: 72/72. Implemented by a subagent, reviewed by the orchestrating session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)